### PR TITLE
Recognize mac os darwin version 10.12

### DIFF
--- a/Tools/gulp/gulp-regenerate-expected.js
+++ b/Tools/gulp/gulp-regenerate-expected.js
@@ -15,11 +15,19 @@ function GetAutoRestFolder() {
   if (isWindows) {
     return "src/core/AutoRest/bin/Debug/net451/win7-x64/";
   }
-  if( isMac ) {
-	return "src/core/AutoRest/bin/Debug/net451/osx.10.11-x64/";
+  if (isMac) {
+    var mac_os_10_11 = "src/core/AutoRest/bin/Debug/net451/osx.10.11-x64/";
+    var mac_os_10_12 = "src/core/AutoRest/bin/Debug/net451/osx.10.12-x64/";
+    if (fs.existsSync(mac_os_10_11)) {
+      return mac_os_10_11;
+    }
+    if (fs.existsSync(mac_os_10_12)) {
+      return mac_os_10_12;
+    }
+    throw new Error("Unknown Mac Darwin OS version.");
   } 
-  if( isLinux ) { 
-	return "src/core/AutoRest/bin/Debug/net451/ubuntu.14.04-x64/"
+  if (isLinux) { 
+    return "src/core/AutoRest/bin/Debug/net451/ubuntu.14.04-x64/"
   }
    throw new Error("Unknown platform?");
 }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,11 +32,19 @@ function GetAutoRestFolder() {
   if (isWindows) {
     return "src/core/AutoRest/bin/Debug/net451/win7-x64/";
   }
-  if( isMac ) {
-	return "src/core/AutoRest/bin/Debug/net451/osx.10.11-x64/";
+  if (isMac) {
+    var mac_os_10_11 = "src/core/AutoRest/bin/Debug/net451/osx.10.11-x64/";
+    var mac_os_10_12 = "src/core/AutoRest/bin/Debug/net451/osx.10.12-x64/";
+    if (fs.existsSync(mac_os_10_11)) {
+      return mac_os_10_11;
+    }
+    if (fs.existsSync(mac_os_10_12)) {
+      return mac_os_10_12;
+    }
+    throw new Error("Unknown Mac Darwin OS version.");
   }
-  if( isLinux ) {
-	return "src/core/AutoRest/bin/Debug/net451/ubuntu.14.04-x64/"
+  if (isLinux) {
+    return "src/core/AutoRest/bin/Debug/net451/ubuntu.14.04-x64/"
   }
    throw new Error("Unknown platform?");
 }


### PR DESCRIPTION
Me (the early adopter) using Mac OS version 10.12 ran into the problem. With this PR now AutoRest will recognize both version of Darwin OS 10.11 & 10.12

@fearthecowboy Please review as you get a chance. Thanks! 