### PR TITLE
Generate markdown help docs when generating template schemas.

### DIFF
--- a/src/core/AutoRest.Core/CodeGenerator.cs
+++ b/src/core/AutoRest.Core/CodeGenerator.cs
@@ -76,7 +76,7 @@ namespace AutoRest.Core
             {
                 await template.ExecuteAsync().ConfigureAwait(false);
             }
-            await Write(stringBuilder.ToString(), fileName);
+            await Write(stringBuilder.ToString(), fileName, true);
         }
 
         /// <summary>
@@ -84,8 +84,9 @@ namespace AutoRest.Core
         /// </summary>
         /// <param name="template"></param>
         /// <param name="fileName"></param>
+        /// <param name="skipEmptyLines"></param>
         /// <returns></returns>
-        public async Task Write(string template, string fileName)
+        public async Task Write(string template, string fileName, bool skipEmptyLines)
         {
             string filePath = null;
 
@@ -131,7 +132,7 @@ namespace AutoRest.Core
                     {
                         await textWriter.WriteLineAsync();
                     }
-                    else if (!string.IsNullOrWhiteSpace(line))
+                    else if (!skipEmptyLines || !string.IsNullOrWhiteSpace(line))
                     {
                         await textWriter.WriteLineAsync(line);
                     }

--- a/src/generator/AutoRest.AzureResourceSchema/CodeGeneratorArs.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/CodeGeneratorArs.cs
@@ -29,9 +29,11 @@ namespace AutoRest.AzureResourceSchema
             {
                 StringWriter stringWriter = new StringWriter();
                 ResourceSchemaWriter.Write(stringWriter, resourceSchemas[resourceProvider]);
+                await Write(stringWriter.ToString(), resourceProvider + ".json", true);
 
-                // string schemaPath = Path.Combine(Settings.Instance.OutputDirectory,);
-                await Write(stringWriter.ToString(), resourceProvider + ".json");
+                stringWriter = new StringWriter();
+                ResourceMarkdownWriter.Write(stringWriter, resourceSchemas[resourceProvider]);
+                await Write(stringWriter.ToString(), resourceProvider + ".md", false);
             }
         }
     }

