### PR TITLE
[Go] Workaround golint stuttering

### DIFF
--- a/src/generator/AutoRest.Go/GoCodeNamer.cs
+++ b/src/generator/AutoRest.Go/GoCodeNamer.cs
@@ -260,21 +260,15 @@ namespace AutoRest.Go
                                             .Any(et => (et is IType && (et as IType).Name.Equals(name)) || (et is Method && (et as Method).Name.Equals(name)));
                         if (exported is EnumType)
                         {
-                            (exported as EnumType).Name = nameInUse
-                                                            ? name + "Enum"
-                                                            : name;
+                            (exported as EnumType).Name = AttachTypeName(name, PackageName, nameInUse, "Enum");
                         }
                         else if (exported is CompositeType)
                         {
-                            (exported as CompositeType).Name = nameInUse
-                                                            ? name + "Type"
-                                                            : name;
+                            (exported as CompositeType).Name = AttachTypeName(name, PackageName, nameInUse, "Type");
                         }
                         else if (exported is Method)
                         {
-                            (exported as Method).Name = nameInUse
-                                                            ? name + "Method"
-                                                            : name;
+                            (exported as Method).Name = AttachTypeName(name, PackageName, nameInUse, "Method");
                         }
                     });
             }
@@ -531,6 +525,23 @@ namespace AutoRest.Go
         private IType NormalizeDictionaryType(DictionaryType dictionaryType)
         {
             return new MapType(NormalizeTypeReference(dictionaryType.ValueType));
+        }
+
+        /// <summary>
+        /// Formats a string to work around golint name stuttering
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="packageName"></param>
+        /// <param name="nameInUse"></param>
+        /// <param name="attachment"></param>
+        /// <returns>The formatted string</returns>
+        public static string AttachTypeName(string name, string packageName, bool nameInUse, string attachment)
+        {
+            return nameInUse
+                ? name.Equals(packageName, StringComparison.OrdinalIgnoreCase)
+                    ? attachment + name
+                    : name + attachment
+                : name;
         }
 
         /// <summary>

--- a/src/generator/AutoRest.Go/GoCodeNamer.cs
+++ b/src/generator/AutoRest.Go/GoCodeNamer.cs
@@ -539,7 +539,7 @@ namespace AutoRest.Go
         {
             return nameInUse
                 ? name.Equals(packageName, StringComparison.OrdinalIgnoreCase)
-                    ? attachment + name
+                    ? name
                     : name + attachment
                 : name;
         }


### PR DESCRIPTION
When a model / enum / method name starts with the package name, golint will notice the stuttering. For example: `compute.ComputeVM`. Golint will suggest something like `compute.VM`. The problem is when the name of the model / enum /method is exaclty the same as the package. AutoRest currently generates `containerservice.ContainerServiceType`. With this change, it would generate `containerservice.TypeContainerService`