### PR TITLE
[Ruby - In review] Refactoring calls to create faraday connection

### DIFF
--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/credentials/application_token_provider.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/credentials/application_token_provider.rb
@@ -91,9 +91,7 @@ module MsRestAzure
 
       url = URI.parse(token_acquire_url)
 
-      connection = Faraday.new(:url => url, :ssl => MsRest.ssl_options) do |builder|
-        builder.adapter Faraday.default_adapter
-      end
+      connection = MsRest::HttpOperationRequest.create_faraday_connection(url)
 
       request_body = REQUEST_BODY_PATTERN.dup
       request_body['{resource_uri}'] = ERB::Util.url_encode(@settings.token_audience)

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
@@ -99,9 +99,9 @@ module MsRestAzure
     def get_request(options = {})
       link = @azure_async_operation_header_link || @location_header_link
       faraday_options = {
-          :middlewares => request.middlewares,
-          :headers => request.headers,
-          :log => request.log
+          middlewares: request.middlewares,
+          headers: request.headers,
+          log: request.log
       }
       @connection ||= MsRest::HttpOperationRequest.create_faraday_connection(options[:base_uri], faraday_options)
       options[:connection] = @connection

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
@@ -99,9 +99,10 @@ module MsRestAzure
     def get_request(options = {})
       link = @azure_async_operation_header_link || @location_header_link
       faraday_options = {
-          middlewares: request.middlewares,
-          headers: request.headers,
-          log: request.log
+          middlewares: @request.middlewares,
+          headers: @request.headers,
+          log: @request.log,
+          ssl: @request.ssl
       }
       @connection ||= MsRest::HttpOperationRequest.create_faraday_connection(options[:base_uri], faraday_options)
       options[:connection] = @connection

--- a/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
+++ b/src/client/Ruby/ms-rest-azure/lib/ms_rest_azure/polling_state.rb
@@ -98,7 +98,14 @@ module MsRestAzure
     
     def get_request(options = {})
       link = @azure_async_operation_header_link || @location_header_link
-      options[:connection] = create_connection(options[:base_uri])
+      faraday_options = {
+          :middlewares => request.middlewares,
+          :headers => request.headers,
+          :log => request.log
+      }
+      @connection ||= MsRest::HttpOperationRequest.create_faraday_connection(options[:base_uri], faraday_options)
+      options[:connection] = @connection
+
       MsRest::HttpOperationRequest.new(nil, link, :get, options)
     end
 
@@ -109,17 +116,5 @@ module MsRestAzure
 
     attr_accessor :connection
 
-    def create_connection(base_url)
-      @connection ||= Faraday.new(:url => base_url, :ssl => MsRest.ssl_options) do |faraday|
-        [[MsRest::RetryPolicyMiddleware, times: 3, retry: 0.02], [:cookie_jar]].each{ |args| faraday.use(*args) }
-        faraday.adapter Faraday.default_adapter
-        faraday.headers = request.headers
-        logging = ENV['AZURE_HTTP_LOGGING'] || request.log
-        if logging
-          faraday.response :logger, nil, { :bodies => logging == 'full' }
-        end
-      end
-    end
   end
-
 end

--- a/src/client/Ruby/ms-rest-azure/spec/azure_service_client_spec.rb
+++ b/src/client/Ruby/ms-rest-azure/spec/azure_service_client_spec.rb
@@ -36,7 +36,7 @@ module MsRestAzure
       azure_service_client = AzureServiceClient.new nil
       azure_service_client.long_running_operation_retry_timeout = 0
 
-      allow_any_instance_of(MsRestAzure::PollingState).to receive(:create_connection).and_return(nil)
+      allow_any_instance_of(MsRestAzure::PollingState).to receive(:get_request).and_return(nil)
       allow(azure_service_client).to receive(:update_state_from_azure_async_operation_header) do |request, polling_state|
         polling_state.status = AsyncOperationStatus::SUCCESS_STATUS
         polling_state.resource = 'resource'
@@ -63,7 +63,7 @@ module MsRestAzure
       azure_service_client = AzureServiceClient.new nil
       azure_service_client.long_running_operation_retry_timeout = 0
 
-      allow_any_instance_of(MsRestAzure::PollingState).to receive(:create_connection).and_return(nil)
+      allow_any_instance_of(MsRestAzure::PollingState).to receive(:get_request).and_return(nil)
       allow(azure_service_client).to receive(:update_state_from_location_header) do |request, polling_state|
         polling_state.status = AsyncOperationStatus::SUCCESS_STATUS
         polling_state.resource = 'resource'
@@ -86,7 +86,7 @@ module MsRestAzure
       azure_service_client = AzureServiceClient.new nil
       azure_service_client.long_running_operation_retry_timeout = 0
 
-      allow_any_instance_of(MsRestAzure::PollingState).to receive(:create_connection).and_return(nil)
+      allow_any_instance_of(MsRestAzure::PollingState).to receive(:get_request).and_return(nil)
       allow(azure_service_client).to receive(:update_state_from_azure_async_operation_header) do |request, polling_state|
         polling_state.status = AsyncOperationStatus::FAILED_STATUS
       end

