### PR TITLE
Fix parameter validation codegen for flattened types.

### DIFF
--- a/src/generator/AutoRest.Go/GoCodeGenerator.cs
+++ b/src/generator/AutoRest.Go/GoCodeGenerator.cs
@@ -68,6 +68,19 @@ namespace AutoRest.Go
                                             !string.IsNullOrEmpty(Settings.PackageVersion)
                                                     ? Settings.PackageVersion
                                                     : "0.0.0");
+
+            // unfortunately there is an ordering issue here.  during model generation we might
+            // flatten some types (but not all depending on type).  then during client generation
+            // the validation codegen needs to know if a type was flattened so it can generate
+            // the correct code, so we need to generate models before clients.
+
+            // Models
+            var modelsTemplate = new ModelsTemplate
+            {
+                Model = new ModelsTemplateModel(serviceClient, packageName),
+            };
+            await Write(modelsTemplate, GoCodeNamer.FormatFileName("models"));
+
             // Service client
             var serviceClientTemplate = new ServiceClientTemplate
             {
@@ -83,13 +96,6 @@ namespace AutoRest.Go
                 };
                 await Write(groupedMethodTemplate, GoCodeNamer.FormatFileName(methodGroupName.ToLowerInvariant()));
             }
-
-            // Models
-            var modelsTemplate = new ModelsTemplate
-            {
-                Model = new ModelsTemplateModel(serviceClient, packageName),
-            };
-            await Write(modelsTemplate, GoCodeNamer.FormatFileName("models"));
 
             // Version
             var versionTemplate = new VersionTemplate


### PR DESCRIPTION
The codegen for parameter validation wasn't updated to account for type
flattening which introduced regressions in the SDK.  Track if a type was
flattened and if it was generate the appropriate validation code.