### PR TITLE
XML escaped parameter descriptions and fixed word wrapping

### DIFF
--- a/src/core/AutoRest.Core.Tests/CodeGeneratorsTests.cs
+++ b/src/core/AutoRest.Core.Tests/CodeGeneratorsTests.cs
@@ -55,8 +55,8 @@ namespace AutoRest.Core.Tests
 
             sampleModelTemplate.Model = sampleViewModel;
             var output = sampleModelTemplate.ToString();
-            Assert.True(output.ContainsMultiline(@"/// Deserialize current type to Json object because today is Friday
-        /// and there is a sun outside the window."));
+            Assert.True(output.ContainsMultiline(@"/// Deserialize current type to Json object because today is Friday and
+        /// there is a sun outside the window."));
         }
 
         [Fact]

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/IAutoRestDurationTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/IAutoRestDurationTestService.cs
@@ -49,8 +49,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/IAutoRestDurationTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/IAutoRestDurationTestService.cs
@@ -49,8 +49,8 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationAllSync
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/IAutoRestDurationTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/IAutoRestDurationTestService.cs
@@ -49,8 +49,8 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationNoSync
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/IAzureCompositeModel.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/IAzureCompositeModel.cs
@@ -55,8 +55,8 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 
@@ -106,9 +106,9 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// </summary>
         /// <remarks>
         /// The Products endpoint returns information about the Uber products
-        /// offered at a given location. The response includes the display
-        /// name and other details about each product, and lists the products
-        /// in the proper display order.
+        /// offered at a given location. The response includes the display name
+        /// and other details about each product, and lists the products in the
+        /// proper display order.
         /// </remarks>
         /// <param name='resourceGroupName'>
         /// Resource Group ID.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/IInheritanceOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/IInheritanceOperations.cs
@@ -37,9 +37,9 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// </summary>
         /// <param name='complexBody'>
         /// Please put a siamese with id=2, name="Siameee", color=green,
-        /// breed=persion, which hates 2 dogs, the 1st one named "Potato"
-        /// with id=1 and food="tomato", and the 2nd one named "Tomato" with
-        /// id=-1 and food="french fries".
+        /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with
+        /// id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1
+        /// and food="french fries".
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/IPolymorphismOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/IPolymorphismOperations.cs
@@ -85,9 +85,9 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse> PutValidWithHttpMessagesAsync(Fish complexBody, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Put complex types that are polymorphic, attempting to omit
-        /// required 'birthday' field - the request should not be allowed
-        /// from the client
+        /// Put complex types that are polymorphic, attempting to omit required
+        /// 'birthday' field - the request should not be allowed from the
+        /// client
         /// </summary>
         /// <param name='complexBody'>
         /// Please attempt put a sawshark that looks like this, the client

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/InheritanceOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/InheritanceOperations.cs
@@ -197,10 +197,9 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// Put complex types that extend others
         /// </summary>
         /// <param name='complexBody'>
-        /// Please put a siamese with id=2, name="Siameee", color=green,
-        /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1
-        /// and food="tomato", and the 2nd one named "Tomato" with id=-1 and
-        /// food="french fries".
+        /// Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+        /// which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato",
+        /// and the 2nd one named "Tomato" with id=-1 and food="french fries".
         /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/InheritanceOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/InheritanceOperationsExtensions.cs
@@ -52,10 +52,9 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
             /// The operations group for this extension method.
             /// </param>
             /// <param name='complexBody'>
-            /// Please put a siamese with id=2, name="Siameee", color=green,
-            /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1
-            /// and food="tomato", and the 2nd one named "Tomato" with id=-1 and
-            /// food="french fries".
+            /// Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+            /// which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato",
+            /// and the 2nd one named "Tomato" with id=-1 and food="french fries".
             /// </param>
             public static void PutValid(this IInheritanceOperations operations, Siamese complexBody)
             {
@@ -69,10 +68,9 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
             /// The operations group for this extension method.
             /// </param>
             /// <param name='complexBody'>
-            /// Please put a siamese with id=2, name="Siameee", color=green,
-            /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1
-            /// and food="tomato", and the 2nd one named "Tomato" with id=-1 and
-            /// food="french fries".
+            /// Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+            /// which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato",
+            /// and the 2nd one named "Tomato" with id=-1 and food="french fries".
             /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Product.cs
@@ -24,7 +24,7 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
         /// Initializes a new instance of the Product class.
         /// </summary>
         /// <param name="productId">Unique identifier representing a specific
-        /// product for a given latitude & longitude. For example, uberX in
+        /// product for a given latitude &amp; longitude. For example, uberX in
         /// San Francisco will have a different product_id than uberX in Los
         /// Angeles.</param>
         /// <param name="description">Description of product.</param>
@@ -43,7 +43,7 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
         /// <summary>
         /// Gets or sets unique identifier representing a specific product for
-        /// a given latitude &amp; longitude. For example, uberX in San
+        /// a given latitude &amp;amp; longitude. For example, uberX in San
         /// Francisco will have a different product_id than uberX in Los
         /// Angeles.
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/PolymorphismOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/PolymorphismOperations.cs
@@ -217,8 +217,7 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
         /// 'age':105,
         /// 'birthday': '1900-01-05T01:00:00Z',
         /// 'length':10.0,
-        /// 'picture': new Buffer([255, 255, 255, 255,
-        /// 254]).toString('base64'),
+        /// 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
         /// 'species':'dangerous',
         /// },
         /// {

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/PolymorphismOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/PolymorphismOperationsExtensions.cs
@@ -72,8 +72,7 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
             /// 'age':105,
             /// 'birthday': '1900-01-05T01:00:00Z',
             /// 'length':10.0,
-            /// 'picture': new Buffer([255, 255, 255, 255,
-            /// 254]).toString('base64'),
+            /// 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
             /// 'species':'dangerous',
             /// },
             /// {
@@ -119,8 +118,7 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient
             /// 'age':105,
             /// 'birthday': '1900-01-05T01:00:00Z',
             /// 'length':10.0,
-            /// 'picture': new Buffer([255, 255, 255, 255,
-            /// 254]).toString('base64'),
+            /// 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
             /// 'species':'dangerous',
             /// },
             /// {

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/IAutoRestParameterGroupingTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/IAutoRestParameterGroupingTestService.cs
@@ -49,8 +49,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureReport/IAutoRestReportServiceForAzure.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureReport/IAutoRestReportServiceForAzure.cs
@@ -49,8 +49,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/IAutoRestResourceFlatteningTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/IAutoRestResourceFlatteningTestService.cs
@@ -49,8 +49,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/IAutoRestAzureSpecialParametersTestClient.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/IAutoRestAzureSpecialParametersTestClient.cs
@@ -61,8 +61,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeaders.cs
@@ -16,14 +16,14 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     public partial class HeaderCustomNamedRequestIdHeaders
     {
         /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdHeaders class.
+        /// Initializes a new instance of the HeaderCustomNamedRequestIdHeaders
+        /// class.
         /// </summary>
         public HeaderCustomNamedRequestIdHeaders() { }
 
         /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdHeaders class.
+        /// Initializes a new instance of the HeaderCustomNamedRequestIdHeaders
+        /// class.
         /// </summary>
         /// <param name="fooRequestId">Gets the foo-request-id.</param>
         public HeaderCustomNamedRequestIdHeaders(string fooRequestId = default(string))

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperations.cs
@@ -42,8 +42,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         public AutoRestAzureSpecialParametersTestClient Client { get; private set; }
 
         /// <summary>
-        /// POST method with subscriptionId modeled in credentials.  Set the
-        /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+        /// POST method with subscriptionId modeled in credentials.  Set the credential
+        /// subscriptionId to '1234-5678-9012-3456' to succeed
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -182,9 +182,9 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         }
 
         /// <summary>
-        /// POST method with subscriptionId modeled in credentials.  Set the
-        /// credential subscriptionId to null, and client-side validation should
-        /// prevent you from making this call
+        /// POST method with subscriptionId modeled in credentials.  Set the credential
+        /// subscriptionId to null, and client-side validation should prevent you from
+        /// making this call
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -323,8 +323,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         }
 
         /// <summary>
-        /// POST method with subscriptionId modeled in credentials.  Set the
-        /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+        /// POST method with subscriptionId modeled in credentials.  Set the credential
+        /// subscriptionId to '1234-5678-9012-3456' to succeed
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -471,8 +471,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         }
 
         /// <summary>
-        /// POST method with subscriptionId modeled in credentials.  Set the
-        /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+        /// POST method with subscriptionId modeled in credentials.  Set the credential
+        /// subscriptionId to '1234-5678-9012-3456' to succeed
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -611,8 +611,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
         }
 
         /// <summary>
-        /// POST method with subscriptionId modeled in credentials.  Set the
-        /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+        /// POST method with subscriptionId modeled in credentials.  Set the credential
+        /// subscriptionId to '1234-5678-9012-3456' to succeed
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/SubscriptionInCredentialsOperationsExtensions.cs
@@ -18,8 +18,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
     public static partial class SubscriptionInCredentialsOperationsExtensions
     {
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -45,9 +45,9 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to null, and client-side validation should
-            /// prevent you from making this call
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to null, and client-side validation should prevent you from
+            /// making this call
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -58,9 +58,9 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to null, and client-side validation should
-            /// prevent you from making this call
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to null, and client-side validation should prevent you from
+            /// making this call
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -74,8 +74,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -86,8 +86,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -101,8 +101,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -113,8 +113,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -128,8 +128,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -140,8 +140,8 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials
             }
 
             /// <summary>
-            /// POST method with subscriptionId modeled in credentials.  Set the
-            /// credential subscriptionId to '1234-5678-9012-3456' to succeed
+            /// POST method with subscriptionId modeled in credentials.  Set the credential
+            /// subscriptionId to '1234-5678-9012-3456' to succeed
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/IAutoRestParameterizedHostTestClient.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/IAutoRestParameterizedHostTestClient.cs
@@ -54,8 +54,8 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Head/IAutoRestHeadTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Head/IAutoRestHeadTestService.cs
@@ -48,8 +48,8 @@ namespace Fixtures.Azure.AcceptanceTestsHead
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/IAutoRestHeadExceptionTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/IAutoRestHeadExceptionTestService.cs
@@ -48,8 +48,8 @@ namespace Fixtures.Azure.AcceptanceTestsHeadExceptions
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/IAutoRestLongRunningOperationTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/IAutoRestLongRunningOperationTestService.cs
@@ -49,8 +49,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILRORetrysOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILRORetrysOperations.cs
@@ -110,9 +110,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> DeleteAsyncRelativeRetrySucceededWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to
-        /// the initial request, with 'Location' and 'Retry-After' headers,
-        /// Polls return a 200 with a response body after success
+        /// Long running post request, service returns a 500, then a 202 to the
+        /// initial request, with 'Location' and 'Retry-After' headers, Polls
+        /// return a 200 with a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -128,8 +128,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LRORetrysPost202Retry200Headers>> Post202Retry200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to
-        /// the initial request, with an entity that contains
+        /// Long running post request, service returns a 500, then a 202 to the
+        /// initial request, with an entity that contains
         /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
         /// Azure-AsyncOperation header for operation status
         /// </summary>
@@ -240,9 +240,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LRORetrysDeleteAsyncRelativeRetrySucceededHeaders>> BeginDeleteAsyncRelativeRetrySucceededWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to
-        /// the initial request, with 'Location' and 'Retry-After' headers,
-        /// Polls return a 200 with a response body after success
+        /// Long running post request, service returns a 500, then a 202 to the
+        /// initial request, with 'Location' and 'Retry-After' headers, Polls
+        /// return a 200 with a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -258,8 +258,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LRORetrysPost202Retry200Headers>> BeginPost202Retry200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to
-        /// the initial request, with an entity that contains
+        /// Long running post request, service returns a 500, then a 202 to the
+        /// initial request, with an entity that contains
         /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
         /// Azure-AsyncOperation header for operation status
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILROSADsOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILROSADsOperations.cs
@@ -213,9 +213,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> PutError201NoProvisioningStatePayloadWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -235,9 +235,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROSADsPutAsyncRelativeRetryNoStatusHeaders>> PutAsyncRelativeRetryNoStatusWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -303,9 +303,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsPost202NoLocationHeaders>> Post202NoLocationWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -342,9 +342,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> Put200InvalidJsonWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. The endpoint indicated in the
-        /// Azure-AsyncOperation header is invalid.
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// The endpoint indicated in the Azure-AsyncOperation header is
+        /// invalid.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -364,9 +364,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> PutAsyncRelativeRetryInvalidHeaderWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -401,8 +401,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsDelete202RetryInvalidHeaderHeaders>> Delete202RetryInvalidHeaderWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request. The endpoint indicated in the Azure-AsyncOperation
-        /// header is invalid
+        /// request. The endpoint indicated in the Azure-AsyncOperation header
+        /// is invalid
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -448,9 +448,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsPost202RetryInvalidHeaderHeaders>> Post202RetryInvalidHeaderWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. The endpoint indicated in the
-        /// Azure-AsyncOperation header is invalid.
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// The endpoint indicated in the Azure-AsyncOperation header is
+        /// invalid.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -467,9 +467,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> PostAsyncRelativeRetryInvalidHeaderWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -681,9 +681,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> BeginPutError201NoProvisioningStatePayloadWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -703,9 +703,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROSADsPutAsyncRelativeRetryNoStatusHeaders>> BeginPutAsyncRelativeRetryNoStatusWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -771,9 +771,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsPost202NoLocationHeaders>> BeginPost202NoLocationWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -810,9 +810,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> BeginPut200InvalidJsonWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. The endpoint indicated in the
-        /// Azure-AsyncOperation header is invalid.
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// The endpoint indicated in the Azure-AsyncOperation header is
+        /// invalid.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -832,9 +832,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders>> BeginPutAsyncRelativeRetryInvalidHeaderWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -869,8 +869,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsDelete202RetryInvalidHeaderHeaders>> BeginDelete202RetryInvalidHeaderWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request. The endpoint indicated in the Azure-AsyncOperation
-        /// header is invalid
+        /// request. The endpoint indicated in the Azure-AsyncOperation header
+        /// is invalid
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -916,9 +916,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsPost202RetryInvalidHeaderHeaders>> BeginPost202RetryInvalidHeaderWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. The endpoint indicated in the
-        /// Azure-AsyncOperation header is invalid.
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// The endpoint indicated in the Azure-AsyncOperation header is
+        /// invalid.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -935,9 +935,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders>> BeginPostAsyncRelativeRetryInvalidHeaderWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILROsCustomHeaderOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILROsCustomHeaderOperations.cs
@@ -18,11 +18,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
     {
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is
-        /// required message header for all requests. Long running put
-        /// request, service returns a 200 to the initial request, with an
-        /// entity that contains ProvisioningState=’Creating’. Poll the
-        /// endpoint indicated in the Azure-AsyncOperation header for
-        /// operation status
+        /// required message header for all requests. Long running put request,
+        /// service returns a 200 to the initial request, with an entity that
+        /// contains ProvisioningState=’Creating’. Poll the endpoint indicated
+        /// in the Azure-AsyncOperation header for operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -42,10 +41,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsCustomHeaderPutAsyncRetrySucceededHeaders>> PutAsyncRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is
-        /// required message header for all requests. Long running put
-        /// request, service returns a 201 to the initial request, with an
-        /// entity that contains ProvisioningState=’Creating’.  Polls return
-        /// this value until the last poll returns a ‘200’ with
+        /// required message header for all requests. Long running put request,
+        /// service returns a 201 to the initial request, with an entity that
+        /// contains ProvisioningState=’Creating’.  Polls return this value
+        /// until the last poll returns a ‘200’ with
         /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
@@ -89,8 +88,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// required message header for all requests. Long running post
         /// request, service returns a 202 to the initial request, with an
         /// entity that contains ProvisioningState=’Creating’. Poll the
-        /// endpoint indicated in the Azure-AsyncOperation header for
-        /// operation status
+        /// endpoint indicated in the Azure-AsyncOperation header for operation
+        /// status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -107,11 +106,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROsCustomHeaderPostAsyncRetrySucceededHeaders>> PostAsyncRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is
-        /// required message header for all requests. Long running put
-        /// request, service returns a 200 to the initial request, with an
-        /// entity that contains ProvisioningState=’Creating’. Poll the
-        /// endpoint indicated in the Azure-AsyncOperation header for
-        /// operation status
+        /// required message header for all requests. Long running put request,
+        /// service returns a 200 to the initial request, with an entity that
+        /// contains ProvisioningState=’Creating’. Poll the endpoint indicated
+        /// in the Azure-AsyncOperation header for operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -131,10 +129,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsCustomHeaderPutAsyncRetrySucceededHeaders>> BeginPutAsyncRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is
-        /// required message header for all requests. Long running put
-        /// request, service returns a 201 to the initial request, with an
-        /// entity that contains ProvisioningState=’Creating’.  Polls return
-        /// this value until the last poll returns a ‘200’ with
+        /// required message header for all requests. Long running put request,
+        /// service returns a 201 to the initial request, with an entity that
+        /// contains ProvisioningState=’Creating’.  Polls return this value
+        /// until the last poll returns a ‘200’ with
         /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
@@ -178,8 +176,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// required message header for all requests. Long running post
         /// request, service returns a 202 to the initial request, with an
         /// entity that contains ProvisioningState=’Creating’. Poll the
-        /// endpoint indicated in the Azure-AsyncOperation header for
-        /// operation status
+        /// endpoint indicated in the Azure-AsyncOperation header for operation
+        /// status
         /// </summary>
         /// <param name='product'>
         /// Product to put

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILROsOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/ILROsOperations.cs
@@ -61,8 +61,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// <summary>
         /// Long running put request, service returns a 202 to the initial
         /// request, with a location header that points to a polling URL that
-        /// returns a 200 and an entity that doesn't contains
-        /// ProvisioningState
+        /// returns a 200 and an entity that doesn't contains ProvisioningState
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -82,9 +81,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> Put202Retry200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -104,9 +103,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> Put201CreatingSucceeded200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Updating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// request, with an entity that contains ProvisioningState=’Updating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -126,9 +125,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> Put200UpdatingSucceeded204WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Created’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Failed’
+        /// request, with an entity that contains ProvisioningState=’Created’. 
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Failed’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -148,9 +147,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> Put201CreatingFailed200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Canceled’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Canceled’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -170,8 +169,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> Put200Acceptedcanceled200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 202 to the initial
-        /// request with location header. Subsequent calls to operation
-        /// status do not contain location header.
+        /// request with location header. Subsequent calls to operation status
+        /// do not contain location header.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -191,9 +190,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutNoHeaderInRetryHeaders>> PutNoHeaderInRetryWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -213,9 +212,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutAsyncRetrySucceededHeaders>> PutAsyncRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -235,9 +234,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutAsyncNoRetrySucceededHeaders>> PutAsyncNoRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -257,9 +256,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutAsyncRetryFailedHeaders>> PutAsyncRetryFailedWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -374,9 +373,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<SubProduct>> PutAsyncSubResourceWithHttpMessagesAsync(string provisioningState = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Accepted’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// request, with an entity that contains ProvisioningState=’Accepted’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -393,9 +392,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsDeleteProvisioning202Accepted200SucceededHeaders>> DeleteProvisioning202Accepted200SucceededWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Failed’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Failed’
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -412,9 +411,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsDeleteProvisioning202DeletingFailed200Headers>> DeleteProvisioning202DeletingFailed200WithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Canceled’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Canceled’
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -571,8 +570,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROsDeleteAsyncRetrycanceledHeaders>> DeleteAsyncRetrycanceledWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with 'Location' header. Poll returns a 200 with a
-        /// response body after success.
+        /// request, with 'Location' header. Poll returns a 200 with a response
+        /// body after success.
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -589,8 +588,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Sku>> Post200WithPayloadWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with 'Location' and 'Retry-After' headers, Polls return
-        /// a 200 with a response body after success
+        /// request, with 'Location' and 'Retry-After' headers, Polls return a
+        /// 200 with a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -628,9 +627,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPost202NoRetry204Headers>> Post202NoRetry204WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -650,9 +649,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPostAsyncRetrySucceededHeaders>> PostAsyncRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -672,9 +671,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPostAsyncNoRetrySucceededHeaders>> PostAsyncNoRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -691,9 +690,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROsPostAsyncRetryFailedHeaders>> PostAsyncRetryFailedWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -753,8 +752,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         /// <summary>
         /// Long running put request, service returns a 202 to the initial
         /// request, with a location header that points to a polling URL that
-        /// returns a 200 and an entity that doesn't contains
-        /// ProvisioningState
+        /// returns a 200 and an entity that doesn't contains ProvisioningState
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -774,9 +772,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> BeginPut202Retry200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -796,9 +794,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> BeginPut201CreatingSucceeded200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Updating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// request, with an entity that contains ProvisioningState=’Updating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -818,9 +816,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> BeginPut200UpdatingSucceeded204WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Created’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Failed’
+        /// request, with an entity that contains ProvisioningState=’Created’. 
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Failed’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -840,9 +838,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> BeginPut201CreatingFailed200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 201 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Canceled’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Canceled’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -862,8 +860,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product>> BeginPut200Acceptedcanceled200WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 202 to the initial
-        /// request with location header. Subsequent calls to operation
-        /// status do not contain location header.
+        /// request with location header. Subsequent calls to operation status
+        /// do not contain location header.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -883,9 +881,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutNoHeaderInRetryHeaders>> BeginPutNoHeaderInRetryWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -905,9 +903,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutAsyncRetrySucceededHeaders>> BeginPutAsyncRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -927,9 +925,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutAsyncNoRetrySucceededHeaders>> BeginPutAsyncNoRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -949,9 +947,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPutAsyncRetryFailedHeaders>> BeginPutAsyncRetryFailedWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running put request, service returns a 200 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -1066,9 +1064,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<SubProduct>> BeginPutAsyncSubResourceWithHttpMessagesAsync(string provisioningState = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Accepted’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// request, with an entity that contains ProvisioningState=’Accepted’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1085,9 +1083,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsDeleteProvisioning202Accepted200SucceededHeaders>> BeginDeleteProvisioning202Accepted200SucceededWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Failed’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Failed’
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1104,9 +1102,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsDeleteProvisioning202DeletingFailed200Headers>> BeginDeleteProvisioning202DeletingFailed200WithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running delete request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the
-        /// last poll returns a ‘200’ with ProvisioningState=’Canceled’
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Canceled’
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1263,8 +1261,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROsDeleteAsyncRetrycanceledHeaders>> BeginDeleteAsyncRetrycanceledWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with 'Location' header. Poll returns a 200 with a
-        /// response body after success.
+        /// request, with 'Location' header. Poll returns a 200 with a response
+        /// body after success.
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1281,8 +1279,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Sku>> BeginPost200WithPayloadWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with 'Location' and 'Retry-After' headers, Polls return
-        /// a 200 with a response body after success
+        /// request, with 'Location' and 'Retry-After' headers, Polls return a
+        /// 200 with a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -1320,9 +1318,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPost202NoRetry204Headers>> BeginPost202NoRetry204WithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -1342,9 +1340,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPostAsyncRetrySucceededHeaders>> BeginPostAsyncRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -1364,9 +1362,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationResponse<Product,LROsPostAsyncNoRetrySucceededHeaders>> BeginPostAsyncNoRetrySucceededWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -1383,9 +1381,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         System.Threading.Tasks.Task<Microsoft.Rest.Azure.AzureOperationHeaderResponse<LROsPostAsyncRetryFailedHeaders>> BeginPostAsyncRetryFailedWithHttpMessagesAsync(Product product = default(Product), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Long running post request, service returns a 202 to the initial
-        /// request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// request, with an entity that contains ProvisioningState=’Creating’.
+        /// Poll the endpoint indicated in the Azure-AsyncOperation header for
+        /// operation status
         /// </summary>
         /// <param name='product'>
         /// Product to put

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperations.cs
@@ -43,8 +43,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// Long running put request, service returns a 500, then a 201 to the initial
-        /// request, with an entity that contains ProvisioningState=’Creating’.
-        /// Polls return this value until the last poll returns a ‘200’ with
+        /// request, with an entity that contains ProvisioningState=’Creating’.  Polls
+        /// return this value until the last poll returns a ‘200’ with
         /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
@@ -93,9 +93,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// Long running delete request, service returns a 500, then a  202 to the
-        /// initial request, with an entity that contains
-        /// ProvisioningState=’Accepted’.  Polls return this value until the last
-        /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// initial request, with an entity that contains ProvisioningState=’Accepted’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -150,9 +150,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to the
-        /// initial request, with 'Location' and 'Retry-After' headers, Polls return
-        /// a 200 with a response body after success
+        /// Long running post request, service returns a 500, then a 202 to the initial
+        /// request, with 'Location' and 'Retry-After' headers, Polls return a 200 with
+        /// a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -172,10 +172,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to the
-        /// initial request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// Long running post request, service returns a 500, then a 202 to the initial
+        /// request, with an entity that contains ProvisioningState=’Creating’. Poll
+        /// the endpoint indicated in the Azure-AsyncOperation header for operation
+        /// status
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -196,8 +196,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// Long running put request, service returns a 500, then a 201 to the initial
-        /// request, with an entity that contains ProvisioningState=’Creating’.
-        /// Polls return this value until the last poll returns a ‘200’ with
+        /// request, with an entity that contains ProvisioningState=’Creating’.  Polls
+        /// return this value until the last poll returns a ‘200’ with
         /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
@@ -567,9 +567,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// Long running delete request, service returns a 500, then a  202 to the
-        /// initial request, with an entity that contains
-        /// ProvisioningState=’Accepted’.  Polls return this value until the last
-        /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// initial request, with an entity that contains ProvisioningState=’Accepted’.
+        /// Polls return this value until the last poll returns a ‘200’ with
+        /// ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -1059,9 +1059,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to the
-        /// initial request, with 'Location' and 'Retry-After' headers, Polls return
-        /// a 200 with a response body after success
+        /// Long running post request, service returns a 500, then a 202 to the initial
+        /// request, with 'Location' and 'Retry-After' headers, Polls return a 200 with
+        /// a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -1220,10 +1220,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running post request, service returns a 500, then a 202 to the
-        /// initial request, with an entity that contains
-        /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-        /// Azure-AsyncOperation header for operation status
+        /// Long running post request, service returns a 500, then a 202 to the initial
+        /// request, with an entity that contains ProvisioningState=’Creating’. Poll
+        /// the endpoint indicated in the Azure-AsyncOperation header for operation
+        /// status
         /// </summary>
         /// <param name='product'>
         /// Product to put

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LRORetrysOperationsExtensions.cs
@@ -19,8 +19,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
     {
             /// <summary>
             /// Long running put request, service returns a 500, then a 201 to the initial
-            /// request, with an entity that contains ProvisioningState=’Creating’.
-            /// Polls return this value until the last poll returns a ‘200’ with
+            /// request, with an entity that contains ProvisioningState=’Creating’.  Polls
+            /// return this value until the last poll returns a ‘200’ with
             /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
@@ -36,8 +36,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running put request, service returns a 500, then a 201 to the initial
-            /// request, with an entity that contains ProvisioningState=’Creating’.
-            /// Polls return this value until the last poll returns a ‘200’ with
+            /// request, with an entity that contains ProvisioningState=’Creating’.  Polls
+            /// return this value until the last poll returns a ‘200’ with
             /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
@@ -99,9 +99,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running delete request, service returns a 500, then a  202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Accepted’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// initial request, with an entity that contains ProvisioningState=’Accepted’.
+            /// Polls return this value until the last poll returns a ‘200’ with
+            /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -113,9 +113,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running delete request, service returns a 500, then a  202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Accepted’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// initial request, with an entity that contains ProvisioningState=’Accepted’.
+            /// Polls return this value until the last poll returns a ‘200’ with
+            /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -196,9 +196,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with 'Location' and 'Retry-After' headers, Polls return
-            /// a 200 with a response body after success
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with 'Location' and 'Retry-After' headers, Polls return a 200 with
+            /// a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -212,9 +212,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with 'Location' and 'Retry-After' headers, Polls return
-            /// a 200 with a response body after success
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with 'Location' and 'Retry-After' headers, Polls return a 200 with
+            /// a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -234,10 +234,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-            /// Azure-AsyncOperation header for operation status
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with an entity that contains ProvisioningState=’Creating’. Poll
+            /// the endpoint indicated in the Azure-AsyncOperation header for operation
+            /// status
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -251,10 +251,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-            /// Azure-AsyncOperation header for operation status
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with an entity that contains ProvisioningState=’Creating’. Poll
+            /// the endpoint indicated in the Azure-AsyncOperation header for operation
+            /// status
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -275,8 +275,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running put request, service returns a 500, then a 201 to the initial
-            /// request, with an entity that contains ProvisioningState=’Creating’.
-            /// Polls return this value until the last poll returns a ‘200’ with
+            /// request, with an entity that contains ProvisioningState=’Creating’.  Polls
+            /// return this value until the last poll returns a ‘200’ with
             /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
@@ -292,8 +292,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running put request, service returns a 500, then a 201 to the initial
-            /// request, with an entity that contains ProvisioningState=’Creating’.
-            /// Polls return this value until the last poll returns a ‘200’ with
+            /// request, with an entity that contains ProvisioningState=’Creating’.  Polls
+            /// return this value until the last poll returns a ‘200’ with
             /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
@@ -355,9 +355,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running delete request, service returns a 500, then a  202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Accepted’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// initial request, with an entity that contains ProvisioningState=’Accepted’.
+            /// Polls return this value until the last poll returns a ‘200’ with
+            /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -369,9 +369,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running delete request, service returns a 500, then a  202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Accepted’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// initial request, with an entity that contains ProvisioningState=’Accepted’.
+            /// Polls return this value until the last poll returns a ‘200’ with
+            /// ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -452,9 +452,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with 'Location' and 'Retry-After' headers, Polls return
-            /// a 200 with a response body after success
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with 'Location' and 'Retry-After' headers, Polls return a 200 with
+            /// a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -468,9 +468,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with 'Location' and 'Retry-After' headers, Polls return
-            /// a 200 with a response body after success
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with 'Location' and 'Retry-After' headers, Polls return a 200 with
+            /// a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -490,10 +490,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-            /// Azure-AsyncOperation header for operation status
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with an entity that contains ProvisioningState=’Creating’. Poll
+            /// the endpoint indicated in the Azure-AsyncOperation header for operation
+            /// status
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -507,10 +507,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running post request, service returns a 500, then a 202 to the
-            /// initial request, with an entity that contains
-            /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
-            /// Azure-AsyncOperation header for operation status
+            /// Long running post request, service returns a 500, then a 202 to the initial
+            /// request, with an entity that contains ProvisioningState=’Creating’. Poll
+            /// the endpoint indicated in the Azure-AsyncOperation header for operation
+            /// status
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROSADsOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROSADsOperations.cs
@@ -249,8 +249,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running put request, service returns a 201 to the initial request
-        /// with no payload
+        /// Long running put request, service returns a 201 to the initial request with
+        /// no payload
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -2258,8 +2258,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running put request, service returns a 201 to the initial request
-        /// with no payload
+        /// Long running put request, service returns a 201 to the initial request with
+        /// no payload
         /// </summary>
         /// <param name='product'>
         /// Product to put

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROSADsOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROSADsOperationsExtensions.cs
@@ -356,8 +356,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 201 to the initial request
-            /// with no payload
+            /// Long running put request, service returns a 201 to the initial request with
+            /// no payload
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -371,8 +371,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 201 to the initial request
-            /// with no payload
+            /// Long running put request, service returns a 201 to the initial request with
+            /// no payload
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1255,8 +1255,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 201 to the initial request
-            /// with no payload
+            /// Long running put request, service returns a 201 to the initial request with
+            /// no payload
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1270,8 +1270,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 201 to the initial request
-            /// with no payload
+            /// Long running put request, service returns a 201 to the initial request with
+            /// no payload
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperations.cs
@@ -43,8 +43,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running put request, service
-        /// returns a 200 to the initial request, with an entity that contains
+        /// message header for all requests. Long running put request, service returns
+        /// a 200 to the initial request, with an entity that contains
         /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
         /// Azure-AsyncOperation header for operation status
         /// </summary>
@@ -69,10 +69,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running put request, service
-        /// returns a 201 to the initial request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the last
-        /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// message header for all requests. Long running put request, service returns
+        /// a 201 to the initial request, with an entity that contains
+        /// ProvisioningState=’Creating’.  Polls return this value until the last poll
+        /// returns a ‘200’ with ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -95,9 +95,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running post request, service
-        /// returns a 202 to the initial request, with 'Location' and 'Retry-After'
-        /// headers, Polls return a 200 with a response body after success
+        /// message header for all requests. Long running post request, service returns
+        /// a 202 to the initial request, with 'Location' and 'Retry-After' headers,
+        /// Polls return a 200 with a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -118,8 +118,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running post request, service
-        /// returns a 202 to the initial request, with an entity that contains
+        /// message header for all requests. Long running post request, service returns
+        /// a 202 to the initial request, with an entity that contains
         /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
         /// Azure-AsyncOperation header for operation status
         /// </summary>
@@ -142,8 +142,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running put request, service
-        /// returns a 200 to the initial request, with an entity that contains
+        /// message header for all requests. Long running put request, service returns
+        /// a 200 to the initial request, with an entity that contains
         /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
         /// Azure-AsyncOperation header for operation status
         /// </summary>
@@ -326,10 +326,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running put request, service
-        /// returns a 201 to the initial request, with an entity that contains
-        /// ProvisioningState=’Creating’.  Polls return this value until the last
-        /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+        /// message header for all requests. Long running put request, service returns
+        /// a 201 to the initial request, with an entity that contains
+        /// ProvisioningState=’Creating’.  Polls return this value until the last poll
+        /// returns a ‘200’ with ProvisioningState=’Succeeded’
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -515,9 +515,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running post request, service
-        /// returns a 202 to the initial request, with 'Location' and 'Retry-After'
-        /// headers, Polls return a 200 with a response body after success
+        /// message header for all requests. Long running post request, service returns
+        /// a 202 to the initial request, with 'Location' and 'Retry-After' headers,
+        /// Polls return a 200 with a response body after success
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -677,8 +677,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-        /// message header for all requests. Long running post request, service
-        /// returns a 202 to the initial request, with an entity that contains
+        /// message header for all requests. Long running post request, service returns
+        /// a 202 to the initial request, with an entity that contains
         /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
         /// Azure-AsyncOperation header for operation status
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsCustomHeaderOperationsExtensions.cs
@@ -19,8 +19,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
     {
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 200 to the initial request, with an entity that contains
+            /// message header for all requests. Long running put request, service returns
+            /// a 200 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>
@@ -37,8 +37,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 200 to the initial request, with an entity that contains
+            /// message header for all requests. Long running put request, service returns
+            /// a 200 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>
@@ -61,10 +61,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 201 to the initial request, with an entity that contains
-            /// ProvisioningState=’Creating’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// message header for all requests. Long running put request, service returns
+            /// a 201 to the initial request, with an entity that contains
+            /// ProvisioningState=’Creating’.  Polls return this value until the last poll
+            /// returns a ‘200’ with ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -79,10 +79,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 201 to the initial request, with an entity that contains
-            /// ProvisioningState=’Creating’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// message header for all requests. Long running put request, service returns
+            /// a 201 to the initial request, with an entity that contains
+            /// ProvisioningState=’Creating’.  Polls return this value until the last poll
+            /// returns a ‘200’ with ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -103,9 +103,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with 'Location' and 'Retry-After'
-            /// headers, Polls return a 200 with a response body after success
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with 'Location' and 'Retry-After' headers,
+            /// Polls return a 200 with a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -120,9 +120,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with 'Location' and 'Retry-After'
-            /// headers, Polls return a 200 with a response body after success
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with 'Location' and 'Retry-After' headers,
+            /// Polls return a 200 with a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -143,8 +143,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with an entity that contains
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>
@@ -161,8 +161,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with an entity that contains
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>
@@ -185,8 +185,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 200 to the initial request, with an entity that contains
+            /// message header for all requests. Long running put request, service returns
+            /// a 200 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>
@@ -203,8 +203,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 200 to the initial request, with an entity that contains
+            /// message header for all requests. Long running put request, service returns
+            /// a 200 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>
@@ -227,10 +227,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 201 to the initial request, with an entity that contains
-            /// ProvisioningState=’Creating’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// message header for all requests. Long running put request, service returns
+            /// a 201 to the initial request, with an entity that contains
+            /// ProvisioningState=’Creating’.  Polls return this value until the last poll
+            /// returns a ‘200’ with ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -245,10 +245,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running put request, service
-            /// returns a 201 to the initial request, with an entity that contains
-            /// ProvisioningState=’Creating’.  Polls return this value until the last
-            /// poll returns a ‘200’ with ProvisioningState=’Succeeded’
+            /// message header for all requests. Long running put request, service returns
+            /// a 201 to the initial request, with an entity that contains
+            /// ProvisioningState=’Creating’.  Polls return this value until the last poll
+            /// returns a ‘200’ with ProvisioningState=’Succeeded’
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -269,9 +269,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with 'Location' and 'Retry-After'
-            /// headers, Polls return a 200 with a response body after success
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with 'Location' and 'Retry-After' headers,
+            /// Polls return a 200 with a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -286,9 +286,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with 'Location' and 'Retry-After'
-            /// headers, Polls return a 200 with a response body after success
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with 'Location' and 'Retry-After' headers,
+            /// Polls return a 200 with a response body after success
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -309,8 +309,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with an entity that contains
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>
@@ -327,8 +327,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// x-ms-client-request-id = 9C4D50EE-2D56-4CD3-8152-34347DC9F2B0 is required
-            /// message header for all requests. Long running post request, service
-            /// returns a 202 to the initial request, with an entity that contains
+            /// message header for all requests. Long running post request, service returns
+            /// a 202 to the initial request, with an entity that contains
             /// ProvisioningState=’Creating’. Poll the endpoint indicated in the
             /// Azure-AsyncOperation header for operation status
             /// </summary>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsOperations.cs
@@ -89,8 +89,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// Long running put request, service returns a 202 to the initial request,
-        /// with a location header that points to a polling URL that returns a 200
-        /// and an entity that doesn't contains ProvisioningState
+        /// with a location header that points to a polling URL that returns a 200 and
+        /// an entity that doesn't contains ProvisioningState
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -212,8 +212,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running put request, service returns a 202 to the initial request
-        /// with location header. Subsequent calls to operation status do not contain
+        /// Long running put request, service returns a 202 to the initial request with
+        /// location header. Subsequent calls to operation status do not contain
         /// location header.
         /// </summary>
         /// <param name='product'>
@@ -332,9 +332,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running put request, service returns a 202 to the initial request
-        /// with Azure-AsyncOperation header. Subsequent calls to operation status do
-        /// not contain Azure-AsyncOperation header.
+        /// Long running put request, service returns a 202 to the initial request with
+        /// Azure-AsyncOperation header. Subsequent calls to operation status do not
+        /// contain Azure-AsyncOperation header.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -576,9 +576,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running delete request, service returns an Azure-AsyncOperation
-        /// header in the initial request. Subsequent calls to operation status do
-        /// not contain Azure-AsyncOperation header.
+        /// Long running delete request, service returns an Azure-AsyncOperation header
+        /// in the initial request. Subsequent calls to operation status do not contain
+        /// Azure-AsyncOperation header.
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1158,8 +1158,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
         /// <summary>
         /// Long running put request, service returns a 202 to the initial request,
-        /// with a location header that points to a polling URL that returns a 200
-        /// and an entity that doesn't contains ProvisioningState
+        /// with a location header that points to a polling URL that returns a 200 and
+        /// an entity that doesn't contains ProvisioningState
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -2042,8 +2042,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running put request, service returns a 202 to the initial request
-        /// with location header. Subsequent calls to operation status do not contain
+        /// Long running put request, service returns a 202 to the initial request with
+        /// location header. Subsequent calls to operation status do not contain
         /// location header.
         /// </summary>
         /// <param name='product'>
@@ -2952,9 +2952,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running put request, service returns a 202 to the initial request
-        /// with Azure-AsyncOperation header. Subsequent calls to operation status do
-        /// not contain Azure-AsyncOperation header.
+        /// Long running put request, service returns a 202 to the initial request with
+        /// Azure-AsyncOperation header. Subsequent calls to operation status do not
+        /// contain Azure-AsyncOperation header.
         /// </summary>
         /// <param name='product'>
         /// Product to put
@@ -5016,9 +5016,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
         }
 
         /// <summary>
-        /// Long running delete request, service returns an Azure-AsyncOperation
-        /// header in the initial request. Subsequent calls to operation status do
-        /// not contain Azure-AsyncOperation header.
+        /// Long running delete request, service returns an Azure-AsyncOperation header
+        /// in the initial request. Subsequent calls to operation status do not contain
+        /// Azure-AsyncOperation header.
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/LROsOperationsExtensions.cs
@@ -91,8 +91,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running put request, service returns a 202 to the initial request,
-            /// with a location header that points to a polling URL that returns a 200
-            /// and an entity that doesn't contains ProvisioningState
+            /// with a location header that points to a polling URL that returns a 200 and
+            /// an entity that doesn't contains ProvisioningState
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -107,8 +107,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running put request, service returns a 202 to the initial request,
-            /// with a location header that points to a polling URL that returns a 200
-            /// and an entity that doesn't contains ProvisioningState
+            /// with a location header that points to a polling URL that returns a 200 and
+            /// an entity that doesn't contains ProvisioningState
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -288,8 +288,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with location header. Subsequent calls to operation status do not contain
+            /// Long running put request, service returns a 202 to the initial request with
+            /// location header. Subsequent calls to operation status do not contain
             /// location header.
             /// </summary>
             /// <param name='operations'>
@@ -304,8 +304,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with location header. Subsequent calls to operation status do not contain
+            /// Long running put request, service returns a 202 to the initial request with
+            /// location header. Subsequent calls to operation status do not contain
             /// location header.
             /// </summary>
             /// <param name='operations'>
@@ -478,9 +478,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with Azure-AsyncOperation header. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running put request, service returns a 202 to the initial request with
+            /// Azure-AsyncOperation header. Subsequent calls to operation status do not
+            /// contain Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -494,9 +494,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with Azure-AsyncOperation header. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running put request, service returns a 202 to the initial request with
+            /// Azure-AsyncOperation header. Subsequent calls to operation status do not
+            /// contain Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -871,9 +871,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running delete request, service returns an Azure-AsyncOperation
-            /// header in the initial request. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running delete request, service returns an Azure-AsyncOperation header
+            /// in the initial request. Subsequent calls to operation status do not contain
+            /// Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -884,9 +884,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running delete request, service returns an Azure-AsyncOperation
-            /// header in the initial request. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running delete request, service returns an Azure-AsyncOperation header
+            /// in the initial request. Subsequent calls to operation status do not contain
+            /// Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1362,8 +1362,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running put request, service returns a 202 to the initial request,
-            /// with a location header that points to a polling URL that returns a 200
-            /// and an entity that doesn't contains ProvisioningState
+            /// with a location header that points to a polling URL that returns a 200 and
+            /// an entity that doesn't contains ProvisioningState
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1378,8 +1378,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
 
             /// <summary>
             /// Long running put request, service returns a 202 to the initial request,
-            /// with a location header that points to a polling URL that returns a 200
-            /// and an entity that doesn't contains ProvisioningState
+            /// with a location header that points to a polling URL that returns a 200 and
+            /// an entity that doesn't contains ProvisioningState
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1559,8 +1559,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with location header. Subsequent calls to operation status do not contain
+            /// Long running put request, service returns a 202 to the initial request with
+            /// location header. Subsequent calls to operation status do not contain
             /// location header.
             /// </summary>
             /// <param name='operations'>
@@ -1575,8 +1575,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with location header. Subsequent calls to operation status do not contain
+            /// Long running put request, service returns a 202 to the initial request with
+            /// location header. Subsequent calls to operation status do not contain
             /// location header.
             /// </summary>
             /// <param name='operations'>
@@ -1749,9 +1749,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with Azure-AsyncOperation header. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running put request, service returns a 202 to the initial request with
+            /// Azure-AsyncOperation header. Subsequent calls to operation status do not
+            /// contain Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1765,9 +1765,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running put request, service returns a 202 to the initial request
-            /// with Azure-AsyncOperation header. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running put request, service returns a 202 to the initial request with
+            /// Azure-AsyncOperation header. Subsequent calls to operation status do not
+            /// contain Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -2142,9 +2142,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running delete request, service returns an Azure-AsyncOperation
-            /// header in the initial request. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running delete request, service returns an Azure-AsyncOperation header
+            /// in the initial request. Subsequent calls to operation status do not contain
+            /// Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -2155,9 +2155,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro
             }
 
             /// <summary>
-            /// Long running delete request, service returns an Azure-AsyncOperation
-            /// header in the initial request. Subsequent calls to operation status do
-            /// not contain Azure-AsyncOperation header.
+            /// Long running delete request, service returns an Azure-AsyncOperation header
+            /// in the initial request. Subsequent calls to operation status do not contain
+            /// Azure-AsyncOperation header.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDelete202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDelete202Retry200Headers.cs
@@ -16,19 +16,19 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     public partial class LRORetrysDelete202Retry200Headers
     {
         /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysDelete202Retry200Headers class.
+        /// Initializes a new instance of the LRORetrysDelete202Retry200Headers
+        /// class.
         /// </summary>
         public LRORetrysDelete202Retry200Headers() { }
 
         /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysDelete202Retry200Headers class.
+        /// Initializes a new instance of the LRORetrysDelete202Retry200Headers
+        /// class.
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/retryerror/delete/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LRORetrysDelete202Retry200Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/retryerror/deleteasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LRORetrysDeleteAsyncRelativeRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.cs
@@ -29,8 +29,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/retryerror/delete/provisioning/202/accepted/200/succeeded</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LRORetrysDeleteProvisioning202Accepted200SucceededHeaders(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPost202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPost202Retry200Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/retryerror/post/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LRORetrysPost202Retry200Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/retryerror/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LRORetrysPostAsyncRelativeRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/retryerror/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LRORetrysPutAsyncRelativeRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202NonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202NonRetry400Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/retryerror/delete/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsDelete202NonRetry400Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202RetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202RetryInvalidHeaderHeaders.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /foo</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to /bar</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to /bar</param>
         public LROSADsDelete202RetryInvalidHeaderHeaders(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetry400Headers.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/nonretryerror/deleteasync/retry/operationResults/400</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsDeleteAsyncRelativeRetry400Headers(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders.cs
@@ -29,8 +29,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// status: will be set to /foo</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /foo</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to /bar</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to /bar</param>
         public LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.cs
@@ -32,8 +32,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/error/deleteasync/retry/failed/operationResults/invalidjsonpolling</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryNoStatusHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryNoStatusHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/deleteasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsDeleteAsyncRelativeRetryNoStatusHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteNonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteNonRetry400Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/retryerror/delete/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsDeleteNonRetry400Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NoLocationHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NoLocationHeaders.cs
@@ -25,10 +25,10 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// Initializes a new instance of the LROSADsPost202NoLocationHeaders
         /// class.
         /// </summary>
-        /// <param name="location">Location to poll for result status: will
-        /// not be set</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="location">Location to poll for result status: will not
+        /// be set</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPost202NoLocationHeaders(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NonRetry400Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/retryerror/post/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPost202NonRetry400Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202RetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202RetryInvalidHeaderHeaders.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /foo</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to /bar</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to /bar</param>
         public LROSADsPost202RetryInvalidHeaderHeaders(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetry400Headers.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/nonretryerror/putasync/retry/operationResults/400</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPostAsyncRelativeRetry400Headers(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders.cs
@@ -29,8 +29,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// status: will be set to foo</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to foo</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to /bar</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to /bar</param>
         public LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/error/postasync/retry/failed/operationResults/invalidjsonpolling</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryNoPayloadHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryNoPayloadHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/error/putasync/retry/failed/operationResults/nopayload</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPostAsyncRelativeRetryNoPayloadHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostNonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostNonRetry400Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/retryerror/post/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPostNonRetry400Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetry400Headers.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/nonretryerror/putasync/retry/operationResults/400</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPutAsyncRelativeRetry400Headers(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/succeeded/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/failed/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/failed/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/succeeded/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPutAsyncRelativeRetryNoStatusHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/succeeded/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPost202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPost202Retry200Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/customheader/post/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsCustomHeaderPost202Retry200Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPostAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPostAsyncRetrySucceededHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/customheader/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsCustomHeaderPostAsyncRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPutAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPutAsyncRetrySucceededHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/customheader/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsCustomHeaderPutAsyncRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202NoRetry204Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202NoRetry204Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/delete/202/noretry/204</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDelete202NoRetry204Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202Retry200Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/delete/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDelete202Retry200Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoRetrySucceededHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/deleteasync/noretry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDeleteAsyncNoRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetryFailedHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetryFailedHeaders.cs
@@ -16,22 +16,22 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     public partial class LROsDeleteAsyncRetryFailedHeaders
     {
         /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncRetryFailedHeaders class.
+        /// Initializes a new instance of the LROsDeleteAsyncRetryFailedHeaders
+        /// class.
         /// </summary>
         public LROsDeleteAsyncRetryFailedHeaders() { }
 
         /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncRetryFailedHeaders class.
+        /// Initializes a new instance of the LROsDeleteAsyncRetryFailedHeaders
+        /// class.
         /// </summary>
         /// <param name="azureAsyncOperation">Location to poll for result
         /// status: will be set to
         /// /lro/deleteasync/retry/failed/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/deleteasync/retry/failed/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDeleteAsyncRetryFailedHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrySucceededHeaders.cs
@@ -31,8 +31,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// <param name="location">Location to poll for result status: will be
         /// set to
         /// /lro/deleteasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDeleteAsyncRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrycanceledHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrycanceledHeaders.cs
@@ -29,10 +29,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// status: will be set to
         /// /lro/deleteasync/retry/canceled/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
-        /// set to
-        /// /lro/deleteasync/retry/canceled/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// set to /lro/deleteasync/retry/canceled/operationResults/200</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDeleteAsyncRetrycanceledHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Accepted200SucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Accepted200SucceededHeaders.cs
@@ -28,8 +28,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/delete/provisioning/202/accepted/200/succeeded</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDeleteProvisioning202Accepted200SucceededHeaders(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202DeletingFailed200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202DeletingFailed200Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/delete/provisioning/202/deleting/200/failed</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDeleteProvisioning202DeletingFailed200Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Deletingcanceled200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Deletingcanceled200Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/delete/provisioning/202/deleting/200/canceled</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsDeleteProvisioning202Deletingcanceled200Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202NoRetry204Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202NoRetry204Headers.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/post/202/noretry/204</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPost202NoRetry204Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202Retry200Headers.cs
@@ -25,8 +25,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// </summary>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/post/202/retry/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPost202Retry200Headers(string location = default(string), int? retryAfter = default(int?))
         {
             Location = location;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncNoRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncNoRetrySucceededHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/succeeded/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPostAsyncNoRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetryFailedHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetryFailedHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/failed/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/failed/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPostAsyncRetryFailedHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrySucceededHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/succeeded/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPostAsyncRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrycanceledHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrycanceledHeaders.cs
@@ -16,22 +16,22 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     public partial class LROsPostAsyncRetrycanceledHeaders
     {
         /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncRetrycanceledHeaders class.
+        /// Initializes a new instance of the LROsPostAsyncRetrycanceledHeaders
+        /// class.
         /// </summary>
         public LROsPostAsyncRetrycanceledHeaders() { }
 
         /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncRetrycanceledHeaders class.
+        /// Initializes a new instance of the LROsPostAsyncRetrycanceledHeaders
+        /// class.
         /// </summary>
         /// <param name="azureAsyncOperation">Location to poll for result
         /// status: will be set to
         /// /lro/putasync/retry/canceled/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/canceled/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPostAsyncRetrycanceledHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrySucceededHeaders.cs
@@ -29,8 +29,7 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// status: will be set to
         /// /lro/putasync/noretry/succeeded/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
-        /// set to
-        /// /lro/putasync/noretry/succeeded/operationResults/200</param>
+        /// set to /lro/putasync/noretry/succeeded/operationResults/200</param>
         public LROsPutAsyncNoRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetryFailedHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetryFailedHeaders.cs
@@ -30,8 +30,8 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// /lro/putasync/retry/failed/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/failed/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPutAsyncRetryFailedHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetrySucceededHeaders.cs
@@ -16,22 +16,22 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     public partial class LROsPutAsyncRetrySucceededHeaders
     {
         /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncRetrySucceededHeaders class.
+        /// Initializes a new instance of the LROsPutAsyncRetrySucceededHeaders
+        /// class.
         /// </summary>
         public LROsPutAsyncRetrySucceededHeaders() { }
 
         /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncRetrySucceededHeaders class.
+        /// Initializes a new instance of the LROsPutAsyncRetrySucceededHeaders
+        /// class.
         /// </summary>
         /// <param name="azureAsyncOperation">Location to poll for result
         /// status: will be set to
         /// /lro/putasync/retry/succeeded/operationResults/200</param>
         /// <param name="location">Location to poll for result status: will be
         /// set to /lro/putasync/retry/succeeded/operationResults/200</param>
-        /// <param name="retryAfter">Number of milliseconds until the next
-        /// poll should be sent, will be set to zero</param>
+        /// <param name="retryAfter">Number of milliseconds until the next poll
+        /// should be sent, will be set to zero</param>
         public LROsPutAsyncRetrySucceededHeaders(string azureAsyncOperation = default(string), string location = default(string), int? retryAfter = default(int?))
         {
             AzureAsyncOperation = azureAsyncOperation;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/OperationResult.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/OperationResult.cs
@@ -21,9 +21,9 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
         /// Initializes a new instance of the OperationResult class.
         /// </summary>
         /// <param name="status">The status of the request. Possible values
-        /// include: 'Succeeded', 'Failed', 'canceled', 'Accepted',
-        /// 'Creating', 'Created', 'Updating', 'Updated', 'Deleting',
-        /// 'Deleted', 'OK'</param>
+        /// include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating',
+        /// 'Created', 'Updating', 'Updated', 'Deleting', 'Deleted',
+        /// 'OK'</param>
         public OperationResult(string status = default(string), OperationResultError error = default(OperationResultError))
         {
             Status = status;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/IAutoRestPagingTestService.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/IAutoRestPagingTestService.cs
@@ -49,8 +49,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/OperationResult.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/OperationResult.cs
@@ -21,9 +21,9 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
         /// Initializes a new instance of the OperationResult class.
         /// </summary>
         /// <param name="status">The status of the request. Possible values
-        /// include: 'Succeeded', 'Failed', 'canceled', 'Accepted',
-        /// 'Creating', 'Created', 'Updating', 'Updated', 'Deleting',
-        /// 'Deleted', 'OK'</param>
+        /// include: 'Succeeded', 'Failed', 'canceled', 'Accepted', 'Creating',
+        /// 'Created', 'Updating', 'Updated', 'Deleting', 'Deleted',
+        /// 'OK'</param>
         public OperationResult(string status = default(string))
         {
             Status = status;

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesOptions.cs
@@ -25,8 +25,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
         /// Initializes a new instance of the PagingGetMultiplePagesOptions
         /// class.
         /// </summary>
-        /// <param name="maxresults">Sets the maximum number of items to
-        /// return in the response.</param>
+        /// <param name="maxresults">Sets the maximum number of items to return
+        /// in the response.</param>
         /// <param name="timeout">Sets the maximum time that the server can
         /// spend processing the request, in seconds. The default is 30
         /// seconds.</param>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetNextOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetNextOptions.cs
@@ -25,8 +25,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
         /// Initializes a new instance of the
         /// PagingGetMultiplePagesWithOffsetNextOptions class.
         /// </summary>
-        /// <param name="maxresults">Sets the maximum number of items to
-        /// return in the response.</param>
+        /// <param name="maxresults">Sets the maximum number of items to return
+        /// in the response.</param>
         /// <param name="timeout">Sets the maximum time that the server can
         /// spend processing the request, in seconds. The default is 30
         /// seconds.</param>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetOptions.cs
@@ -27,8 +27,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
         /// PagingGetMultiplePagesWithOffsetOptions class.
         /// </summary>
         /// <param name="offset">Offset of return value</param>
-        /// <param name="maxresults">Sets the maximum number of items to
-        /// return in the response.</param>
+        /// <param name="maxresults">Sets the maximum number of items to return
+        /// in the response.</param>
         /// <param name="timeout">Sets the maximum time that the server can
         /// spend processing the request, in seconds. The default is 30
         /// seconds.</param>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetOdataMultiplePagesOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetOdataMultiplePagesOptions.cs
@@ -25,8 +25,8 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
         /// Initializes a new instance of the
         /// PagingGetOdataMultiplePagesOptions class.
         /// </summary>
-        /// <param name="maxresults">Sets the maximum number of items to
-        /// return in the response.</param>
+        /// <param name="maxresults">Sets the maximum number of items to return
+        /// in the response.</param>
         /// <param name="timeout">Sets the maximum time that the server can
         /// spend processing the request, in seconds. The default is 30
         /// seconds.</param>

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/PagingOperations.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/PagingOperations.cs
@@ -973,9 +973,9 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         }
 
         /// <summary>
-        /// A paging operation that includes a nextLink that has 10 pages, of which
-        /// the 2nd call fails first with 500. The client should retry and finish all
-        /// 10 pages eventually.
+        /// A paging operation that includes a nextLink that has 10 pages, of which the
+        /// 2nd call fails first with 500. The client should retry and finish all 10
+        /// pages eventually.
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -3328,9 +3328,9 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
         }
 
         /// <summary>
-        /// A paging operation that includes a nextLink that has 10 pages, of which
-        /// the 2nd call fails first with 500. The client should retry and finish all
-        /// 10 pages eventually.
+        /// A paging operation that includes a nextLink that has 10 pages, of which the
+        /// 2nd call fails first with 500. The client should retry and finish all 10
+        /// pages eventually.
         /// </summary>
         /// <param name='nextPageLink'>
         /// The NextLink from the previous successful call to List operation.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/PagingOperationsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/PagingOperationsExtensions.cs
@@ -192,9 +192,9 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
             }
 
             /// <summary>
-            /// A paging operation that includes a nextLink that has 10 pages, of which
-            /// the 2nd call fails first with 500. The client should retry and finish all
-            /// 10 pages eventually.
+            /// A paging operation that includes a nextLink that has 10 pages, of which the
+            /// 2nd call fails first with 500. The client should retry and finish all 10
+            /// pages eventually.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -205,9 +205,9 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
             }
 
             /// <summary>
-            /// A paging operation that includes a nextLink that has 10 pages, of which
-            /// the 2nd call fails first with 500. The client should retry and finish all
-            /// 10 pages eventually.
+            /// A paging operation that includes a nextLink that has 10 pages, of which the
+            /// 2nd call fails first with 500. The client should retry and finish all 10
+            /// pages eventually.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -674,9 +674,9 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
             }
 
             /// <summary>
-            /// A paging operation that includes a nextLink that has 10 pages, of which
-            /// the 2nd call fails first with 500. The client should retry and finish all
-            /// 10 pages eventually.
+            /// A paging operation that includes a nextLink that has 10 pages, of which the
+            /// 2nd call fails first with 500. The client should retry and finish all 10
+            /// pages eventually.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -690,9 +690,9 @@ namespace Fixtures.Azure.AcceptanceTestsPaging
             }
 
             /// <summary>
-            /// A paging operation that includes a nextLink that has 10 pages, of which
-            /// the 2nd call fails first with 500. The client should retry and finish all
-            /// 10 pages eventually.
+            /// A paging operation that includes a nextLink that has 10 pages, of which the
+            /// 2nd call fails first with 500. The client should retry and finish all 10
+            /// pages eventually.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/IMicrosoftAzureTestUrl.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/IMicrosoftAzureTestUrl.cs
@@ -59,8 +59,8 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion
         int? LongRunningOperationRetryTimeout { get; set; }
 
         /// <summary>
-        /// When set to true a unique x-ms-client-request-id value is
-        /// generated and included in each request. Default is true.
+        /// When set to true a unique x-ms-client-request-id value is generated
+        /// and included in each request. Default is true.
         /// </summary>
         bool? GenerateClientRequestId { get; set; }
 

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/Array.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/Array.cs
@@ -5736,8 +5736,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
         }
 
         /// <summary>
-        /// Get array value ['a string that gets encoded with base64url', 'test
-        /// string' 'Lorem ipsum'] with the items base64url encoded
+        /// Get array value ['a string that gets encoded with base64url', 'test string'
+        /// 'Lorem ipsum'] with the items base64url encoded
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -7609,8 +7609,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
 
         /// <summary>
         /// Get an array of Dictionaries of type &lt;string, string&gt; with value
-        /// [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8':
-        /// 'eight', '9': 'nine'}]
+        /// [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight',
+        /// '9': 'nine'}]
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/ArrayExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/ArrayExtensions.cs
@@ -1340,8 +1340,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
             }
 
             /// <summary>
-            /// Get array value ['a string that gets encoded with base64url', 'test
-            /// string' 'Lorem ipsum'] with the items base64url encoded
+            /// Get array value ['a string that gets encoded with base64url', 'test string'
+            /// 'Lorem ipsum'] with the items base64url encoded
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1352,8 +1352,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
             }
 
             /// <summary>
-            /// Get array value ['a string that gets encoded with base64url', 'test
-            /// string' 'Lorem ipsum'] with the items base64url encoded
+            /// Get array value ['a string that gets encoded with base64url', 'test string'
+            /// 'Lorem ipsum'] with the items base64url encoded
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1777,8 +1777,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
 
             /// <summary>
             /// Get an array of Dictionaries of type &lt;string, string&gt; with value
-            /// [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8':
-            /// 'eight', '9': 'nine'}]
+            /// [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight',
+            /// '9': 'nine'}]
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1790,8 +1790,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
 
             /// <summary>
             /// Get an array of Dictionaries of type &lt;string, string&gt; with value
-            /// [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8':
-            /// 'eight', '9': 'nine'}]
+            /// [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven', '8': 'eight',
+            /// '9': 'nine'}]
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/IArray.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/IArray.cs
@@ -737,8 +737,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> PutDurationValidWithHttpMessagesAsync(System.Collections.Generic.IList<System.TimeSpan?> arrayBody, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25,
-        /// 29, 43)] with each item encoded in base64
+        /// Get byte array value [hex(FF FF FF FA), hex(01 02 03), hex (25, 29,
+        /// 43)] with each item encoded in base64
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -790,8 +790,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<byte[]>>> GetByteInvalidNullWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Get array value ['a string that gets encoded with base64url',
-        /// 'test string' 'Lorem ipsum'] with the items base64url encoded
+        /// Get array value ['a string that gets encoded with base64url', 'test
+        /// string' 'Lorem ipsum'] with the items base64url encoded
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -891,8 +891,7 @@ namespace Fixtures.AcceptanceTestsBodyArray
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<Product>>> GetComplexValidWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Put an array of complex type with values [{'integer': 1 'string':
-        /// '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string':
-        /// '6'}]
+        /// '2'}, {'integer': 3, 'string': '4'}, {'integer': 5, 'string': '6'}]
         /// </summary>
         /// <param name='arrayBody'>
         /// </param>
@@ -942,8 +941,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<System.Collections.Generic.IList<string>>>> GetArrayEmptyWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Get an array of array of strings [['1', '2', '3'], null, ['7',
-        /// '8', '9']]
+        /// Get an array of array of strings [['1', '2', '3'], null, ['7', '8',
+        /// '9']]
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -976,8 +975,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<System.Collections.Generic.IList<string>>>> GetArrayItemEmptyWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Get an array of array of strings [['1', '2', '3'], ['4', '5',
-        /// '6'], ['7', '8', '9']]
+        /// Get an array of array of strings [['1', '2', '3'], ['4', '5', '6'],
+        /// ['7', '8', '9']]
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -993,8 +992,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<System.Collections.Generic.IList<string>>>> GetArrayValidWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Put An array of array of strings [['1', '2', '3'], ['4', '5',
-        /// '6'], ['7', '8', '9']]
+        /// Put An array of array of strings [['1', '2', '3'], ['4', '5', '6'],
+        /// ['7', '8', '9']]
         /// </summary>
         /// <param name='arrayBody'>
         /// </param>
@@ -1046,8 +1045,8 @@ namespace Fixtures.AcceptanceTestsBodyArray
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IList<System.Collections.Generic.IDictionary<string, string>>>> GetDictionaryEmptyWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get an array of Dictionaries of type &lt;string, string&gt; with
-        /// value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7':
-        /// 'seven', '8': 'eight', '9': 'nine'}]
+        /// value [{'1': 'one', '2': 'two', '3': 'three'}, null, {'7': 'seven',
+        /// '8': 'eight', '9': 'nine'}]
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyByte/IByteModel.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyByte/IByteModel.cs
@@ -67,8 +67,8 @@ namespace Fixtures.AcceptanceTestsBodyByte
         /// Put non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7 F6)
         /// </summary>
         /// <param name='byteBody'>
-        /// Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8
-        /// F7 F6)
+        /// Base64-encoded non-ascii byte string hex(FF FE FD FC FB FA F9 F8 F7
+        /// F6)
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/IInheritance.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/IInheritance.cs
@@ -36,9 +36,9 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// </summary>
         /// <param name='complexBody'>
         /// Please put a siamese with id=2, name="Siameee", color=green,
-        /// breed=persion, which hates 2 dogs, the 1st one named "Potato"
-        /// with id=1 and food="tomato", and the 2nd one named "Tomato" with
-        /// id=-1 and food="french fries".
+        /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with
+        /// id=1 and food="tomato", and the 2nd one named "Tomato" with id=-1
+        /// and food="french fries".
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/IPolymorphism.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/IPolymorphism.cs
@@ -84,9 +84,9 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> PutValidWithHttpMessagesAsync(Fish complexBody, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Put complex types that are polymorphic, attempting to omit
-        /// required 'birthday' field - the request should not be allowed
-        /// from the client
+        /// Put complex types that are polymorphic, attempting to omit required
+        /// 'birthday' field - the request should not be allowed from the
+        /// client
         /// </summary>
         /// <param name='complexBody'>
         /// Please attempt put a sawshark that looks like this, the client

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Inheritance.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Inheritance.cs
@@ -168,10 +168,9 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// Put complex types that extend others
         /// </summary>
         /// <param name='complexBody'>
-        /// Please put a siamese with id=2, name="Siameee", color=green,
-        /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1
-        /// and food="tomato", and the 2nd one named "Tomato" with id=-1 and
-        /// food="french fries".
+        /// Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+        /// which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato",
+        /// and the 2nd one named "Tomato" with id=-1 and food="french fries".
         /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/InheritanceExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/InheritanceExtensions.cs
@@ -51,10 +51,9 @@ namespace Fixtures.AcceptanceTestsBodyComplex
             /// The operations group for this extension method.
             /// </param>
             /// <param name='complexBody'>
-            /// Please put a siamese with id=2, name="Siameee", color=green,
-            /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1
-            /// and food="tomato", and the 2nd one named "Tomato" with id=-1 and
-            /// food="french fries".
+            /// Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+            /// which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato",
+            /// and the 2nd one named "Tomato" with id=-1 and food="french fries".
             /// </param>
             public static void PutValid(this IInheritance operations, Siamese complexBody)
             {
@@ -68,10 +67,9 @@ namespace Fixtures.AcceptanceTestsBodyComplex
             /// The operations group for this extension method.
             /// </param>
             /// <param name='complexBody'>
-            /// Please put a siamese with id=2, name="Siameee", color=green,
-            /// breed=persion, which hates 2 dogs, the 1st one named "Potato" with id=1
-            /// and food="tomato", and the 2nd one named "Tomato" with id=-1 and
-            /// food="french fries".
+            /// Please put a siamese with id=2, name="Siameee", color=green, breed=persion,
+            /// which hates 2 dogs, the 1st one named "Potato" with id=1 and food="tomato",
+            /// and the 2nd one named "Tomato" with id=-1 and food="french fries".
             /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Polymorphism.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Polymorphism.cs
@@ -188,8 +188,7 @@ namespace Fixtures.AcceptanceTestsBodyComplex
         /// 'age':105,
         /// 'birthday': '1900-01-05T01:00:00Z',
         /// 'length':10.0,
-        /// 'picture': new Buffer([255, 255, 255, 255,
-        /// 254]).toString('base64'),
+        /// 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
         /// 'species':'dangerous',
         /// },
         /// {

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/PolymorphismExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/PolymorphismExtensions.cs
@@ -71,8 +71,7 @@ namespace Fixtures.AcceptanceTestsBodyComplex
             /// 'age':105,
             /// 'birthday': '1900-01-05T01:00:00Z',
             /// 'length':10.0,
-            /// 'picture': new Buffer([255, 255, 255, 255,
-            /// 254]).toString('base64'),
+            /// 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
             /// 'species':'dangerous',
             /// },
             /// {
@@ -118,8 +117,7 @@ namespace Fixtures.AcceptanceTestsBodyComplex
             /// 'age':105,
             /// 'birthday': '1900-01-05T01:00:00Z',
             /// 'length':10.0,
-            /// 'picture': new Buffer([255, 255, 255, 255,
-            /// 254]).toString('base64'),
+            /// 'picture': new Buffer([255, 255, 255, 255, 254]).toString('base64'),
             /// 'species':'dangerous',
             /// },
             /// {

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Dictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Dictionary.cs
@@ -4876,8 +4876,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
         /// <summary>
         /// Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01
-        /// GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492
-        /// 10:15:01 GMT"}
+        /// GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01
+        /// GMT"}
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -5616,8 +5616,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         }
 
         /// <summary>
-        /// Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the
-        /// first item base64 encoded
+        /// Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first
+        /// item base64 encoded
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -7873,8 +7873,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
         /// <summary>
         /// Get an dictionaries of dictionaries of type &lt;string, string&gt; with
-        /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four",
-        /// "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+        /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5":
+        /// "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
         /// </summary>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.
@@ -8000,8 +8000,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
         /// <summary>
         /// Get an dictionaries of dictionaries of type &lt;string, string&gt; with
-        /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four",
-        /// "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+        /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5":
+        /// "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
         /// </summary>
         /// <param name='arrayBody'>
         /// </param>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/DictionaryExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/DictionaryExtensions.cs
@@ -1129,8 +1129,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
             /// <summary>
             /// Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01
-            /// GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492
-            /// 10:15:01 GMT"}
+            /// GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01
+            /// GMT"}
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1142,8 +1142,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
             /// <summary>
             /// Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000 00:00:01
-            /// GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492
-            /// 10:15:01 GMT"}
+            /// GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12 Oct 1492 10:15:01
+            /// GMT"}
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1311,8 +1311,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
             }
 
             /// <summary>
-            /// Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the
-            /// first item base64 encoded
+            /// Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first
+            /// item base64 encoded
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1323,8 +1323,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
             }
 
             /// <summary>
-            /// Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the
-            /// first item base64 encoded
+            /// Get byte dictionary value {"0": hex(FF FF FF FA), "1": null} with the first
+            /// item base64 encoded
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1850,8 +1850,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
             /// <summary>
             /// Get an dictionaries of dictionaries of type &lt;string, string&gt; with
-            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four",
-            /// "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5":
+            /// "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1863,8 +1863,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
             /// <summary>
             /// Get an dictionaries of dictionaries of type &lt;string, string&gt; with
-            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four",
-            /// "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5":
+            /// "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1882,8 +1882,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
             /// <summary>
             /// Get an dictionaries of dictionaries of type &lt;string, string&gt; with
-            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four",
-            /// "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5":
+            /// "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -1897,8 +1897,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
 
             /// <summary>
             /// Get an dictionaries of dictionaries of type &lt;string, string&gt; with
-            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four",
-            /// "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+            /// value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4": "four", "5":
+            /// "five", "6": "six"}, "2": {"7": "seven", "8": "eight", "9": "nine"}}
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/IDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/IDictionary.cs
@@ -147,8 +147,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, bool?>>> GetBooleanTfftWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Set dictionary value empty {"0": true, "1": false, "2": false,
-        /// "3": true }
+        /// Set dictionary value empty {"0": true, "1": false, "2": false, "3":
+        /// true }
         /// </summary>
         /// <param name='arrayBody'>
         /// </param>
@@ -529,8 +529,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, string>>> GetStringWithInvalidWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Get integer dictionary value {"0": "2000-12-01", "1":
-        /// "1980-01-02", "2": "1492-10-12"}
+        /// Get integer dictionary value {"0": "2000-12-01", "1": "1980-01-02",
+        /// "2": "1492-10-12"}
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -668,8 +668,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, System.DateTime?>>> GetDateTimeInvalidCharsWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get date-time-rfc1123 dictionary value {"0": "Fri, 01 Dec 2000
-        /// 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed,
-        /// 12 Oct 1492 10:15:01 GMT"}
+        /// 00:00:01 GMT", "1": "Wed, 02 Jan 1980 00:11:35 GMT", "2": "Wed, 12
+        /// Oct 1492 10:15:01 GMT"}
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -860,8 +860,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, Widget>>> GetComplexItemNullWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Get dictionary of complex type with empty item {"0": {"integer":
-        /// 1, "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
+        /// Get dictionary of complex type with empty item {"0": {"integer": 1,
+        /// "string": "2"}, "1:" {}, "2": {"integer": 5, "string": "6"}}
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1051,8 +1051,8 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, System.Collections.Generic.IDictionary<string, string>>>> GetDictionaryEmptyWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get an dictionaries of dictionaries of type &lt;string, string&gt;
-        /// with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
-        /// null, "2": {"7": "seven", "8": "eight", "9": "nine"}}
+        /// with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": null,
+        /// "2": {"7": "seven", "8": "eight", "9": "nine"}}
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1087,9 +1087,9 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, System.Collections.Generic.IDictionary<string, string>>>> GetDictionaryItemEmptyWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get an dictionaries of dictionaries of type &lt;string, string&gt;
-        /// with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
-        /// {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8":
-        /// "eight", "9": "nine"}}
+        /// with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4":
+        /// "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight",
+        /// "9": "nine"}}
         /// </summary>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.
@@ -1106,9 +1106,9 @@ namespace Fixtures.AcceptanceTestsBodyDictionary
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<System.Collections.Generic.IDictionary<string, System.Collections.Generic.IDictionary<string, string>>>> GetDictionaryValidWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get an dictionaries of dictionaries of type &lt;string, string&gt;
-        /// with value {"0": {"1": "one", "2": "two", "3": "three"}, "1":
-        /// {"4": "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8":
-        /// "eight", "9": "nine"}}
+        /// with value {"0": {"1": "one", "2": "two", "3": "three"}, "1": {"4":
+        /// "four", "5": "five", "6": "six"}, "2": {"7": "seven", "8": "eight",
+        /// "9": "nine"}}
         /// </summary>
         /// <param name='arrayBody'>
         /// </param>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyString/IStringModel.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyString/IStringModel.cs
@@ -125,8 +125,8 @@ namespace Fixtures.AcceptanceTestsBodyString
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> PutMbcsWithHttpMessagesAsync(string stringBody, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Get string value with leading and trailing whitespace
-        /// '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all
-        /// good men to come to the aid of their
+        /// '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good
+        /// men to come to the aid of their
         /// country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'
         /// </summary>
         /// <param name='customHeaders'>
@@ -144,8 +144,8 @@ namespace Fixtures.AcceptanceTestsBodyString
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<string>> GetWhitespaceWithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Set String value with leading and trailing whitespace
-        /// '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all
-        /// good men to come to the aid of their
+        /// '&lt;tab&gt;&lt;space&gt;&lt;space&gt;Now is the time for all good
+        /// men to come to the aid of their
         /// country&lt;tab&gt;&lt;space&gt;&lt;space&gt;'
         /// </summary>
         /// <param name='stringBody'>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Header.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Header.cs
@@ -789,8 +789,8 @@ namespace Fixtures.AcceptanceTestsHeader
         }
 
         /// <summary>
-        /// Send a post request with header values "scenario": "positive", "value":
-        /// 105 or "scenario": "negative", "value": -2
+        /// Send a post request with header values "scenario": "positive", "value": 105
+        /// or "scenario": "negative", "value": -2
         /// </summary>
         /// <param name='scenario'>
         /// Send a post request with header values "scenario": "positive" or "negative"
@@ -1596,8 +1596,8 @@ namespace Fixtures.AcceptanceTestsHeader
         }
 
         /// <summary>
-        /// Send a post request with header values "scenario": "true", "value": true
-        /// or "scenario": "false", "value": false
+        /// Send a post request with header values "scenario": "true", "value": true or
+        /// "scenario": "false", "value": false
         /// </summary>
         /// <param name='scenario'>
         /// Send a post request with header values "scenario": "true" or "false"
@@ -2684,8 +2684,8 @@ namespace Fixtures.AcceptanceTestsHeader
 
         /// <summary>
         /// Send a post request with header values "scenario": "valid", "value": "Wed,
-        /// 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan
-        /// 0001 00:00:00 GMT"
+        /// 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001
+        /// 00:00:00 GMT"
         /// </summary>
         /// <param name='scenario'>
         /// Send a post request with header values "scenario": "valid" or "min"
@@ -3503,8 +3503,8 @@ namespace Fixtures.AcceptanceTestsHeader
         }
 
         /// <summary>
-        /// Send a post request with header values "scenario": "valid", "value":
-        /// "GREY" or "scenario": "null", "value": null
+        /// Send a post request with header values "scenario": "valid", "value": "GREY"
+        /// or "scenario": "null", "value": null
         /// </summary>
         /// <param name='scenario'>
         /// Send a post request with header values "scenario": "valid" or "null" or

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/HeaderExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/HeaderExtensions.cs
@@ -208,8 +208,8 @@ namespace Fixtures.AcceptanceTestsHeader
             }
 
             /// <summary>
-            /// Send a post request with header values "scenario": "positive", "value":
-            /// 105 or "scenario": "negative", "value": -2
+            /// Send a post request with header values "scenario": "positive", "value": 105
+            /// or "scenario": "negative", "value": -2
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -226,8 +226,8 @@ namespace Fixtures.AcceptanceTestsHeader
             }
 
             /// <summary>
-            /// Send a post request with header values "scenario": "positive", "value":
-            /// 105 or "scenario": "negative", "value": -2
+            /// Send a post request with header values "scenario": "positive", "value": 105
+            /// or "scenario": "negative", "value": -2
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -427,8 +427,8 @@ namespace Fixtures.AcceptanceTestsHeader
             }
 
             /// <summary>
-            /// Send a post request with header values "scenario": "true", "value": true
-            /// or "scenario": "false", "value": false
+            /// Send a post request with header values "scenario": "true", "value": true or
+            /// "scenario": "false", "value": false
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -445,8 +445,8 @@ namespace Fixtures.AcceptanceTestsHeader
             }
 
             /// <summary>
-            /// Send a post request with header values "scenario": "true", "value": true
-            /// or "scenario": "false", "value": false
+            /// Send a post request with header values "scenario": "true", "value": true or
+            /// "scenario": "false", "value": false
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -736,8 +736,8 @@ namespace Fixtures.AcceptanceTestsHeader
 
             /// <summary>
             /// Send a post request with header values "scenario": "valid", "value": "Wed,
-            /// 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan
-            /// 0001 00:00:00 GMT"
+            /// 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001
+            /// 00:00:00 GMT"
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -756,8 +756,8 @@ namespace Fixtures.AcceptanceTestsHeader
 
             /// <summary>
             /// Send a post request with header values "scenario": "valid", "value": "Wed,
-            /// 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan
-            /// 0001 00:00:00 GMT"
+            /// 01 Jan 2010 12:34:56 GMT" or "scenario": "min", "value": "Mon, 01 Jan 0001
+            /// 00:00:00 GMT"
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -960,8 +960,8 @@ namespace Fixtures.AcceptanceTestsHeader
             }
 
             /// <summary>
-            /// Send a post request with header values "scenario": "valid", "value":
-            /// "GREY" or "scenario": "null", "value": null
+            /// Send a post request with header values "scenario": "valid", "value": "GREY"
+            /// or "scenario": "null", "value": null
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -980,8 +980,8 @@ namespace Fixtures.AcceptanceTestsHeader
             }
 
             /// <summary>
-            /// Send a post request with header values "scenario": "valid", "value":
-            /// "GREY" or "scenario": "null", "value": null
+            /// Send a post request with header values "scenario": "valid", "value": "GREY"
+            /// or "scenario": "null", "value": null
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/IHeader.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/IHeader.cs
@@ -256,8 +256,8 @@ namespace Fixtures.AcceptanceTestsHeader
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationHeaderResponse<HeaderResponseDoubleHeaders>> ResponseDoubleWithHttpMessagesAsync(string scenario, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Send a post request with header values "scenario": "true",
-        /// "value": true or "scenario": "false", "value": false
+        /// Send a post request with header values "scenario": "true", "value":
+        /// true or "scenario": "false", "value": false
         /// </summary>
         /// <param name='scenario'>
         /// Send a post request with header values "scenario": "true" or
@@ -302,8 +302,8 @@ namespace Fixtures.AcceptanceTestsHeader
         /// <summary>
         /// Send a post request with header values "scenario": "valid",
         /// "value": "The quick brown fox jumps over the lazy dog" or
-        /// "scenario": "null", "value": null or "scenario": "empty",
-        /// "value": ""
+        /// "scenario": "null", "value": null or "scenario": "empty", "value":
+        /// ""
         /// </summary>
         /// <param name='scenario'>
         /// Send a post request with header values "scenario": "valid" or

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDatetimeRfc1123Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDatetimeRfc1123Headers.cs
@@ -33,8 +33,8 @@ namespace Fixtures.AcceptanceTestsHeader.Models
         }
 
         /// <summary>
-        /// Gets or sets response with header values "Wed, 01 Jan 2010
-        /// 12:34:56 GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
+        /// Gets or sets response with header values "Wed, 01 Jan 2010 12:34:56
+        /// GMT" or "Mon, 01 Jan 0001 00:00:00 GMT"
         /// </summary>
         [Newtonsoft.Json.JsonConverter(typeof(Microsoft.Rest.Serialization.DateTimeRfc1123JsonConverter))]
         [Newtonsoft.Json.JsonProperty(PropertyName = "value")]

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseProtectedKeyHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseProtectedKeyHeaders.cs
@@ -16,14 +16,14 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     public partial class HeaderResponseProtectedKeyHeaders
     {
         /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderResponseProtectedKeyHeaders class.
+        /// Initializes a new instance of the HeaderResponseProtectedKeyHeaders
+        /// class.
         /// </summary>
         public HeaderResponseProtectedKeyHeaders() { }
 
         /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderResponseProtectedKeyHeaders class.
+        /// Initializes a new instance of the HeaderResponseProtectedKeyHeaders
+        /// class.
         /// </summary>
         /// <param name="contentType">response with header value
         /// "Content-Type": "text/html"</param>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseStringHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseStringHeaders.cs
@@ -33,8 +33,8 @@ namespace Fixtures.AcceptanceTestsHeader.Models
         }
 
         /// <summary>
-        /// Gets or sets response with header values "The quick brown fox
-        /// jumps over the lazy dog" or null or ""
+        /// Gets or sets response with header values "The quick brown fox jumps
+        /// over the lazy dog" or null or ""
         /// </summary>
         [Newtonsoft.Json.JsonProperty(PropertyName = "value")]
         public string Value { get; set; }

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/HttpRedirects.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/HttpRedirects.cs
@@ -530,8 +530,8 @@ namespace Fixtures.AcceptanceTestsHttp
 
         /// <summary>
         /// Put true Boolean value in request returns 301.  This request should not be
-        /// automatically redirected, but should return the received 301 to the
-        /// caller for evaluation
+        /// automatically redirected, but should return the received 301 to the caller
+        /// for evaluation
         /// </summary>
         /// <param name='booleanValue'>
         /// Simple boolean value true

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/HttpRedirectsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/HttpRedirectsExtensions.cs
@@ -130,8 +130,8 @@ namespace Fixtures.AcceptanceTestsHttp
 
             /// <summary>
             /// Put true Boolean value in request returns 301.  This request should not be
-            /// automatically redirected, but should return the received 301 to the
-            /// caller for evaluation
+            /// automatically redirected, but should return the received 301 to the caller
+            /// for evaluation
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -146,8 +146,8 @@ namespace Fixtures.AcceptanceTestsHttp
 
             /// <summary>
             /// Put true Boolean value in request returns 301.  This request should not be
-            /// automatically redirected, but should return the received 301 to the
-            /// caller for evaluation
+            /// automatically redirected, but should return the received 301 to the caller
+            /// for evaluation
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/IHttpRedirects.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/IHttpRedirects.cs
@@ -71,9 +71,9 @@ namespace Fixtures.AcceptanceTestsHttp
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationHeaderResponse<HttpRedirectsGet301Headers>> Get301WithHttpMessagesAsync(System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Put true Boolean value in request returns 301.  This request
-        /// should not be automatically redirected, but should return the
-        /// received 301 to the caller for evaluation
+        /// Put true Boolean value in request returns 301.  This request should
+        /// not be automatically redirected, but should return the received 301
+        /// to the caller for evaluation
         /// </summary>
         /// <param name='booleanValue'>
         /// Simple boolean value true

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestService.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestService.cs
@@ -1009,8 +1009,8 @@ namespace Fixtures.AcceptanceTestsModelFlattening
         /// </summary>
         /// <param name='productId'>
         /// Unique identifier representing a specific product for a given latitude
-        /// &amp; longitude. For example, uberX in San Francisco will have a
-        /// different product_id than uberX in Los Angeles.
+        /// &amp; longitude. For example, uberX in San Francisco will have a different
+        /// product_id than uberX in Los Angeles.
         /// </param>
         /// <param name='maxProductDisplayName'>
         /// Display name of product.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestServiceExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/AutoRestResourceFlatteningTestServiceExtensions.cs
@@ -250,8 +250,8 @@ namespace Fixtures.AcceptanceTestsModelFlattening
             /// </param>
             /// <param name='productId'>
             /// Unique identifier representing a specific product for a given latitude
-            /// &amp; longitude. For example, uberX in San Francisco will have a
-            /// different product_id than uberX in Los Angeles.
+            /// &amp; longitude. For example, uberX in San Francisco will have a different
+            /// product_id than uberX in Los Angeles.
             /// </param>
             /// <param name='maxProductDisplayName'>
             /// Display name of product.
@@ -279,8 +279,8 @@ namespace Fixtures.AcceptanceTestsModelFlattening
             /// </param>
             /// <param name='productId'>
             /// Unique identifier representing a specific product for a given latitude
-            /// &amp; longitude. For example, uberX in San Francisco will have a
-            /// different product_id than uberX in Los Angeles.
+            /// &amp; longitude. For example, uberX in San Francisco will have a different
+            /// product_id than uberX in Los Angeles.
             /// </param>
             /// <param name='maxProductDisplayName'>
             /// Display name of product.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/IAutoRestResourceFlatteningTestService.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/IAutoRestResourceFlatteningTestService.cs
@@ -126,8 +126,8 @@ namespace Fixtures.AcceptanceTestsModelFlattening
         /// </summary>
         /// <param name='productId'>
         /// Unique identifier representing a specific product for a given
-        /// latitude &amp; longitude. For example, uberX in San Francisco
-        /// will have a different product_id than uberX in Los Angeles.
+        /// latitude &amp; longitude. For example, uberX in San Francisco will
+        /// have a different product_id than uberX in Los Angeles.
         /// </param>
         /// <param name='maxProductDisplayName'>
         /// Display name of product.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/BaseProduct.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/BaseProduct.cs
@@ -24,7 +24,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
         /// Initializes a new instance of the BaseProduct class.
         /// </summary>
         /// <param name="productId">Unique identifier representing a specific
-        /// product for a given latitude & longitude. For example, uberX in
+        /// product for a given latitude &amp; longitude. For example, uberX in
         /// San Francisco will have a different product_id than uberX in Los
         /// Angeles.</param>
         /// <param name="description">Description of product.</param>
@@ -36,7 +36,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
 
         /// <summary>
         /// Gets or sets unique identifier representing a specific product for
-        /// a given latitude &amp; longitude. For example, uberX in San
+        /// a given latitude &amp;amp; longitude. For example, uberX in San
         /// Francisco will have a different product_id than uberX in Los
         /// Angeles.
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenParameterGroup.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenParameterGroup.cs
@@ -26,7 +26,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
         /// </summary>
         /// <param name="name">Product name with value 'groupproduct'</param>
         /// <param name="productId">Unique identifier representing a specific
-        /// product for a given latitude & longitude. For example, uberX in
+        /// product for a given latitude &amp; longitude. For example, uberX in
         /// San Francisco will have a different product_id than uberX in Los
         /// Angeles.</param>
         /// <param name="maxProductDisplayName">Display name of
@@ -52,7 +52,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
 
         /// <summary>
         /// Gets or sets unique identifier representing a specific product for
-        /// a given latitude &amp; longitude. For example, uberX in San
+        /// a given latitude &amp;amp; longitude. For example, uberX in San
         /// Francisco will have a different product_id than uberX in Los
         /// Angeles.
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/SimpleProduct.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/SimpleProduct.cs
@@ -25,7 +25,7 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
         /// Initializes a new instance of the SimpleProduct class.
         /// </summary>
         /// <param name="productId">Unique identifier representing a specific
-        /// product for a given latitude & longitude. For example, uberX in
+        /// product for a given latitude &amp; longitude. For example, uberX in
         /// San Francisco will have a different product_id than uberX in Los
         /// Angeles.</param>
         /// <param name="maxProductDisplayName">Display name of

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ExplicitModel.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ExplicitModel.cs
@@ -1791,8 +1791,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
 
         /// <summary>
         /// Test explicitly required complex object. Please put a valid class-wrapper
-        /// with 'value' = null and the client library should throw before the
-        /// request is sent.
+        /// with 'value' = null and the client library should throw before the request
+        /// is sent.
         /// </summary>
         /// <param name='value'>
         /// </param>
@@ -2568,8 +2568,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         }
 
         /// <summary>
-        /// Test explicitly required array. Please put a header 'headerParameter'
-        /// =&gt; null and the client library should throw before the request is sent.
+        /// Test explicitly required array. Please put a header 'headerParameter' =&gt;
+        /// null and the client library should throw before the request is sent.
         /// </summary>
         /// <param name='headerParameter'>
         /// </param>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ExplicitModelExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/ExplicitModelExtensions.cs
@@ -471,8 +471,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
 
             /// <summary>
             /// Test explicitly required complex object. Please put a valid class-wrapper
-            /// with 'value' = null and the client library should throw before the
-            /// request is sent.
+            /// with 'value' = null and the client library should throw before the request
+            /// is sent.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -486,8 +486,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
 
             /// <summary>
             /// Test explicitly required complex object. Please put a valid class-wrapper
-            /// with 'value' = null and the client library should throw before the
-            /// request is sent.
+            /// with 'value' = null and the client library should throw before the request
+            /// is sent.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -667,8 +667,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
             }
 
             /// <summary>
-            /// Test explicitly required array. Please put a header 'headerParameter'
-            /// =&gt; null and the client library should throw before the request is sent.
+            /// Test explicitly required array. Please put a header 'headerParameter' =&gt;
+            /// null and the client library should throw before the request is sent.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -681,8 +681,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
             }
 
             /// <summary>
-            /// Test explicitly required array. Please put a header 'headerParameter'
-            /// =&gt; null and the client library should throw before the request is sent.
+            /// Test explicitly required array. Please put a header 'headerParameter' =&gt;
+            /// null and the client library should throw before the request is sent.
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/IExplicitModel.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/IExplicitModel.cs
@@ -48,8 +48,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> PostOptionalIntegerParameterWithHttpMessagesAsync(int? bodyParameter = default(int?), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Test explicitly required integer. Please put a valid int-wrapper
-        /// with 'value' = null and the client library should throw before
-        /// the request is sent.
+        /// with 'value' = null and the client library should throw before the
+        /// request is sent.
         /// </summary>
         /// <param name='value'>
         /// </param>
@@ -148,8 +148,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> PostOptionalStringParameterWithHttpMessagesAsync(string bodyParameter = default(string), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Test explicitly required string. Please put a valid string-wrapper
-        /// with 'value' = null and the client library should throw before
-        /// the request is sent.
+        /// with 'value' = null and the client library should throw before the
+        /// request is sent.
         /// </summary>
         /// <param name='value'>
         /// </param>
@@ -167,8 +167,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         /// </exception>
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse<Error>> PostRequiredStringPropertyWithHttpMessagesAsync(string value, System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
-        /// Test explicitly optional integer. Please put a valid
-        /// string-wrapper with 'value' = null.
+        /// Test explicitly optional integer. Please put a valid string-wrapper
+        /// with 'value' = null.
         /// </summary>
         /// <param name='value'>
         /// </param>
@@ -324,8 +324,8 @@ namespace Fixtures.AcceptanceTestsRequiredOptional
         System.Threading.Tasks.Task<Microsoft.Rest.HttpOperationResponse> PostOptionalArrayParameterWithHttpMessagesAsync(System.Collections.Generic.IList<string> bodyParameter = default(System.Collections.Generic.IList<string>), System.Collections.Generic.Dictionary<string, System.Collections.Generic.List<string>> customHeaders = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// Test explicitly required array. Please put a valid array-wrapper
-        /// with 'value' = null and the client library should throw before
-        /// the request is sent.
+        /// with 'value' = null and the client library should throw before the
+        /// request is sent.
         /// </summary>
         /// <param name='value'>
         /// </param>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/IPaths.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/IPaths.cs
@@ -385,8 +385,8 @@ namespace Fixtures.AcceptanceTestsUrl
         /// &amp;=+$,/?#[]end' , null, ''] using the csv-array format
         /// </summary>
         /// <param name='arrayPath'>
-        /// an array of string ['ArrayPath1', 'begin!*'();:@
-        /// &amp;=+$,/?#[]end' , null, ''] using the csv-array format
+        /// an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end'
+        /// , null, ''] using the csv-array format
         /// </param>
         /// <param name='customHeaders'>
         /// The headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/PathItems.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/PathItems.cs
@@ -41,8 +41,8 @@ namespace Fixtures.AcceptanceTestsUrl
 
         /// <summary>
         /// send globalStringPath='globalStringPath',
-        /// pathItemStringPath='pathItemStringPath',
-        /// localStringPath='localStringPath', globalStringQuery='globalStringQuery',
+        /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+        /// globalStringQuery='globalStringQuery',
         /// pathItemStringQuery='pathItemStringQuery',
         /// localStringQuery='localStringQuery'
         /// </summary>
@@ -200,9 +200,8 @@ namespace Fixtures.AcceptanceTestsUrl
 
         /// <summary>
         /// send globalStringPath='globalStringPath',
-        /// pathItemStringPath='pathItemStringPath',
-        /// localStringPath='localStringPath', globalStringQuery=null,
-        /// pathItemStringQuery='pathItemStringQuery',
+        /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+        /// globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
         /// localStringQuery='localStringQuery'
         /// </summary>
         /// <param name='localStringPath'>
@@ -359,9 +358,9 @@ namespace Fixtures.AcceptanceTestsUrl
 
         /// <summary>
         /// send globalStringPath=globalStringPath,
-        /// pathItemStringPath='pathItemStringPath',
-        /// localStringPath='localStringPath', globalStringQuery=null,
-        /// pathItemStringQuery='pathItemStringQuery', localStringQuery=null
+        /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+        /// globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
+        /// localStringQuery=null
         /// </summary>
         /// <param name='localStringPath'>
         /// should contain value 'localStringPath'
@@ -517,9 +516,9 @@ namespace Fixtures.AcceptanceTestsUrl
 
         /// <summary>
         /// send globalStringPath='globalStringPath',
-        /// pathItemStringPath='pathItemStringPath',
-        /// localStringPath='localStringPath', globalStringQuery='globalStringQuery',
-        /// pathItemStringQuery=null, localStringQuery=null
+        /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+        /// globalStringQuery='globalStringQuery', pathItemStringQuery=null,
+        /// localStringQuery=null
         /// </summary>
         /// <param name='localStringPath'>
         /// should contain value 'localStringPath'

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/PathItemsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/PathItemsExtensions.cs
@@ -18,8 +18,8 @@ namespace Fixtures.AcceptanceTestsUrl
     {
             /// <summary>
             /// send globalStringPath='globalStringPath',
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery='globalStringQuery',
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery='globalStringQuery',
             /// pathItemStringQuery='pathItemStringQuery',
             /// localStringQuery='localStringQuery'
             /// </summary>
@@ -45,8 +45,8 @@ namespace Fixtures.AcceptanceTestsUrl
 
             /// <summary>
             /// send globalStringPath='globalStringPath',
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery='globalStringQuery',
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery='globalStringQuery',
             /// pathItemStringQuery='pathItemStringQuery',
             /// localStringQuery='localStringQuery'
             /// </summary>
@@ -75,9 +75,8 @@ namespace Fixtures.AcceptanceTestsUrl
 
             /// <summary>
             /// send globalStringPath='globalStringPath',
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery=null,
-            /// pathItemStringQuery='pathItemStringQuery',
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
             /// localStringQuery='localStringQuery'
             /// </summary>
             /// <param name='operations'>
@@ -102,9 +101,8 @@ namespace Fixtures.AcceptanceTestsUrl
 
             /// <summary>
             /// send globalStringPath='globalStringPath',
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery=null,
-            /// pathItemStringQuery='pathItemStringQuery',
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
             /// localStringQuery='localStringQuery'
             /// </summary>
             /// <param name='operations'>
@@ -132,9 +130,9 @@ namespace Fixtures.AcceptanceTestsUrl
 
             /// <summary>
             /// send globalStringPath=globalStringPath,
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery=null,
-            /// pathItemStringQuery='pathItemStringQuery', localStringQuery=null
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
+            /// localStringQuery=null
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -158,9 +156,9 @@ namespace Fixtures.AcceptanceTestsUrl
 
             /// <summary>
             /// send globalStringPath=globalStringPath,
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery=null,
-            /// pathItemStringQuery='pathItemStringQuery', localStringQuery=null
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery=null, pathItemStringQuery='pathItemStringQuery',
+            /// localStringQuery=null
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -187,9 +185,9 @@ namespace Fixtures.AcceptanceTestsUrl
 
             /// <summary>
             /// send globalStringPath='globalStringPath',
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery='globalStringQuery',
-            /// pathItemStringQuery=null, localStringQuery=null
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery='globalStringQuery', pathItemStringQuery=null,
+            /// localStringQuery=null
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.
@@ -213,9 +211,9 @@ namespace Fixtures.AcceptanceTestsUrl
 
             /// <summary>
             /// send globalStringPath='globalStringPath',
-            /// pathItemStringPath='pathItemStringPath',
-            /// localStringPath='localStringPath', globalStringQuery='globalStringQuery',
-            /// pathItemStringQuery=null, localStringQuery=null
+            /// pathItemStringPath='pathItemStringPath', localStringPath='localStringPath',
+            /// globalStringQuery='globalStringQuery', pathItemStringQuery=null,
+            /// localStringQuery=null
             /// </summary>
             /// <param name='operations'>
             /// The operations group for this extension method.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/Paths.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/Paths.cs
@@ -2660,8 +2660,8 @@ namespace Fixtures.AcceptanceTestsUrl
         /// null, ''] using the csv-array format
         /// </summary>
         /// <param name='arrayPath'>
-        /// an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' ,
-        /// null, ''] using the csv-array format
+        /// an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null,
+        /// ''] using the csv-array format
         /// </param>
         /// <param name='customHeaders'>
         /// Headers that will be added to request.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/PathsExtensions.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/PathsExtensions.cs
@@ -680,8 +680,8 @@ namespace Fixtures.AcceptanceTestsUrl
             /// The operations group for this extension method.
             /// </param>
             /// <param name='arrayPath'>
-            /// an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' ,
-            /// null, ''] using the csv-array format
+            /// an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null,
+            /// ''] using the csv-array format
             /// </param>
             public static void ArrayCsvInPath(this IPaths operations, System.Collections.Generic.IList<string> arrayPath)
             {
@@ -696,8 +696,8 @@ namespace Fixtures.AcceptanceTestsUrl
             /// The operations group for this extension method.
             /// </param>
             /// <param name='arrayPath'>
-            /// an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' ,
-            /// null, ''] using the csv-array format
+            /// an array of string ['ArrayPath1', 'begin!*'();:@ &amp;=+$,/?#[]end' , null,
+            /// ''] using the csv-array format
             /// </param>
             /// <param name='cancellationToken'>
             /// The cancellation token.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/IPetStoreonHeroku.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/IPetStoreonHeroku.cs
@@ -12,6 +12,7 @@ namespace Fixtures.AdditionalProperties
 
     /// <summary>
     /// **This example has a working backend hosted in Heroku**
+    /// 
     /// </summary>
     public partial interface IPetStoreonHeroku : System.IDisposable
     {

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/Pet.cs
@@ -33,8 +33,8 @@ namespace Fixtures.AdditionalProperties.Models
         }
 
         /// <summary>
-        /// Gets or sets unmatched properties from the message are
-        /// deserialized this collection
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
         /// </summary>
         [Newtonsoft.Json.JsonExtensionData]
         public System.Collections.Generic.IDictionary<string, Feature> AdditionalProperties { get; set; }

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithStringDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithStringDictionary.cs
@@ -29,8 +29,8 @@ namespace Fixtures.AdditionalProperties.Models
         }
 
         /// <summary>
-        /// Gets or sets unmatched properties from the message are
-        /// deserialized this collection
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
         /// </summary>
         [Newtonsoft.Json.JsonExtensionData]
         public System.Collections.Generic.IDictionary<string, string> AdditionalProperties { get; set; }

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithTypedDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithTypedDictionary.cs
@@ -29,8 +29,8 @@ namespace Fixtures.AdditionalProperties.Models
         }
 
         /// <summary>
-        /// Gets or sets unmatched properties from the message are
-        /// deserialized this collection
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
         /// </summary>
         [Newtonsoft.Json.JsonExtensionData]
         public System.Collections.Generic.IDictionary<string, Feature> AdditionalProperties { get; set; }

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithUntypedDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithUntypedDictionary.cs
@@ -29,8 +29,8 @@ namespace Fixtures.AdditionalProperties.Models
         }
 
         /// <summary>
-        /// Gets or sets unmatched properties from the message are
-        /// deserialized this collection
+        /// Gets or sets unmatched properties from the message are deserialized
+        /// this collection
         /// </summary>
         [Newtonsoft.Json.JsonExtensionData]
         public System.Collections.Generic.IDictionary<string, object> AdditionalProperties { get; set; }

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/PetStoreonHeroku.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/PetStoreonHeroku.cs
@@ -13,6 +13,7 @@ namespace Fixtures.AdditionalProperties
 
     /// <summary>
     /// **This example has a working backend hosted in Heroku**
+    /// 
     /// </summary>
     public partial class PetStoreonHeroku : Microsoft.Rest.ServiceClient<PetStoreonHeroku>, IPetStoreonHeroku
     {

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Internal.Ctors/IInternalClient.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Internal.Ctors/IInternalClient.cs
@@ -10,8 +10,8 @@ namespace Fixtures.InternalCtors
 {
 
     /// <summary>
-    /// A sample API that uses a petstore as an example to demonstrate
-    /// features in the swagger-2.0 specification
+    /// A sample API that uses a petstore as an example to demonstrate features
+    /// in the swagger-2.0 specification
     /// </summary>
     public partial interface IInternalClient : System.IDisposable
     {

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Internal.Ctors/InternalClient.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Internal.Ctors/InternalClient.cs
@@ -11,8 +11,8 @@ namespace Fixtures.InternalCtors
     using Microsoft.Rest;
 
     /// <summary>
-    /// A sample API that uses a petstore as an example to demonstrate
-    /// features in the swagger-2.0 specification
+    /// A sample API that uses a petstore as an example to demonstrate features
+    /// in the swagger-2.0 specification
     /// </summary>
     public partial class InternalClient : Microsoft.Rest.ServiceClient<InternalClient>, IInternalClient
     {

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/IPolymorphicAnimalStore.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/IPolymorphicAnimalStore.cs
@@ -36,9 +36,9 @@ namespace Fixtures.MirrorPolymorphic
         /// </summary>
         /// <remarks>
         /// The Products endpoint returns information about the Uber products
-        /// offered at a given location. The response includes the display
-        /// name and other details about each product, and lists the products
-        /// in the proper display order.
+        /// offered at a given location. The response includes the display name
+        /// and other details about each product, and lists the products in the
+        /// proper display order.
         /// </remarks>
         /// <param name='animalCreateOrUpdateParameter'>
         /// An Animal

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/IRecursiveTypesAPI.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/IRecursiveTypesAPI.cs
@@ -36,9 +36,9 @@ namespace Fixtures.MirrorRecursiveTypes
         /// </summary>
         /// <remarks>
         /// The Products endpoint returns information about the Uber products
-        /// offered at a given location. The response includes the display
-        /// name and other details about each product, and lists the products
-        /// in the proper display order.
+        /// offered at a given location. The response includes the display name
+        /// and other details about each product, and lists the products in the
+        /// proper display order.
         /// </remarks>
         /// <param name='subscriptionId'>
         /// Subscription Id.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/Models/Product.cs
@@ -21,7 +21,7 @@ namespace Fixtures.MirrorRecursiveTypes.Models
         /// Initializes a new instance of the Product class.
         /// </summary>
         /// <param name="productId">Unique identifier representing a specific
-        /// product for a given latitude & longitude. For example, uberX in
+        /// product for a given latitude &amp; longitude. For example, uberX in
         /// San Francisco will have a different product_id than uberX in Los
         /// Angeles.</param>
         public Product(string productId = default(string), Product parentProduct = default(Product), System.Collections.Generic.IList<Product> innerProducts = default(System.Collections.Generic.IList<Product>))
@@ -33,7 +33,7 @@ namespace Fixtures.MirrorRecursiveTypes.Models
 
         /// <summary>
         /// Gets or sets unique identifier representing a specific product for
-        /// a given latitude &amp; longitude. For example, uberX in San
+        /// a given latitude &amp;amp; longitude. For example, uberX in San
         /// Francisco will have a different product_id than uberX in Los
         /// Angeles.
         /// </summary>

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/ISequenceRequestResponseTest.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/ISequenceRequestResponseTest.cs
@@ -11,8 +11,8 @@ namespace Fixtures.MirrorSequences
     using Models;
 
     /// <summary>
-    /// A sample API that uses a petstore as an example to demonstrate
-    /// features in the swagger-2.0 specification
+    /// A sample API that uses a petstore as an example to demonstrate features
+    /// in the swagger-2.0 specification
     /// </summary>
     public partial interface ISequenceRequestResponseTest : System.IDisposable
     {

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/SequenceRequestResponseTest.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/SequenceRequestResponseTest.cs
@@ -12,8 +12,8 @@ namespace Fixtures.MirrorSequences
     using Models;
 
     /// <summary>
-    /// A sample API that uses a petstore as an example to demonstrate
-    /// features in the swagger-2.0 specification
+    /// A sample API that uses a petstore as an example to demonstrate features
+    /// in the swagger-2.0 specification
     /// </summary>
     public partial class SequenceRequestResponseTest : Microsoft.Rest.ServiceClient<SequenceRequestResponseTest>, ISequenceRequestResponseTest
     {

--- a/src/generator/AutoRest.CSharp.Unit.Tests/Bug1552.cs
+++ b/src/generator/AutoRest.CSharp.Unit.Tests/Bug1552.cs
@@ -1,0 +1,103 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// 
+
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using AutoRest.Core.Utilities;
+using Microsoft.CodeAnalysis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AutoRest.CSharp.Unit.Tests
+{
+    public class Bug1552 : BugTest
+    {
+        public Bug1552(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /// <summary>
+        ///     https://github.com/Azure/autorest/issues/Bug1552
+        ///     C# codegen can generate invalid C# comments.
+        /// </summary>
+        [Fact]
+        public async Task CheckForProperDescriptionEscaping()
+        {
+            using (var fileSystem = GenerateCodeForTestFromSpec())
+            {
+                // if newlines and stuff aren't excaped properly, compilation will fail
+                var result = await Compile(fileSystem);
+
+                // filter the warnings
+                var warnings = result.Messages.Where(
+                    each => each.Severity == DiagnosticSeverity.Warning
+                            && !SuppressWarnings.Contains(each.Id)).ToArray();
+                
+                // filter the errors
+                var errors = result.Messages.Where(each => each.Severity == DiagnosticSeverity.Error).ToArray();
+
+                Write(warnings, fileSystem);
+                Write(errors, fileSystem);
+
+                // use this to write out all the messages, even hidden ones.
+                // Write(result.Messages, fileSystem);
+
+                // Don't proceed unless we have zero warnings.
+                Assert.Empty(warnings);
+                // Don't proceed unless we have zero Errors.
+                Assert.Empty(errors);
+
+                // Should also succeed.
+                Assert.True(result.Succeeded);
+
+                // try to load the assembly
+                var asm = Assembly.Load(result.Output.GetBuffer());
+                Assert.NotNull(asm);
+
+                // verify that "Func<int>" doesn't exist in the sources (otherwise escaping is still insufficient, even if newlines were handled)
+                var unescapedFiles = fileSystem
+                    .VirtualStore
+                    .Where(file => file.Key.EndsWith(".cs"))
+                    .Where(file => file.Value.ToString().Contains("Func<int>"));
+                Assert.Empty(unescapedFiles);
+            }
+        }
+
+        /// <summary>
+        ///     Wordwrap was a root of the problem, so here are some additional tests for the new version.
+        /// </summary>
+        [Fact]
+        public void CheckWordWrap()
+        {
+            // no break
+            Assert.Equal(1, "".WordWrap(7).Count());
+            Assert.Equal(1, "aaaaaaaaa".WordWrap(7).Count());
+            Assert.Equal(1, "aaaaaaaa".WordWrap(7).Count());
+            Assert.Equal(1, "aaaaaaa".WordWrap(7).Count());
+            Assert.Equal(1, "aaaaaa".WordWrap(7).Count());
+
+            // correct cutting
+            Assert.Equal(1, "aaa".WordWrap(7).Count());
+            Assert.Equal(1, "aaa aaa".WordWrap(7).Count());
+            Assert.Equal(2, "aaa aaa aaa".WordWrap(7).Count());
+            Assert.Equal(2, "aaa aaa aaa aaa".WordWrap(7).Count());
+            Assert.Equal(3, "aaa aaa aaa aaa aaa".WordWrap(7).Count());
+            Assert.Equal(1, "aaa".WordWrap(6).Count());
+            Assert.Equal(2, "aaa aaa".WordWrap(6).Count());
+            Assert.Equal(3, "aaa aaa aaa".WordWrap(6).Count());
+            Assert.Equal(4, "aaa aaa aaa aaa".WordWrap(6).Count());
+            Assert.Equal(5, "aaa aaa aaa aaa aaa".WordWrap(6).Count());
+
+            // correct newline handling
+            Assert.Equal(2, "aa \r aa".WordWrap(100).Count());
+            Assert.Equal(2, "aa \n aa".WordWrap(100).Count());
+            Assert.Equal(2, "aa \r\n aa".WordWrap(100).Count());
+
+            Assert.Equal(3, "aaa\raaa aaa aaa".WordWrap(7).Count());
+            Assert.Equal(2, "aaa aaa\raaa aaa".WordWrap(7).Count());
+            Assert.Equal(3, "aaa aaa aaa\raaa".WordWrap(7).Count());
+        }
+    }
+}

--- a/src/generator/AutoRest.CSharp.Unit.Tests/Resource/Bug1552/Bug1552.yaml
+++ b/src/generator/AutoRest.CSharp.Unit.Tests/Resource/Bug1552/Bug1552.yaml
@@ -1,0 +1,32 @@
+﻿swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Simple API
+  description: "\rpublic \rFunc<int> Injected;\na \r\nasd\n"
+paths:
+  /operation:
+    get:
+      summary: "\rpublic \rFunc<int> Injected;\na \r\nasd\n"
+      description: "\rpublic \rFunc<int> Injected;\na \r\nasd\n"
+      operationId: deprecated_operation
+      deprecated: true
+      responses:
+        200:
+          description: "\rpublic \rFunc<int> Injected;\na \r\nasd\n"
+          type: integer
+    parameters:
+      - name: latitude
+        in: query
+        description: "\rpublic \rFunc<int> Injected;\na \r\nasd\n"
+        required: true
+        type: number
+        format: double
+definitions: 
+  descriptionTest:
+    description: "\rpublic \rFunc<int> Injected;\na \r\nasd\n"
+    properties:
+      prop1:
+        description: "\rpublic \rFunc<int> Injected;\na \r\nasd\n"
+        type: array
+        items:
+          type: string

--- a/src/generator/AutoRest.CSharp/ClientModelExtensions.cs
+++ b/src/generator/AutoRest.CSharp/ClientModelExtensions.cs
@@ -154,7 +154,7 @@ namespace AutoRest.CSharp
             }
 
             string documentation = String.Empty;
-            string summary = string.IsNullOrEmpty(property.Summary) ? property.Documentation : property.Summary;
+            string summary = string.IsNullOrEmpty(property.Summary) ? property.Documentation.EscapeXmlComment() : property.Summary.EscapeXmlComment();
 
             if (summary.TrimStart().StartsWith("Gets ", StringComparison.OrdinalIgnoreCase))
             {

--- a/src/generator/AutoRest.CSharp/Model/CompositeTypeCs.cs
+++ b/src/generator/AutoRest.CSharp/Model/CompositeTypeCs.cs
@@ -148,7 +148,7 @@ namespace AutoRest.CSharp.Model
 
                 foreach (var property in parametersWithDocumentation)
                 {
-                    var documentationInnerText = string.IsNullOrEmpty(property.Summary) ? property.Documentation : property.Summary;
+                    var documentationInnerText = string.IsNullOrEmpty(property.Summary) ? property.Documentation.EscapeXmlComment() : property.Summary.EscapeXmlComment();
 
                     var documentation = string.Format(
                         CultureInfo.InvariantCulture,


### PR DESCRIPTION
- parameter descriptions weren't XML escaped consistently
- word wrapping didn't wrap on '\r' (and was somewhat entirely wrong)
- fixes #1552
- updates expected sources of acceptance tests