### PR TITLE
fix python tests so node does not kill py3.5 buffered output

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -782,6 +782,20 @@ gulp.task('package', function(cb) {
 });
 */
 
+var runAsync = function(command, opts, cb){
+  if(!opts.args){
+    opts.args = [];
+  }
+  opts.stdio = [process.stdin, process.stdout, process.stderr];
+  cmd = spawn(command, opts.args, opts);
+  cmd.on('close', (code) => {
+    if(code != 0){
+      cb(code);
+    } else {
+      cb(null);
+    }
+  });
+};
 
 gulp.task('test:node', shell.task('npm test', {cwd: './src/generator/AutoRest.NodeJS.Tests/', verbosity: 3}));
 gulp.task('test:node:azure', shell.task('npm test', {cwd: './src/generator/AutoRest.NodeJS.Azure.Tests/', verbosity: 3}));
@@ -789,8 +803,8 @@ gulp.task('test:node:azure', shell.task('npm test', {cwd: './src/generator/AutoR
 gulp.task('test:ruby', ['regenerate:expected:ruby'], shell.task('ruby RspecTests/tests_runner.rb', { cwd: './src/generator/AutoRest.Ruby.Tests', verbosity: 3 }));
 gulp.task('test:ruby:azure', ['regenerate:expected:rubyazure'], shell.task('ruby RspecTests/tests_runner.rb', { cwd: './src/generator/AutoRest.Ruby.Azure.Tests', verbosity: 3 }));
 
-gulp.task('test:python', shell.task('tox', {cwd: './src/generator/AutoRest.Python.Tests/', verbosity: 3}));
-gulp.task('test:python:azure', shell.task('tox', {cwd: './src/generator/AutoRest.Python.Azure.Tests/', verbosity: 3}));
+gulp.task('test:python', function(cb){ runAsync('tox', {cwd: './src/generator/AutoRest.Python.Tests/'}, cb) });
+gulp.task('test:python:azure', function(cb){ runAsync('tox', {cwd: './src/generator/AutoRest.Python.Azure.Tests/'}, cb) });
 
 /* Until JAVA is back in master
 gulp.task('test:java', ['test:java:init', 'test:clientruntime:java:init', 'test:clientruntime:javaazure:init'], shell.task(basePathOrThrow() + '/gradlew :codegen-tests:check', {cwd: './', verbosity: 3}));


### PR DESCRIPTION
When  running `gulp test:python` the gulp process would close stdin prior to the tox owned `coverage report` would finish in python 3.5. To remedy this issue, I've introduced a runAsync method which gives the child process control of the stdin, out and err.

```
Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/version.py           Traceback (most recent call last):
  File "/Users/david/devigned/microsoft/azure/autorest/src/generator/AutoRest.Python.Tests/.tox/py35/bin/coverage", line 11, in <module>
    sys.exit(main())
  File "/Users/david/devigned/microsoft/azure/autorest/src/generator/AutoRest.Python.Tests/.tox/py35/lib/python3.5/site-packages/coverage/cmdline.py", line 753, in main
    status = CoverageScript().command_line(argv)
  File "/Users/david/devigned/microsoft/azure/autorest/src/generator/AutoRest.Python.Tests/.tox/py35/lib/python3.5/site-packages/coverage/cmdline.py", line 504, in command_line
    skip_covered=options.skip_covered, **report_args)
  File "/Users/david/devigned/microsoft/azure/autorest/src/generator/AutoRest.Python.Tests/.tox/py35/lib/python3.5/site-packages/coverage/control.py", line 985, in report
    return reporter.report(morfs, outfile=file)
  File "/Users/david/devigned/microsoft/azure/autorest/src/generator/AutoRest.Python.Tests/.tox/py35/lib/python3.5/site-packages/coverage/summary.py", line 125, in report
    writeout(line[0])
  File "/Users/david/devigned/microsoft/azure/autorest/src/generator/AutoRest.Python.Tests/.tox/py35/lib/python3.5/site-packages/coverage/summary.py", line 60, in writeout
    outfile.write(line.rstrip())
BlockingIOError: [Errno 35] write could not complete without blocking
ERROR: InvocationError: '/Users/david/devigned/microsoft/azure/autorest/src/generator/AutoRest.Python.Tests/.tox/py35/bin/coverage report --fail-under=60 —omit=AcceptanceTests*.py,*.tox*.py'
```

@fearthecowboy I think shell.task should probably be deprecated and then have one less dependency.