--- a/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
@@ -68,14 +68,11 @@ module MsRest
     # @return [URI] body the HTTP response body.
     def run_promise(&block)
       Concurrent::Promise.new do
-        @connection ||= Faraday.new(:url => base_uri, :ssl => MsRest.ssl_options) do |faraday|
-          middlewares.each{ |args| faraday.use(*args) } unless middlewares.nil?
-          faraday.adapter Faraday.default_adapter
-          logging = ENV['AZURE_HTTP_LOGGING'] || log
-          if logging
-            faraday.response :logger, nil, { :bodies => logging == 'full' }
-          end
-        end
+        options = {
+            :middlewares => middlewares,
+            :log => log
+        }
+        @connection ||= HttpOperationRequest.create_faraday_connection(base_uri, options)
 
         @connection.run_request(:"#{method}", build_path, body, {'User-Agent' => user_agent}.merge(headers)) do |req|
           req.params = req.params.merge(query_params.reject{|_, v| v.nil?}) unless query_params.nil?
@@ -83,8 +80,7 @@ module MsRest
         end
       end
     end
-    
-    
+
     # Creates a path from the path template and the path_params and skip_encoding_path_params
     # @return [URI] body the HTTP response body.
     def build_path
@@ -121,7 +117,20 @@ module MsRest
         log: log  
       }.to_json(*a)
     end
-    
+
+    def self.create_faraday_connection(base_uri, options = {})
+      Faraday.new(:url => base_uri, :ssl => MsRest.ssl_options) do |faraday|
+        unless options.empty?
+          options[:middlewares].each{ |args| faraday.use(*args) } unless options[:middlewares].nil?
+          faraday.headers = options[:headers] unless options[:headers].nil?
+          logging = ENV['AZURE_HTTP_LOGGING'] || options[:log]
+          if logging
+            faraday.response :logger, nil, { :bodies => logging == 'full' }
+          end
+        end
+        faraday.adapter Faraday.default_adapter
+      end
+    end
   end
-  
+
 end

--- a/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
@@ -43,6 +43,9 @@ module MsRest
     
     # @return [Array] strings to be appended to the user agent in the request
     attr_accessor :user_agent_extended
+
+    # @return [Hash] ssl options
+    attr_accessor :ssl
     
     # Creates and initialize new instance of the HttpOperationResponse class.
     # @param [String|URI] base uri for requests
@@ -72,6 +75,7 @@ module MsRest
             middlewares: middlewares,
             log: log
         }
+        MsRest.use_ssl_cert(@ssl)
         @connection ||= HttpOperationRequest.create_faraday_connection(base_uri, options)
 
         @connection.run_request(:"#{method}", build_path, body, {'User-Agent' => user_agent}.merge(headers)) do |req|
@@ -119,7 +123,8 @@ module MsRest
     end
 
     def self.create_faraday_connection(base_uri, options = {})
-      Faraday.new(:url => base_uri, :ssl => MsRest.ssl_options) do |faraday|
+      ssl_options = options[:ssl] || MsRest.ssl_options
+      Faraday.new(:url => base_uri, :ssl => ssl_options) do |faraday|
         unless options.empty?
           options[:middlewares].each{ |args| faraday.use(*args) } unless options[:middlewares].nil?
           faraday.headers = options[:headers] unless options[:headers].nil?

--- a/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/http_operation_request.rb
@@ -69,8 +69,8 @@ module MsRest
     def run_promise(&block)
       Concurrent::Promise.new do
         options = {
-            :middlewares => middlewares,
-            :log => log
+            middlewares: middlewares,
+            log: log
         }
         @connection ||= HttpOperationRequest.create_faraday_connection(base_uri, options)
 

--- a/src/client/Ruby/ms-rest/lib/ms_rest/service_client.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/service_client.rb
@@ -40,7 +40,7 @@ module MsRest
     def make_request_async(base_url, method, path, options = {})
       options = @middlewares.merge(options)
       options[:credentials] = options[:credentials] || @credentials
-      options[:ssl] = options[:ssl] || @@ssl_options
+      options[:ssl] = options[:ssl] || MsRest.ssl_options
       request  = MsRest::HttpOperationRequest.new(base_url, path, method, options)
       promise = request.run_promise do |req|
         options[:credentials].sign_request(req) unless options[:credentials].nil?

--- a/src/client/Ruby/ms-rest/lib/ms_rest/service_client.rb
+++ b/src/client/Ruby/ms-rest/lib/ms_rest/service_client.rb
@@ -40,6 +40,7 @@ module MsRest
     def make_request_async(base_url, method, path, options = {})
       options = @middlewares.merge(options)
       options[:credentials] = options[:credentials] || @credentials
+      options[:ssl] = options[:ssl] || @@ssl_options
       request  = MsRest::HttpOperationRequest.new(base_url, path, method, options)
       promise = request.run_promise do |req|
         options[:credentials].sign_request(req) unless options[:credentials].nil?


### PR DESCRIPTION
Refactoring calls to create connections in client runtime, to centralize where we create new Faraday connections.