### PR TITLE
x-ms-pageable update

### DIFF
--- a/src/generator/AutoRest.CSharp.Azure/Model/CodeModelCsa.cs
+++ b/src/generator/AutoRest.CSharp.Azure/Model/CodeModelCsa.cs
@@ -24,7 +24,8 @@ namespace AutoRest.CSharp.Azure.Model
                 yield return "Microsoft.Rest";
                 yield return "Microsoft.Rest.Azure";
 
-                if (ModelTypes.Any(m => !m.Extensions.ContainsKey(AzureExtensions.ExternalExtension)))
+                if (ModelTypes.Any(m => !m.Extensions.ContainsKey(AzureExtensions.ExternalExtension)) ||
+                    pageClasses.Any())
                 {
                     yield return ModelsName;
                 }

--- a/src/generator/AutoRest.CSharp.Azure/Model/MethodGroupCsa.cs
+++ b/src/generator/AutoRest.CSharp.Azure/Model/MethodGroupCsa.cs
@@ -38,7 +38,9 @@ namespace AutoRest.CSharp.Azure.Model
             {
                 yield return "Microsoft.Rest.Azure";
 
-                if (CodeModel.ModelTypes.Any(m => !m.Extensions.ContainsKey(AzureExtensions.ExternalExtension)) || CodeModel.HeaderTypes.Any())
+                if (CodeModel.ModelTypes.Any(m => !m.Extensions.ContainsKey(AzureExtensions.ExternalExtension)) || 
+                    CodeModel.HeaderTypes.Any() || 
+                    (CodeModel as CodeModelCsa).pageClasses.Any())
                 {
                     yield return CodeModel.ModelsName;
                 }

--- a/src/generator/AutoRest.CSharp.Azure/TransformerCsa.cs
+++ b/src/generator/AutoRest.CSharp.Azure/TransformerCsa.cs
@@ -149,15 +149,15 @@ namespace AutoRest.CSharp.Azure
                     var compositType = (CompositeType)method.Responses[responseStatus].Body;
                     var sequenceType =
                         compositType.Properties.Select(p => p.ModelType).FirstOrDefault(t => t is SequenceType) as
-                            SequenceType;
+                            SequenceTypeCs;
 
                     // if the type is a wrapper over page-able response
                     if (sequenceType != null)
                     {
                         var pagableTypeName = string.Format(CultureInfo.InvariantCulture, pageTypeFormat, pageClassName,
-                            sequenceType.ElementType.Name);
+                            sequenceType.ElementType.AsNullableType(!sequenceType.ElementType.IsValueType() || (sequenceType.IsXNullable ?? true)));
                         var ipagableTypeName = string.Format(CultureInfo.InvariantCulture, ipageTypeFormat,
-                            sequenceType.ElementType.Name);
+                            sequenceType.ElementType.AsNullableType(!sequenceType.ElementType.IsValueType() || (sequenceType.IsXNullable ?? true)));
 
                         var pagedResult = New<ILiteralType>(pagableTypeName) as CompositeType;
 

--- a/src/generator/AutoRest.CSharp.Unit.Tests/Bug1623.cs
+++ b/src/generator/AutoRest.CSharp.Unit.Tests/Bug1623.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+// 
+
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace AutoRest.CSharp.Unit.Tests
+{
+    public class Bug1623 : BugTest
+    {
+        public Bug1623(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        /// <summary>
+        ///     https://github.com/Azure/autorest/issues/Bug1623
+        ///     x-ms-pageable and nullability.
+        /// </summary>
+        [Fact]
+        public async Task CheckForCorrectParameterType()
+        {
+            using (var fileSystem = GenerateCodeForTestFromSpec(codeGenerator: "Azure.CSharp"))
+            {
+                // Expected Files
+                Assert.True(fileSystem.FileExists(@"GeneratedCode\Models\Page.cs"));
+                Assert.True(fileSystem.FileExists(@"GeneratedCode\IProductsOperations.cs"));
+                Assert.True(fileSystem.FileExists(@"GeneratedCode\ProductsOperationsExtensions.cs"));
+
+                var result = await Compile(fileSystem);
+
+                // filter the warnings
+                var warnings = result.Messages.Where(
+                    each => each.Severity == DiagnosticSeverity.Warning
+                            && !SuppressWarnings.Contains(each.Id)).ToArray();
+
+                // filter the errors
+                var errors = result.Messages.Where(each => each.Severity == DiagnosticSeverity.Error).ToArray();
+
+                Write(warnings, fileSystem);
+                Write(errors, fileSystem);
+
+                // use this to write out all the messages, even hidden ones.
+                // Write(result.Messages, fileSystem);
+
+                // Don't proceed unless we have zero warnings.
+                Assert.Empty(warnings);
+                // Don't proceed unless we have zero Errors.
+                Assert.Empty(errors);
+
+                // Should also succeed.
+                Assert.True(result.Succeeded);
+
+                // try to load the assembly
+                var asm = Assembly.Load(result.Output.GetBuffer());
+                Assert.NotNull(asm);
+
+                // verify that parameter is of correct type
+                var ops = asm.ExportedTypes.FirstOrDefault(each => each.FullName == "Test.ProductsOperationsExtensions");
+                Assert.NotNull(ops);
+                var opsMethod = ops.GetMethod("List");
+                Assert.NotNull(opsMethod);
+                var opsMethodReturnType = opsMethod.ReturnType?.GetGenericArguments()?.FirstOrDefault();
+                Assert.NotNull(opsMethodReturnType);
+                Assert.Equal(typeof(int?), opsMethodReturnType);
+            }
+        }
+    }
+}

--- a/src/generator/AutoRest.CSharp.Unit.Tests/Resource/Bug1623/Bug1623.yaml
+++ b/src/generator/AutoRest.CSharp.Unit.Tests/Resource/Bug1623/Bug1623.yaml
@@ -1,0 +1,27 @@
+﻿swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Simple API
+produces:
+  - application/json
+paths:
+  /operationInteger:
+    get:
+      x-ms-pageable:
+        nextLinkName: nextLink
+      operationId: products_list
+      responses:
+        200:
+          description: OK
+          schema:
+            $ref: '#/definitions/ProductListResult'
+definitions:
+  ProductListResult:
+    type: object
+    properties:
+      value:
+        type: array
+        items:
+          type: integer
+      nextLink:
+        type: string


### PR DESCRIPTION
- fixed missing `using Model;` directive if there is no model definition (but `Page<>` is still in there! => compiler error)
- fixed nullability of element type (always chose plain version, did not care about `x-nullable`) - fixes #1623