### PR TITLE
Various minor bug fixes in the Go generator.

### DIFF
--- a/src/generator/AutoRest.Go/Extensions.cs
+++ b/src/generator/AutoRest.Go/Extensions.cs
@@ -29,7 +29,8 @@ namespace AutoRest.Go
 
         private static Dictionary<string, string> plural = new Dictionary<string, string>()
         {
-            { "eventhub", "eventhubs" }
+            { "eventhub", "eventhubs" },
+            { "containerservice", "containerservices" }
         };
 
         /////////////////////////////////////////////////////////////////////////////////////////

--- a/src/generator/AutoRest.Go/TemplateModels/ServiceClientTemplateModel.cs
+++ b/src/generator/AutoRest.Go/TemplateModels/ServiceClientTemplateModel.cs
@@ -120,6 +120,11 @@ namespace AutoRest.Go.TemplateModels
                         });
                 }
 
+                foreach (var p in Properties)
+                {
+                    p.Type.AddImports(imports);
+                }
+
                 if (validationImports)
                     imports.UnionWith(GoCodeNamer.ValidationImport);
                 return imports.OrderBy(i => i);

--- a/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
@@ -110,7 +110,7 @@ func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParameter
     @:if @(p.Type.GetEmptyCheck(p.GetParameterName(),false)) {
         @:preparer = autorest.DecoratePreparer(preparer,
                             @:@(string.Format("autorest.WithHeader(\"{0}\",autorest.String({1}))",
-                            p.SerializedName, p.Name)))
+                            p.SerializedName, p.GetParameterName())))
     @:}
 }
 


### PR DESCRIPTION
Added a plural entry for "containerservice" to prevent type names from
getting improperly truncated (e.g. "ContainerServices" became "s").
Add imports based on property types in the service client template model.
Use GetParameterName() to handle the case where the parameter is a
property on the client type.