### PR TITLE
Change version of typescript

### DIFF
--- a/src/generator/AutoRest.NodeJS.Tests/package.json
+++ b/src/generator/AutoRest.NodeJS.Tests/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "tslint": "^2.5.1",
-    "typescript": "^1.6.2"
+    "typescript": "^2.0.10"
   },
   "homepage": "https://github.com/Azure/AutoRest/src/generator/AutoRest.NodeJS.Tests",
   "repository": {


### PR DESCRIPTION
A recent update to `moment.js` causes older versions of `tsc` to fail during the build/test of nodejs projects.