### PR TITLE
Various minor bug fixes in the Go generator.

### DIFF
--- a/src/generator/AutoRest.Go/GoCodeGenerator.cs
+++ b/src/generator/AutoRest.Go/GoCodeGenerator.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 
 using AutoRest.Core;
 using AutoRest.Core.ClientModel;
+using AutoRest.Extensions;
 using AutoRest.Go.TemplateModels;
 using AutoRest.Go.Templates;
 
@@ -45,6 +46,7 @@ namespace AutoRest.Go
         /// <param name="serviceClientModel"></param>
         public override void NormalizeClientModel(ServiceClient serviceClientModel)
         {
+            SwaggerExtensions.ProcessGlobalParameters(serviceClientModel);
             // Add the current package name as a reserved keyword
             _namingFramework.ReserveNamespace(Settings.Namespace);
             _namingFramework.NormalizeClientModel(serviceClientModel);

--- a/src/generator/AutoRest.Go/TemplateModels/ServiceClientTemplateModel.cs
+++ b/src/generator/AutoRest.Go/TemplateModels/ServiceClientTemplateModel.cs
@@ -120,6 +120,11 @@ namespace AutoRest.Go.TemplateModels
                         });
                 }
 
+                foreach (var p in Properties)
+                {
+                    p.Type.AddImports(imports);
+                }
+
                 if (validationImports)
                     imports.UnionWith(GoCodeNamer.ValidationImport);
                 return imports.OrderBy(i => i);

--- a/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
@@ -110,7 +110,7 @@ func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParameter
     @:if @(p.Type.GetEmptyCheck(p.GetParameterName(),false)) {
         @:preparer = autorest.DecoratePreparer(preparer,
                             @:@(string.Format("autorest.WithHeader(\"{0}\",autorest.String({1}))",
-                            p.SerializedName, p.Name)))
+                            p.SerializedName, p.GetParameterName())))
     @:}
 }
 

--- a/src/generator/AutoRest.NodeJS.Tests/package.json
+++ b/src/generator/AutoRest.NodeJS.Tests/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "tslint": "^2.5.1",
-    "typescript": "^1.6.2"
+    "typescript": "^2.0.10"
   },
   "homepage": "https://github.com/Azure/AutoRest/src/generator/AutoRest.NodeJS.Tests",
   "repository": {


### PR DESCRIPTION
Added a plural entry for "containerservice" to prevent type names from
getting improperly truncated (e.g. "ContainerServices" became "s").
Add imports based on property types in the service client template model.
Use GetParameterName() to handle the case where the parameter is a
property on the client type.
Add support for x-ms-client-flatten by embedding child structs as an
anonymous field.
Add support for x-ms-parameter-location extension.