### PR TITLE
[Ruby] Operation methods should not include constants in the signature

### DIFF
--- a/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
@@ -22,7 +22,7 @@
   @WrapComment("# ", Model.Description)@:
 @:#
 }
-@foreach (var parameter in Model.LocalParameters)
+@foreach (var parameter in Model.MethodParameters)
 {
 @:@WrapComment("# ", string.Format("@param {0} {1}{2}", parameter.Name, parameter.Type.GetYardDocumentation(), parameter.Documentation))
 }
@@ -54,7 +54,7 @@ end
   @WrapComment("# ", Model.Description)@:
 @:#
 }
-@foreach (var parameter in Model.LocalParameters)
+@foreach (var parameter in Model.MethodParameters)
 {
 @:@WrapComment("# ", string.Format("@param {0} {1}{2}", parameter.Name, parameter.Type.GetYardDocumentation(), parameter.Documentation))
 }
@@ -70,7 +70,7 @@ def @(Model.Name)(@(Model.MethodParameterDeclaration))
 end
 @EmptyLine
 #
-@foreach (var parameter in Model.LocalParameters)
+@foreach (var parameter in Model.MethodParameters)
 {
 @:@WrapComment("# ", string.Format("@param {0} {1}{2}", parameter.Name, parameter.Type.GetYardDocumentation(), parameter.Documentation))
 }

--- a/src/generator/AutoRest.Ruby/TemplateModels/MethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby/TemplateModels/MethodTemplateModel.cs
@@ -319,29 +319,16 @@ namespace AutoRest.Ruby.TemplateModels
 
         /// <summary>
         /// Get the parameters that are actually method parameters in the order they appear in the method signature
-        /// exclude global parameters
-        /// </summary>
-        public IEnumerable<ParameterTemplateModel> LocalParameters
-        {
-            get
-            {
-                //Omit parameter group parameters for now since AutoRest-Ruby doesn't support them
-                return
-                    ParameterTemplateModels.Where(
-                        p => p != null && p.ClientProperty == null && !string.IsNullOrWhiteSpace(p.Name))
-                        .OrderBy(item => !item.IsRequired);
-            }
-        }
-
-        /// <summary>
-        /// Get the parameters that are actually method parameters in the order they appear in the method signature
         /// exclude global parameters and constants
         /// </summary>
         public IEnumerable<ParameterTemplateModel> MethodParameters
         {
             get
             {
-                return LocalParameters.Where(p => !p.IsConstant);
+                return
+                    ParameterTemplateModels.Where(
+                        p => p != null && p.ClientProperty == null && !string.IsNullOrWhiteSpace(p.Name) && !p.IsConstant)
+                        .OrderBy(item => !item.IsRequired);
             }
         }
 

--- a/src/generator/AutoRest.Ruby/TemplateModels/MethodTemplateModel.cs
+++ b/src/generator/AutoRest.Ruby/TemplateModels/MethodTemplateModel.cs
@@ -275,7 +275,7 @@ namespace AutoRest.Ruby.TemplateModels
             get
             {
                 List<string> declarations = new List<string>();
-                foreach (var parameter in LocalParameters.Where(p => !p.IsConstant))
+                foreach (var parameter in MethodParameters)
                 {
                     string format = "{0}";
                     if (!parameter.IsRequired)
@@ -310,7 +310,7 @@ namespace AutoRest.Ruby.TemplateModels
         {
             get
             {
-                var invocationParams = LocalParameters.Where(p => !p.IsConstant).Select(p => p.Name).ToList();
+                var invocationParams = MethodParameters.Select(p => p.Name).ToList();
                 invocationParams.Add("custom_headers");
 
                 return string.Join(", ", invocationParams);
@@ -330,6 +330,18 @@ namespace AutoRest.Ruby.TemplateModels
                     ParameterTemplateModels.Where(
                         p => p != null && p.ClientProperty == null && !string.IsNullOrWhiteSpace(p.Name))
                         .OrderBy(item => !item.IsRequired);
+            }
+        }
+
+        /// <summary>
+        /// Get the parameters that are actually method parameters in the order they appear in the method signature
+        /// exclude global parameters and constants
+        /// </summary>
+        public IEnumerable<ParameterTemplateModel> MethodParameters
+        {
+            get
+            {
+                return LocalParameters.Where(p => !p.IsConstant);
             }
         }
 

--- a/src/generator/AutoRest.Ruby/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/MethodTemplate.cshtml
@@ -15,7 +15,7 @@
   @WrapComment("# ", Model.Description)@:
 @:#
 }
-@foreach (var parameter in Model.LocalParameters.Where(p => !p.IsConstant))
+@foreach (var parameter in Model.MethodParameters)
 {
 @:@WrapComment("# ", string.Format("@param {0} {1}{2}", parameter.Name, parameter.Type.GetYardDocumentation(), parameter.Documentation))
 }
@@ -42,7 +42,7 @@ end
   @WrapComment("# ", Model.Description)@:
 @:#
 }
-@foreach (var parameter in Model.LocalParameters.Where(p => !p.IsConstant))
+@foreach (var parameter in Model.MethodParameters)
 {
 @:@WrapComment("# ", string.Format("@param {0} {1}{2}", parameter.Name, parameter.Type.GetYardDocumentation(), parameter.Documentation))
 }
@@ -67,7 +67,7 @@ end
   @WrapComment("# ", Model.Description)@:
 @:#
 }
-@foreach (var parameter in Model.LocalParameters.Where(p => !p.IsConstant))
+@foreach (var parameter in Model.MethodParameters)
 {
 @:@WrapComment("# ", string.Format("@param {0} {1}{2}", parameter.Name, parameter.Type.GetYardDocumentation(), parameter.Documentation))
 }


### PR DESCRIPTION
This change excludes usage of constant parameters in the operations documentation comments. 
Example Error: https://github.com/Azure/azure-sdk-for-ruby/pull/481#discussion-diff-81245530R134