### PR TITLE
[Ruby] Adding function to record telemetry on service client

### DIFF
--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_accounts.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_accounts.rb
@@ -915,13 +915,13 @@ module Petstore
 
     #
     # Asynchronously creates a new storage account with the specified parameters.
-    # Existing accounts cannot be updated with this API and should instead use the
-    # Update Storage Account API. If an account is already created and subsequent
-    # PUT request is issued with exact same set of properties, then HTTP 200 would
-    # be returned.
+    # Existing accounts cannot be updated with this API and should instead use
+    # the Update Storage Account API. If an account is already created and
+    # subsequent PUT request is issued with exact same set of properties, then
+    # HTTP 200 would be returned.
     #
-    # @param resource_group_name [String] The name of the resource group within the
-    # user's subscription.
+    # @param resource_group_name [String] The name of the resource group within
+    # the user's subscription.
     # @param account_name [String] The name of the storage account within the
     # specified resource group. Storage account names must be between 3 and 24
     # characters in length and use numbers and lower-case letters only.
@@ -939,13 +939,13 @@ module Petstore
 
     #
     # Asynchronously creates a new storage account with the specified parameters.
-    # Existing accounts cannot be updated with this API and should instead use the
-    # Update Storage Account API. If an account is already created and subsequent
-    # PUT request is issued with exact same set of properties, then HTTP 200 would
-    # be returned.
+    # Existing accounts cannot be updated with this API and should instead use
+    # the Update Storage Account API. If an account is already created and
+    # subsequent PUT request is issued with exact same set of properties, then
+    # HTTP 200 would be returned.
     #
-    # @param resource_group_name [String] The name of the resource group within the
-    # user's subscription.
+    # @param resource_group_name [String] The name of the resource group within
+    # the user's subscription.
     # @param account_name [String] The name of the storage account within the
     # specified resource group. Storage account names must be between 3 and 24
     # characters in length and use numbers and lower-case letters only.
@@ -962,13 +962,13 @@ module Petstore
 
     #
     # Asynchronously creates a new storage account with the specified parameters.
-    # Existing accounts cannot be updated with this API and should instead use the
-    # Update Storage Account API. If an account is already created and subsequent
-    # PUT request is issued with exact same set of properties, then HTTP 200 would
-    # be returned.
+    # Existing accounts cannot be updated with this API and should instead use
+    # the Update Storage Account API. If an account is already created and
+    # subsequent PUT request is issued with exact same set of properties, then
+    # HTTP 200 would be returned.
     #
-    # @param resource_group_name [String] The name of the resource group within the
-    # user's subscription.
+    # @param resource_group_name [String] The name of the resource group within
+    # the user's subscription.
     # @param account_name [String] The name of the storage account within the
     # specified resource group. Storage account names must be between 3 and 24
     # characters in length and use numbers and lower-case letters only.

--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
@@ -59,6 +59,7 @@ module Petstore
       @accept_language = 'en-US'
       @long_running_operation_retry_timeout = 30
       @generate_client_request_id = true
+      add_telemetry
     end
 
     #
@@ -116,5 +117,17 @@ module Petstore
       super(request_url, method, path, options)
     end
 
+
+    private
+    #
+    # Adds telemetry information.
+    #
+    def add_telemetry
+        sdk_information = 'azure_storage'
+        if defined? Petstore::VERSION
+          sdk_information = "#{sdk_information}/#{Petstore::VERSION}" 
+        end
+        add_user_agent_information(sdk_information)
+    end
   end
 end

--- a/Samples/petstore/Ruby/generated/petstore/swagger_petstore.rb
+++ b/Samples/petstore/Ruby/generated/petstore/swagger_petstore.rb
@@ -24,6 +24,7 @@ module Petstore
       fail ArgumentError, 'invalid type of credentials input parameter' unless credentials.is_a?(MsRest::ServiceClientCredentials)
       @credentials = credentials
 
+      add_telemetry
     end
 
     #
@@ -1924,5 +1925,17 @@ module Petstore
       promise.execute
     end
 
