### PR TITLE
Fix for Java and Java.Fluent codegens

### DIFF
--- a/src/generator/AutoRest.Java.Azure.Fluent/AzureJavaFluentCodeGenerator.cs
+++ b/src/generator/AutoRest.Java.Azure.Fluent/AzureJavaFluentCodeGenerator.cs
@@ -66,6 +66,7 @@ namespace AutoRest.Java.Azure.Fluent
             AzureExtensions.ProcessParameterizedHost(serviceClient, Settings);
             AzureExtensions.ProcessClientRequestIdExtension(serviceClient);
             AzureExtensions.UpdateHeadMethods(serviceClient);
+            AzureExtensions.ProcessGlobalParameters(serviceClient);
             AzureExtensions.FlattenModels(serviceClient);
             AzureExtensions.FlattenMethodParameters(serviceClient, Settings);
             ParameterGroupExtensionHelper.AddParameterGroups(serviceClient);

--- a/src/generator/AutoRest.Java.Azure/AzureJavaCodeGenerator.cs
+++ b/src/generator/AutoRest.Java.Azure/AzureJavaCodeGenerator.cs
@@ -65,6 +65,7 @@ namespace AutoRest.Java.Azure
             AzureExtensions.ProcessParameterizedHost(serviceClient, Settings);
             AzureExtensions.ProcessClientRequestIdExtension(serviceClient);
             AzureExtensions.UpdateHeadMethods(serviceClient);
+            AzureExtensions.ProcessGlobalParameters(serviceClient);
             AzureExtensions.FlattenModels(serviceClient);
             AzureExtensions.FlattenMethodParameters(serviceClient, Settings);
             ParameterGroupExtensionHelper.AddParameterGroups(serviceClient);


### PR DESCRIPTION
Without this fix CDN Java code is generated incorrectly - ResourceGroupName global parameter is generated as client level property, but it should be method input parameter for Get/Put/Patch/Delete operations. 