### PR TITLE
Code changes to avoid returning nil values from synchrnous wrappers

### DIFF
--- a/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/lro_spec.rb
+++ b/src/generator/AutoRest.Ruby.Azure.Tests/RspecTests/lro_spec.rb
@@ -49,8 +49,7 @@ describe 'Long Running Operation' do
   end
 
   it 'should retry on 202 server response in POST request' do
-    result = @lros_client.post202retry200_async(@product).value!
-    expect(result.body).to be_nil
+    result = @lros_client.post202retry200_async(@product).value!    
     expect(result.response.status).to eq(200)
   end
 
@@ -149,7 +148,6 @@ describe 'Long Running Operation' do
 
   it 'should succeed for delete no header in retry' do
     result = @lros_client.delete_no_header_in_retry_async().value!
-    expect(result.body).to be_nil
     expect(result.response.status).to eq(204)
   end
 
@@ -284,13 +282,11 @@ describe 'Long Running Operation with retry' do
 
   it 'should retry DELETE request on 500 response' do
     result = @lroretrys_client.delete202retry200_async().value!
-    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
   it 'should retry POST request on 500 response' do
     result = @lroretrys_client.post202retry200_async(@product).value!
-    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 
@@ -473,7 +469,6 @@ describe 'Long Running Operation with custom header' do
 
   it 'should succeed for custom header post' do
     result = @lros_custom_header_client.post202retry200_async(@product, @custom_header).value!
-    expect(result.body).to be_nil
     expect(result.response.status).to eq(200)
   end
 end

--- a/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby.Azure/Templates/AzureMethodTemplate.cshtml
@@ -67,6 +67,11 @@ end
 @WrapComment("# ", string.Format("@return [{0}] operation results.", Model.OperationReturnTypeString))@:
 @:#
 }
+else
+{
+@WrapComment("# ", string.Format("@return {0} operation results.", Model.Name))@:
+@:#
+}
 def @(Model.Name)(@(Model.MethodParameterDeclaration))
   @Model.ResponseGeneration()
 end
@@ -91,6 +96,10 @@ def @(Model.Name)_async(@(Model.MethodParameterDeclaration))
     @if (Model.ReturnType.Body != null)
     {
       @:@(Model.DeserializePollingResponse("parsed_response", Model.ReturnType.Body))
+    }
+    else
+    {
+      @:parsed_response
     }
     end
 

--- a/src/generator/AutoRest.Ruby/Model/MethodRb.cs
+++ b/src/generator/AutoRest.Ruby/Model/MethodRb.cs
@@ -495,14 +495,7 @@ namespace AutoRest.Ruby.Model
         {
             IndentedStringBuilder builder = new IndentedStringBuilder("");
             builder.AppendLine("response = {0}_async({1}).value!", Name, MethodParameterInvocation);
-            if (ReturnType.Body != null)
-            {
-                builder.AppendLine("response.body unless response.nil?");
-            }
-            else
-            {
-                builder.AppendLine("nil");
-            }
+            builder.AppendLine("response.body unless response.nil?");
             return builder.ToString();
         }
 


### PR DESCRIPTION
This is related to avoid nil return values in the synchronous wrappers. I will send out the detailed explanation seperately. 

 @salameer @veronicagg @vishrutshah Please review.

Related to https://github.com/Azure/azure-sdk-for-ruby/issues/566 