### PR TITLE
Prevent errors caused by tsc regression

### DIFF
--- a/src/generator/AutoRest.NodeJS.Tests/package.json
+++ b/src/generator/AutoRest.NodeJS.Tests/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "tslint": "^2.5.1",
-    "typescript": "^2.0.10"
+    "typescript": "2.0.10"
   },
   "homepage": "https://github.com/Azure/AutoRest/src/generator/AutoRest.NodeJS.Tests",
   "repository": {


### PR DESCRIPTION
A ton of tests fail in recent tsc due to "xyz implicitly has type any" errors (although they have a specific inferred type) around some mocha code. 

This happens starting with version `2.1.1`, the last "working" version is `2.0.10`.