+
+    private
+    #
+    # Adds telemetry information.
+    #
+    def add_telemetry
+        sdk_information = 'petstore'
+        if defined? Petstore::VERSION
+          sdk_information = "#{sdk_information}/#{Petstore::VERSION}" 
+        end
+        add_user_agent_information(sdk_information)
+    end
   end
 end

--- a/src/generator/AutoRest.Ruby.Azure.Tests/Gemfile
+++ b/src/generator/AutoRest.Ruby.Azure.Tests/Gemfile
@@ -2,6 +2,6 @@ source 'https://rubygems.org'
 
 group :development, :local, :test do
   gem 'rspec'
-  gem 'ms_rest', '~> 0.6.0'
-  gem 'ms_rest_azure', '~> 0.6.0'
+  gem 'ms_rest', '~> 0.6.1'
+  gem 'ms_rest_azure', '~> 0.6.1'
 end

--- a/src/generator/AutoRest.Ruby.Tests/Gemfile
+++ b/src/generator/AutoRest.Ruby.Tests/Gemfile
@@ -3,5 +3,5 @@ source 'https://rubygems.org'
 group :development, :local, :test do
   gem 'rspec'
   gem 'faraday-cookie_jar', '~> 0.0.6'
-  gem 'ms_rest', '~> 0.6.0'
+  gem 'ms_rest', '~> 0.6.1'
 end

--- a/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
@@ -76,6 +76,7 @@ module @Settings.Namespace
       {
       @:@@@(property.Name) = @(property.DefaultValue)
       }
+      add_telemetry()
     end
 
     @EmptyLine
@@ -137,6 +138,18 @@ module @Settings.Namespace
 
       @EmptyLine
       super(request_url, method, path, options)
+    end
+
+    @EmptyLine
+    #
+    # Adds telemetry information.
+    #
+    def add_telemetry()
+        sdk_information = '@GeneratorSettingsRb.Instance.sdkPath'
+        if defined? @Settings.Namespace::VERSION
+          sdk_information = "#{sdk_information}/#{@Settings.Namespace::VERSION}" 
+        end
+        add_user_agent_information(sdk_information)
     end
 
     @EmptyLine

--- a/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
@@ -76,7 +76,7 @@ module @Settings.Namespace
       {
       @:@@@(property.Name) = @(property.DefaultValue)
       }
-      add_telemetry()
+      add_telemetry
     end
 
     @EmptyLine
@@ -141,23 +141,24 @@ module @Settings.Namespace
     end
 
     @EmptyLine
-    #
-    # Adds telemetry information.
-    #
-    def add_telemetry()
-        sdk_information = '@GeneratorSettingsRb.Instance.sdkPath'
-        if defined? @Settings.Namespace::VERSION
-          sdk_information = "#{sdk_information}/#{@Settings.Namespace::VERSION}" 
-        end
-        add_user_agent_information(sdk_information)
-    end
-
-    @EmptyLine
     @foreach (var method in Model.MethodTemplateModels)
     {
     @:@(Include(new MethodTemplate(), method))
     @EmptyLine
     @:
     }
+
+    @EmptyLine
+    private
+    #
+    # Adds telemetry information.
+    #
+    def add_telemetry
+        sdk_information = '@GeneratorSettingsRb.Instance.sdkPath'
+        if defined? @Settings.Namespace::VERSION
+          sdk_information = "#{sdk_information}/#{@Settings.Namespace::VERSION}" 
+        end
+        add_user_agent_information(sdk_information)
+    end
   end
 end


### PR DESCRIPTION
This is part of the feature [Azure-SDK-For-Ruby #517](https://github.com/Azure/azure-sdk-for-ruby/issues/517). We've exposed user_agent_extended array on the ServiceClient of ms_rest to be used for appending additional telemetry information to be sent via User-Agent header. Here we leverage that extension to add a function into each client generated through `Ruby` & `Azure.Ruby` generator to push sdk information into `User-Agent`

User-Agent Header Will look like for `Azure.Ruby` generator
```
Ruby/2.3.0 (x86_64-darwin15) ms_rest/0.6.0 ms_rest_azure/0.6.0 Azure-SDK-For-Ruby
        azure_mgmt_compute/0.7.0 
```

This PR will pass once we release new `ms_rest` and `ms_rest_azure` libraries.