### PR TITLE
Allow "$schema" property in spec files

### DIFF
--- a/schema/swagger-extensions.json
+++ b/schema/swagger-extensions.json
@@ -15,6 +15,10 @@
     }
   },
   "properties": {
+    "$schema": {
+      "type": "string", 
+      "format": "uri"
+    },
     "swagger": {
       "type": "string",
       "enum": [


### PR DESCRIPTION
  * Allowing "$schema" enables intelligent JSON editors like Visual
    Studio to automatically detect the schema to use to validate the
    current file and provide autocompletion.
  * In the AutoRest world, the value of this property should always be
    the URL of some version of schema containing AutoRest extensions to
    the Swagger spec.