--- a/src/generator/AutoRest.AzureResourceSchema/JsonSchema.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/JsonSchema.cs
@@ -13,6 +13,7 @@ namespace AutoRest.AzureResourceSchema
     /// </summary>
     public class JsonSchema
     {
+        private string resourceType;
         private IList<string> enumList;
         private IDictionary<string, JsonSchema> properties;
         private IList<string> requiredList;
@@ -48,38 +49,29 @@ namespace AutoRest.AzureResourceSchema
         public string JsonType { get; set; }
 
         /// <summary>
-        /// Get the resource type of this JsonSchema. If this JsonSchema defines an Azure Resource,
-        /// then this value will be found in definition.properties.type.enum[0]. If this JsonSchema
-        /// does not define an Azure Resource, then this will return null.
+        /// Gets or sets the resource type of this JsonSchema.
         /// </summary>
         public string ResourceType
         {
             get
             {
-                string result = null;
-
-                if (Properties != null &&
-                    Properties.ContainsKey("type") &&
-                    Properties["type"].Enum != null)
-                {
-                    result = Properties["type"].Enum.SingleOrDefault();
-                }
-
-                return result;
+                return resourceType;
             }
             set
             {
-                if (properties == null)
+                resourceType = value;
+                if (Properties != null && Properties.ContainsKey("type"))
                 {
-                    properties = new Dictionary<string, JsonSchema>();
-                }
+                    // update the value of the type enum.  we have to be careful though that we don't
+                    // stomp over some other enum that happens to have the name "type".  this code path
+                    // is typically hit when building a child resource definition from a cloned parent.
+                    if (Properties["type"].enumList.Count > 1)
+                        throw new InvalidOperationException("Attempt to update 'type' enum that contains more than one member (possible collision).");
+                    if (!Properties["type"].enumList[0].EndsWith(value))
+                        throw new InvalidOperationException($"The updated type value '{value}' is not a child of type value '{Properties["type"].enumList[0]}'");
 
-                if (!Properties.ContainsKey("type"))
-                {
-                    Properties["type"] = new JsonSchema();
+                    Properties["type"].enumList[0] = value;
                 }
-
-                Properties["type"].enumList = new List<string>() { value };
             }
         }
 

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/Anchor.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/Anchor.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class Anchor : MarkdownElement
+    {
+        private string _id;
+
+        public Anchor(string id)
+        {
+            if (string.IsNullOrEmpty(id))
+                throw new ArgumentException(nameof(id));
+
+            _id = id;
+        }
+
+        public override string ToMarkdown()
+        {
+            return $"<a id=\"{_id}\" />";
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/BulletList.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/BulletList.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class BulletList : MarkdownElement
+    {
+        private IEnumerable<string> _items;
+
+        public BulletList(IEnumerable<string> items)
+        {
+            if (items == null)
+                throw new ArgumentNullException(nameof(items));
+            if (!items.Any())
+                throw new ArgumentException("Collection contains no elements.", "items");
+
+            _items = items;
+        }
+
+        public override string ToMarkdown()
+        {
+            var sb = new StringBuilder();
+
+            foreach (var item in _items)
+                sb.AppendLine(string.Format("- {0}", item));
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/Codeblock.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/Codeblock.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class Codeblock : MarkdownElement
+    {
+        private string _s;
+
+        public Codeblock(string content)
+        {
+            if (string.IsNullOrEmpty(content))
+                throw new ArgumentException(nameof(content));
+
+            _s = content;
+        }
+
+        public override string ToMarkdown()
+        {
+            return string.Format("```{0}{1}{2}```", Environment.NewLine, _s, Environment.NewLine);
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/Header.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/Header.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class Header : MarkdownElement
+    {
+        private int _level;
+        private string _s;
+
+        public Header(string format, params object[] arg) : this(1, format, arg)
+        {
+            // empty
+        }
+
+        public Header(int level, string format, params object[] arg)
+        {
+            if (level < 1)
+                throw new ArgumentOutOfRangeException("Header level cannot be less than one.");
+            if (string.IsNullOrEmpty(format))
+                throw new ArgumentException(nameof(format));
+
+            _level = level;
+            _s = string.Format(format, arg);
+        }
+
+        public override string ToMarkdown()
+        {
+            var sb = new StringBuilder(_s.Length + _level + 1);
+            for (var i = 0; i < _level; ++i)
+                sb.Append("#");
+
+            sb.Append(" ");
+            sb.Append(_s);
+
+            return sb.ToString();
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/IMarkdown.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/IMarkdown.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public interface IMarkdown
+    {
+        string ToMarkdown();
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/InlineLink.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/InlineLink.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class InlineLink : MarkdownElement
+    {
+        string _s;
+        string _dest;
+
+        public InlineLink(string destination, string format, params object[] arg)
+        {
+            if (string.IsNullOrEmpty(destination))
+                throw new ArgumentException(nameof(destination));
+            if (string.IsNullOrEmpty(format))
+                throw new ArgumentException(nameof(format));
+
+            _s = string.Format(format, arg);
+            _dest = destination;
+        }
+
+        public override string ToMarkdown()
+        {
+            // if the destination doesn't start with http then assume it's on the same page
+            if (!_dest.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                return $"[{_s}](#{_dest})";
+            else
+                return $"[{_s}]({_dest})";
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/LineBreak.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/LineBreak.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class LineBreak : MarkdownElement
+    {
+        public override string ToMarkdown()
+        {
+            return "<br />";
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/MarkdownElement.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/MarkdownElement.cs
@@ -1,0 +1,15 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public abstract class MarkdownElement : IMarkdown
+    {
+        public abstract string ToMarkdown();
+
+        public override string ToString()
+        {
+            return ToMarkdown();
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/MarkdownWriter.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/MarkdownWriter.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class MarkdownWriter
+    {
+        private TextWriter _tw;
+
+        public MarkdownWriter(TextWriter textWriter)
+        {
+            if (textWriter == null)
+                throw new ArgumentNullException(nameof(textWriter));
+
+            _tw = textWriter;
+        }
+
+        public void Write(string format, params object[] arg)
+        {
+            _tw.Write(format, arg);
+        }
+
+        public void Write(IMarkdown markdownItem)
+        {
+            _tw.Write(markdownItem);
+        }
+
+        public void Write(IEnumerable<IMarkdown> markdownItems)
+        {
+            foreach (var markdownItem in markdownItems)
+                _tw.Write(markdownItem);
+        }
+
+        public void WriteLine()
+        {
+            _tw.WriteLine();
+        }
+
+        public void WriteLine(IMarkdown markdownItem)
+        {
+            _tw.WriteLine(markdownItem);
+        }
+
+        public void WriteLine(string format, params object[] arg)
+        {
+            _tw.WriteLine(format, arg);
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/Paragraph.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/Paragraph.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Text;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class Paragraph : MarkdownElement
+    {
+        private StringBuilder _sb;
+
+        public Paragraph()
+        {
+            _sb = new StringBuilder();
+            _sb.AppendLine();
+        }
+
+        public Paragraph(string content) : this()
+        {
+            Append(content);
+        }
+
+        public Paragraph(string format, params object[] arg) : this()
+        {
+            Append(format, arg);
+        }
+
+        public Paragraph(MarkdownElement md) : this()
+        {
+            Append(md);
+        }
+
+        public void Append(string content)
+        {
+            _sb.Append(content);
+        }
+
+        public void Append(string format, params object[] arg)
+        {
+            _sb.AppendFormat(format, arg);
+        }
+
+        public void Append(MarkdownElement md)
+        {
+            _sb.Append(md.ToString());
+        }
+
+        public override string ToMarkdown()
+        {
+            // TODO: word wrapping?
+            _sb.AppendLine();
+            return _sb.ToString();
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/Strong.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/Strong.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class Strong : MarkdownElement
+    {
+        private string _s;
+
+        public Strong(string content)
+        {
+            if (string.IsNullOrEmpty(content))
+                throw new ArgumentException(nameof(content));
+
+            _s = content;
+        }
+
+        public Strong(string format, params object[] arg)
+        {
+            if (string.IsNullOrEmpty(format))
+                throw new ArgumentException(nameof(format));
+
+            _s = string.Format(format, arg);
+        }
+
+        public Strong(MarkdownElement md)
+        {
+            if (md == null)
+                throw new ArgumentNullException(nameof(md));
+
+            _s = md.ToString();
+        }
+
+        public override string ToMarkdown()
+        {
+            return string.Format("**{0}**", _s);
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/Markdown/Table.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/Markdown/Table.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace AutoRest.AzureResourceSchema.Markdown
+{
+    public class Table : MarkdownElement
+    {
+        private IEnumerable<string> _headers;
+        private List<IEnumerable<string>> _rows;
+
+        public Table(IEnumerable<string> headers)
+        {
+            if (headers == null)
+                throw new ArgumentNullException(nameof(headers));
+            if (!headers.Any())
+                throw new ArgumentException("Collection contained no elements.", "headers");
+
+            _headers = headers;
+            _rows = new List<IEnumerable<string>>();
+        }
+
+        public void AddRow(IEnumerable<string> row)
+        {
+            if (row == null)
+                throw new ArgumentNullException(nameof(row));
+            if (!row.Any())
+                throw new ArgumentException("Collection contained no elements.", "row");
+
+            _rows.Add(row);
+        }
+
+        public override string ToMarkdown()
+        {
+            var sb = new StringBuilder();
+
+            // write table header
+            AppendRow(sb, _headers);
+
+            sb.Append("| ");
+            foreach (var h in _headers)
+                sb.Append(" ---- |");
+            sb.AppendLine();
+
+            foreach (var row in _rows)
+                AppendRow(sb, row);
+
+            // now write the rows
+            return sb.ToString();
+        }
+
+        private void AppendRow(StringBuilder sb, IEnumerable<string> row)
+        {
+            sb.Append("| ");
+            foreach (var r in row)
+                sb.AppendFormat(" {0} |", r);
+
+            sb.AppendLine();
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/ResourceMarkdownWriter.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/ResourceMarkdownWriter.cs
@@ -1,0 +1,421 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.AzureResourceSchema.Markdown;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+using TableQueueEntry = System.Tuple<string, AutoRest.AzureResourceSchema.JsonSchema>;
+
+namespace AutoRest.AzureResourceSchema
+{
+    using TableQueue = Queue<TableQueueEntry>;
+
+    public class ResourceMarkdownWriter
+    {
+        private const string RequiredFalse = "No";
+        private const string RequiredTrue = "Yes";
+
+        private MarkdownWriter _writer;
+        private ResourceSchema _schema;
+
+        private ResourceMarkdownWriter(TextWriter writer, ResourceSchema resourceSchema)
+        {
+            _writer = new MarkdownWriter(writer);
+            _schema = resourceSchema;
+        }
+
+        public static void Write(TextWriter writer, ResourceSchema resourceSchema)
+        {
+            if (writer == null)
+            {
+                throw new ArgumentNullException("writer");
+            }
+            if (resourceSchema == null)
+            {
+                throw new ArgumentNullException("resourceSchema");
+            }
+
+            var mdWriter = new ResourceMarkdownWriter(writer, resourceSchema);
+            mdWriter.Generate();
+        }
+
+        private void Generate()
+        {
+            _writer.WriteLine(new Header("{0} template schema", _schema.Title));
+            _writer.WriteLine(new Paragraph("Creates a {0} resource.", _schema.Title));
+
+            WriteSchemaFormatSection();
+            WriteValuesSection();
+        }
+
+        /// <summary>
+        /// Generates the "schema format" section.
+        /// </summary>
+        private void WriteSchemaFormatSection()
+        {
+            _writer.WriteLine(new Header(2, "Schema format"));
+            _writer.WriteLine(new Paragraph("To create a {0}, add the following schema to the resources section of your template.", _schema.Title));
+
+            foreach (var resDefName in _schema.ResourceDefinitions.Keys)
+            {
+                using (var stringWriter = new StringWriter())
+                {
+                    using (var json = new JsonTextWriter(stringWriter))
+                    {
+                        json.Formatting = Formatting.Indented;
+                        var resDef = _schema.ResourceDefinitions[resDefName];
+                        var root = new JObject();
+
+                        foreach (var prop in resDef.Properties)
+                        {
+                            // omit non-required objects
+                            if (resDef.Required != null && !resDef.Required.Contains(prop.Key))
+                                continue;
+
+                            root.Add(JsonSchemaToJToken(prop.Key, prop.Value));
+                        }
+
+                        root.WriteTo(json);
+                    }
+
+                    // put each resource definition into its own code block
+                    _writer.WriteLine(new Codeblock(stringWriter.ToString()));
+                }
+            }
+        }
+
+        /// <summary>
+        /// Generates the "values" section; this contains tables describing all of the JSON types.
+        /// </summary>
+        private void WriteValuesSection()
+        {
+            _writer.WriteLine(new Header(2, "Values"));
+            _writer.Write(new Paragraph("The following tables describe the values you need to set in the schema."));
+
+            foreach (var resDefName in _schema.ResourceDefinitions.Keys)
+            {
+                var resDef = _schema.ResourceDefinitions[resDefName];
+                Debug.Assert(resDef.JsonType == "object");
+                var table = CreateTable(resDefName, resDef);
+                _writer.Write(table);
+            }
+
+            foreach (var defName in _schema.Definitions.Keys)
+            {
+                var def = _schema.Definitions[defName];
+
+                // there are a handful of objects with null properties because the properties
+                // are all read-only.  for now just skip them to avoid a crash during table creation.
+                if (def.Properties == null)
+                    continue;
+
+                var table = CreateTable(defName, def);
+                _writer.Write(table);
+            }
+        }
+
+        /// <summary>
+        /// Creates a markdown table that describes the specified JSON schema.
+        /// </summary>
+        /// <param name="header">The markdown header to place before the table.</param>
+        /// <param name="jsonSchema">The JSON schema that is to be described by the table.</param>
+        /// <param name="tableQueue">A queue containing the JSON schemas to be converted to table format.</param>
+        /// <returns>A formatted table with sub-header.</returns>
+        private MarkdownElement CreateTable(string header, JsonSchema jsonSchema)
+        {
+            if (string.IsNullOrEmpty(header))
+                throw new ArgumentException(nameof(header));
+            if (jsonSchema == null)
+                throw new ArgumentNullException(nameof(jsonSchema));
+
+            Debug.Assert(jsonSchema.Properties != null);
+
+            // write the table header
+            var paragraph = new Paragraph();
+            paragraph.Append(new Anchor(header));
+            paragraph.Append(Environment.NewLine);
+            paragraph.Append(new Header(2, "{0} object", header));
+            paragraph.Append(Environment.NewLine);
+
+            var table = new Table(new[] { "Name", "Required", "Value" });
+
+            // add a table row for each property in the schema
+            foreach (var prop in jsonSchema.Properties)
+            {
+                // build the content that will appear in the value column.  it looks
+                // something like the following (each entry is separated by a line break):
+
+                // type name
+                // values (might not be present depending on the type)
+                // description
+
+                // type name
+                var sb = new StringBuilder();
+                sb.Append(GetValueTypeName(prop.Value));
+                sb.Append(new LineBreak());
+
+                // required/optional
+                var required = RequiredFalse;
+                if (jsonSchema.Required != null && jsonSchema.Required.Contains(prop.Key))
+                    required = RequiredTrue;
+
+                // valuess
+                var values = GetPossibleValues(prop.Value);
+                if (values.Count > 0)
+                {
+                    if (values.Count == 1)
+                        sb.Append(new Strong(values[0]));
+                    else if (values.Count == 2)
+                        sb.Append(string.Join(" or ", values.Select(v => { return new Strong(v); })));
+                    else
+                        sb.Append(string.Join(", ", values.Select(v => { return new Strong(v); })));
+                    sb.Append(new LineBreak());
+                }
+                else if ((values = GetPossibleValueObjects(prop.Value)).Count > 0)
+                {
+                    if (values.Count == 1)
+                        sb.AppendFormat(new InlineLink(values[0], "{0} object", values[0]).ToString());
+                    else
+                        sb.Append(string.Join(new LineBreak().ToString(), values.Select(
+                            v =>
+                            {
+                                return new InlineLink(v, "{0} object", v).ToString();
+                            })));
+
+                    sb.Append(new LineBreak());
+                }
+
+                // description
+                if (!string.IsNullOrWhiteSpace(prop.Value.Description))
+                {
+                    sb.Append(new LineBreak());
+                    sb.Append(prop.Value.Description);
+                }
+
+                table.AddRow(new[] { prop.Key, required, sb.ToString() });
+            }
+
+            paragraph.Append(table);
+            return paragraph;
+        }
+
+        /// <summary>
+        /// Returns the name of the specified JSON type.
+        /// </summary>
+        /// <param name="jsonSchema">The schema object for which to return the type name.</param>
+        /// <returns>The name of the type contained in the specified schema.</returns>
+        private string GetValueTypeName(JsonSchema jsonSchema)
+        {
+            if (jsonSchema == null)
+                throw new ArgumentNullException(nameof(jsonSchema));
+
+            if (jsonSchema.Enum != null)
+                return "enum";
+            else if (jsonSchema.Ref != null)
+                return "object";
+            else
+                return jsonSchema.JsonType;
+        }
+
+        /// <summary>
+        /// Returns the list of values for the specified schema.
+        /// E.g. for enums the list would contain all of the enum values.
+        /// The returned list can be empty (typically for integral types).
+        /// </summary>
+        /// <param name="jsonSchema">The schema object for which to return the list of values.</param>
+        /// <returns>A list of possible values; can be an empty list.</returns>
+        private IReadOnlyList<string> GetPossibleValues(JsonSchema jsonSchema)
+        {
+            if (jsonSchema == null)
+                throw new ArgumentNullException(nameof(jsonSchema));
+
+            var values = new List<string>();
+
+            if (jsonSchema.Enum != null)
+            {
+                foreach (var e in jsonSchema.Enum)
+                    values.Add(e);
+            }
+            else if (jsonSchema.Items != null && jsonSchema.Items.Ref == null)
+            {
+                if (jsonSchema.Items.Enum != null)
+                {
+                    foreach (var e in jsonSchema.Items.Enum)
+                        values.Add(e);
+                }
+                else if (jsonSchema.Items.JsonType != null)
+                {
+                    values.Add(jsonSchema.Items.JsonType);
+                }
+            }
+            else if (jsonSchema.Format == "uuid")
+            {
+                values.Add("globally unique identifier");
+            }
+
+            return values;
+        }
+
+        /// <summary>
+        /// Returns the list of object type names that can be values for the specified schema.
+        /// The returned list can be empty (i.e. the return values aren't objects).
+        /// </summary>
+        /// <param name="jsonSchema">The schema object for which to return the list of object type names.</param>
+        /// <returns>A list of possible object names; can be an empty list.</returns>
+        private IReadOnlyList<string> GetPossibleValueObjects(JsonSchema jsonSchema)
+        {
+            if (jsonSchema == null)
+                throw new ArgumentNullException(nameof(jsonSchema));
+
+            var values = new List<string>();
+
+            if (jsonSchema.Ref != null)
+            {
+                values.Add(GetDefNameFromPointer(jsonSchema.Ref));
+            }
+            else if (jsonSchema.JsonType == "array" && jsonSchema.Items.Ref != null)
+            {
+                values.Add(GetDefNameFromPointer(jsonSchema.Items.Ref));
+            }
+            else if (jsonSchema.Items != null && jsonSchema.Items.OneOf != null)
+            {
+                foreach (var o in jsonSchema.Items.OneOf)
+                {
+                    var js = ResolveDefinitionRef(o.Ref);
+                    if (js.JsonType == "object")
+                    {
+                        Debug.Assert(!string.IsNullOrEmpty(js.ResourceType));
+                        values.Add(js.ResourceType);
+                    }
+                    else
+                    {
+                        Debug.Assert(false, "unhandled case");
+                    }
+                }
+            }
+
+            return values;
+        }
+
+        /// <summary>
+        /// Returns the name of the item referenced in the specified JSON pointer.
+        /// </summary>
+        /// <param name="jsonPointer">A JSON pointer that points to an item in the list of definitions.</param>
+        /// <returns>A string containing the name of the item referenced.</returns>
+        private string GetDefNameFromPointer(string jsonPointer)
+        {
+            if (string.IsNullOrEmpty(jsonPointer))
+                throw new ArgumentException(nameof(jsonPointer));
+            if (jsonPointer[0] != '#')
+                throw new ArgumentException(string.Format("Invalid argument '{0}', value must be a JSON pointer.", jsonPointer));
+
+            return jsonPointer.Substring(jsonPointer.LastIndexOf('/') + 1);
+        }
+
+        /// <summary>
+        /// Returns a schema object for the specified JSON pointer.
+        /// </summary>
+        /// <param name="jsonPointer">The JSON pointer for which to return a schema object.</param>
+        /// <returns>A JsonSchema object for the specified type.</returns>
+        private JsonSchema ResolveDefinitionRef(string jsonPointer)
+        {
+            if (string.IsNullOrEmpty(jsonPointer))
+                throw new ArgumentException(nameof(jsonPointer));
+
+            var defName = GetDefNameFromPointer(jsonPointer);
+            if (!_schema.Definitions.ContainsKey(defName))
+                throw new InvalidOperationException(string.Format("Didn't find a definition for '{0}'", jsonPointer));
+
+            return _schema.Definitions[defName];
+        }
+
+        /// <summary>
+        /// Creates a JToken hierarchy for the specified JsonSchema object.
+        /// </summary>
+        /// <param name="propName">The property name or null if the specified schema object is not a property.</param>
+        /// <param name="jsonSchema">The schema object to transform into a JToken object.</param>
+        /// <returns>A JToken object.</returns>
+        private JToken JsonSchemaToJToken(string propName, JsonSchema jsonSchema)
+        {
+            return JsonSchemaToJTokenImpl(propName, jsonSchema, new Stack<string>());
+        }
+
+        /// <summary>
+        /// Recursively creates a JToken hierarchy for the specified JsonSchema object (call JsonSchemaToJToken instead of this).
+        /// </summary>
+        /// <param name="propName">The property name or null if the specified schema object is not a property.</param>
+        /// <param name="jsonSchema">The schema object to transform into a JToken object.</param>
+        /// <param name="stack">Stack object used to detect cycles in the graph that would cause infinite recursion.</param>
+        /// <returns>A JToken object.</returns>
+        private JToken JsonSchemaToJTokenImpl(string propName, JsonSchema jsonSchema, Stack<string> stack)
+        {
+            if (jsonSchema == null)
+                throw new ArgumentNullException(nameof(jsonSchema));
+
+            if (jsonSchema.Ref != null)
+            {
+                // some definitions contain cycles which will lead to infinite recursion.
+                // in this case return a JToken object with the referenced definition name.
+                if (!stack.Contains(jsonSchema.Ref))
+                {
+                    stack.Push(jsonSchema.Ref);
+                    var def = ResolveDefinitionRef(jsonSchema.Ref);
+                    var result = JsonSchemaToJTokenImpl(propName, def, stack);
+                    var popped = stack.Pop();
+                    Debug.Assert(string.Compare(popped, jsonSchema.Ref, StringComparison.OrdinalIgnoreCase) == 0);
+                    return result;
+                }
+                else
+                {
+                    var defName = GetDefNameFromPointer(jsonSchema.Ref);
+                    if (propName != null)
+                        return new JProperty(propName, defName);
+                    else
+                        return new JValue(defName);
+                }
+            }
+            else if (jsonSchema.JsonType == "object")
+            {
+                var jobj = new JObject();
+                if (jsonSchema.Properties != null)
+                {
+                    foreach (var prop in jsonSchema.Properties)
+                        jobj.Add(JsonSchemaToJTokenImpl(prop.Key, prop.Value, stack));
+                }
+
+                if (propName != null)
+                    return new JProperty(propName, jobj);
+                else
+                    return jobj;
+            }
+            else if (jsonSchema.JsonType == "array")
+            {
+                Debug.Assert(jsonSchema.Items != null);
+                var jarr = new JArray();
+                jarr.Add(JsonSchemaToJTokenImpl(null, jsonSchema.Items, stack));
+
+                return new JProperty(propName, jarr);
+            }
+            else
+            {
+                string val = null;
+                if (jsonSchema.Enum != null && jsonSchema.Enum.Count == 1)
+                    val = jsonSchema.Enum[0];
+                else
+                    val = jsonSchema.JsonType;
+
+                if (propName != null)
+                    return new JProperty(propName, val);
+                else
+                    return new JValue(val);
+            }
+        }
+    }
+}

--- a/src/generator/AutoRest.AzureResourceSchema/ResourceSchemaParser.cs
+++ b/src/generator/AutoRest.AzureResourceSchema/ResourceSchemaParser.cs
@@ -82,6 +82,7 @@ namespace AutoRest.AzureResourceSchema
                     JsonSchema resourceDefinition = new JsonSchema();
                     resourceDefinition.JsonType = "object";
 
+                    resourceDefinition.ResourceType = resourceType;
                     resourceDefinition.AddProperty("type", JsonSchema.CreateStringEnum(resourceType), true);
                     resourceDefinition.AddProperty("apiVersion", JsonSchema.CreateStringEnum(apiVersion), true);
 
@@ -450,6 +451,11 @@ namespace AutoRest.AzureResourceSchema
                 case KnownPrimaryType.String:
                 case KnownPrimaryType.TimeSpan:
                     result.JsonType = "string";
+                    break;
+
+                case KnownPrimaryType.Uuid:
+                    result.JsonType = "string";
+                    result.Pattern = @"^[0-9a-fA-F]{8}(-[0-9a-fA-F]{4}){3}-[0-9a-fA-F]{12}$";
                     break;
 
                 default:

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerSpecHelper.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerSpecHelper.cs
@@ -64,8 +64,8 @@ namespace AutoRest.Swagger.Tests
             AutoRest.Core.AutoRestController.Generate();
             Assert.NotEmpty(((MemoryFileSystem)settings.FileSystem).VirtualStore);
 
-            var actualFiles = settings.FileSystem.GetFiles("X:\\Output", "*.*", SearchOption.AllDirectories).OrderBy(f => f).ToArray();
-            var expectedFiles = Directory.Exists(resultFolder) ? Directory.GetFiles(resultFolder, "*.*", SearchOption.AllDirectories).OrderBy(f => f).ToArray() : new string[0];
+            var actualFiles = settings.FileSystem.GetFiles("X:\\Output", "*.json", SearchOption.AllDirectories).OrderBy(f => f).ToArray();
+            var expectedFiles = Directory.Exists(resultFolder) ? Directory.GetFiles(resultFolder, "*.json", SearchOption.AllDirectories).OrderBy(f => f).ToArray() : new string[0];
             Assert.Equal(expectedFiles.Length, actualFiles.Length);
 
             for (int i = 0; i < expectedFiles.Length; i++)


### PR DESCRIPTION
The AzureResourceSchema generator will now generate a help document
alongside the generated resource schema.  The doc contains an example
schema and tables describing the various properties; this is modeled from
the existing help docs that are hand-written.
