### PR TITLE
[Ruby] Making credentials nil by default

### DIFF
--- a/Samples/azure-storage/Azure.CSharp/StorageAccountsOperations.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageAccountsOperations.cs
@@ -264,11 +264,8 @@ namespace Petstore
         public async Task<AzureOperationResponse<StorageAccount>> CreateWithHttpMessagesAsync(string resourceGroupName, string accountName, StorageAccountCreateParameters parameters, Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
         {
             // Send Request
-            AzureOperationResponse<StorageAccount> _response = await BeginCreateWithHttpMessagesAsync(
-                resourceGroupName, accountName, parameters, customHeaders, cancellationToken);
-            return await Client.GetPutOrPatchOperationResultAsync(_response,
-                customHeaders,
-                cancellationToken);
+            AzureOperationResponse<StorageAccount> _response = await BeginCreateWithHttpMessagesAsync(resourceGroupName, accountName, parameters, customHeaders, cancellationToken).ConfigureAwait(false);
+            return await Client.GetPutOrPatchOperationResultAsync(_response, customHeaders, cancellationToken).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Samples/azure-storage/Azure.CSharp/StorageAccountsOperationsExtensions.cs
+++ b/Samples/azure-storage/Azure.CSharp/StorageAccountsOperationsExtensions.cs
@@ -27,7 +27,7 @@ namespace Petstore
             /// </param>
             public static CheckNameAvailabilityResult CheckNameAvailability(this IStorageAccountsOperations operations, StorageAccountCheckNameAvailabilityParameters accountName)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).CheckNameAvailabilityAsync(accountName), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.CheckNameAvailabilityAsync(accountName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -75,7 +75,7 @@ namespace Petstore
             /// </param>
             public static StorageAccount Create(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParameters parameters)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).CreateAsync(resourceGroupName, accountName, parameters), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.CreateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -126,7 +126,7 @@ namespace Petstore
             /// </param>
             public static void Delete(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
             {
-                Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).DeleteAsync(resourceGroupName, accountName), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.DeleteAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -169,7 +169,7 @@ namespace Petstore
             /// </param>
             public static StorageAccount GetProperties(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).GetPropertiesAsync(resourceGroupName, accountName), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.GetPropertiesAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -230,7 +230,7 @@ namespace Petstore
             /// </param>
             public static StorageAccount Update(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountUpdateParameters parameters)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).UpdateAsync(resourceGroupName, accountName, parameters), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.UpdateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -287,7 +287,7 @@ namespace Petstore
             /// </param>
             public static StorageAccountKeys ListKeys(this IStorageAccountsOperations operations, string resourceGroupName, string accountName)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).ListKeysAsync(resourceGroupName, accountName), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.ListKeysAsync(resourceGroupName, accountName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -322,7 +322,7 @@ namespace Petstore
             /// </param>
             public static IEnumerable<StorageAccount> List(this IStorageAccountsOperations operations)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).ListAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.ListAsync().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -356,7 +356,7 @@ namespace Petstore
             /// </param>
             public static IEnumerable<StorageAccount> ListByResourceGroup(this IStorageAccountsOperations operations, string resourceGroupName)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).ListByResourceGroupAsync(resourceGroupName), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.ListByResourceGroupAsync(resourceGroupName).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -401,7 +401,7 @@ namespace Petstore
             /// </param>
             public static StorageAccountKeys RegenerateKey(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountRegenerateKeyParameters regenerateKey)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).RegenerateKeyAsync(resourceGroupName, accountName, regenerateKey), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.RegenerateKeyAsync(resourceGroupName, accountName, regenerateKey).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -456,7 +456,7 @@ namespace Petstore
             /// </param>
             public static StorageAccount BeginCreate(this IStorageAccountsOperations operations, string resourceGroupName, string accountName, StorageAccountCreateParameters parameters)
             {
-                return Task.Factory.StartNew(s => ((IStorageAccountsOperations)s).BeginCreateAsync(resourceGroupName, accountName, parameters), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.BeginCreateAsync(resourceGroupName, accountName, parameters).GetAwaiter().GetResult();
             }
 
             /// <summary>

--- a/Samples/azure-storage/Azure.CSharp/UsageOperationsExtensions.cs
+++ b/Samples/azure-storage/Azure.CSharp/UsageOperationsExtensions.cs
@@ -23,7 +23,7 @@ namespace Petstore
             /// </param>
             public static IEnumerable<Usage> List(this IUsageOperations operations)
             {
-                return Task.Factory.StartNew(s => ((IUsageOperations)s).ListAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.ListAsync().GetAwaiter().GetResult();
             }
 
             /// <summary>

--- a/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
+++ b/Samples/azure-storage/Azure.Ruby/generated/azure_storage/storage_management_client.rb
@@ -45,12 +45,11 @@ module Petstore
     # @param base_url [String] the base URI of the service.
     # @param options [Array] filters to be applied to the HTTP requests.
     #
-    def initialize(credentials, base_url = nil, options = nil)
+    def initialize(credentials = nil, base_url = nil, options = nil)
       super(credentials, options)
       @base_url = base_url || 'https://management.azure.com'
 
-      fail ArgumentError, 'credentials is nil' if credentials.nil?
-      fail ArgumentError, 'invalid type of credentials input parameter' unless credentials.is_a?(MsRest::ServiceClientCredentials)
+      fail ArgumentError, 'invalid type of credentials input parameter' unless credentials.is_a?(MsRest::ServiceClientCredentials) unless credentials.nil?
       @credentials = credentials
 
       @storage_accounts = StorageAccounts.new(self)

--- a/Samples/petstore/CSharp/SwaggerPetstoreExtensions.cs
+++ b/Samples/petstore/CSharp/SwaggerPetstoreExtensions.cs
@@ -25,7 +25,7 @@ namespace Petstore
             /// </param>
             public static void AddPetUsingByteArray(this ISwaggerPetstore operations, string body = default(string))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).AddPetUsingByteArrayAsync(body), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.AddPetUsingByteArrayAsync(body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -61,7 +61,7 @@ namespace Petstore
             /// </param>
             public static void AddPet(this ISwaggerPetstore operations, Pet body = default(Pet))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).AddPetAsync(body), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.AddPetAsync(body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -96,7 +96,7 @@ namespace Petstore
             /// </param>
             public static void UpdatePet(this ISwaggerPetstore operations, Pet body = default(Pet))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).UpdatePetAsync(body), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.UpdatePetAsync(body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -130,7 +130,7 @@ namespace Petstore
             /// </param>
             public static IList<Pet> FindPetsByStatus(this ISwaggerPetstore operations, IList<string> status = default(IList<string>))
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).FindPetsByStatusAsync(status), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.FindPetsByStatusAsync(status).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -171,7 +171,7 @@ namespace Petstore
             /// </param>
             public static IList<Pet> FindPetsByTags(this ISwaggerPetstore operations, IList<string> tags = default(IList<string>))
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).FindPetsByTagsAsync(tags), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.FindPetsByTagsAsync(tags).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -213,7 +213,7 @@ namespace Petstore
             /// </param>
             public static string FindPetsWithByteArray(this ISwaggerPetstore operations, long petId)
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).FindPetsWithByteArrayAsync(petId), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.FindPetsWithByteArrayAsync(petId).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -255,7 +255,7 @@ namespace Petstore
             /// </param>
             public static Pet GetPetById(this ISwaggerPetstore operations, long petId)
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetPetByIdAsync(petId), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.GetPetByIdAsync(petId).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -299,7 +299,7 @@ namespace Petstore
             /// </param>
             public static void UpdatePetWithForm(this ISwaggerPetstore operations, string petId, string name = default(string), string status = default(string))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).UpdatePetWithFormAsync(petId, name, status), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.UpdatePetWithFormAsync(petId, name, status).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -338,7 +338,7 @@ namespace Petstore
             /// </param>
             public static void DeletePet(this ISwaggerPetstore operations, long petId, string apiKey = default(string))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).DeletePetAsync(petId, apiKey), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.DeletePetAsync(petId, apiKey).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -377,7 +377,7 @@ namespace Petstore
             /// </param>
             public static void UploadFile(this ISwaggerPetstore operations, long petId, string additionalMetadata = default(string), Stream file = default(Stream))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).UploadFileAsync(petId, additionalMetadata, file), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.UploadFileAsync(petId, additionalMetadata, file).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -414,7 +414,7 @@ namespace Petstore
             /// </param>
             public static IDictionary<string, int?> GetInventory(this ISwaggerPetstore operations)
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetInventoryAsync(), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.GetInventoryAsync().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -448,7 +448,7 @@ namespace Petstore
             /// </param>
             public static Order PlaceOrder(this ISwaggerPetstore operations, Order body = default(Order))
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).PlaceOrderAsync(body), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.PlaceOrderAsync(body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -486,7 +486,7 @@ namespace Petstore
             /// </param>
             public static Order GetOrderById(this ISwaggerPetstore operations, string orderId)
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetOrderByIdAsync(orderId), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.GetOrderByIdAsync(orderId).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -528,7 +528,7 @@ namespace Petstore
             /// </param>
             public static void DeleteOrder(this ISwaggerPetstore operations, string orderId)
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).DeleteOrderAsync(orderId), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.DeleteOrderAsync(orderId).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -566,7 +566,7 @@ namespace Petstore
             /// </param>
             public static void CreateUser(this ISwaggerPetstore operations, User body = default(User))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).CreateUserAsync(body), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.CreateUserAsync(body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -600,7 +600,7 @@ namespace Petstore
             /// </param>
             public static void CreateUsersWithArrayInput(this ISwaggerPetstore operations, IList<User> body = default(IList<User>))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).CreateUsersWithArrayInputAsync(body), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.CreateUsersWithArrayInputAsync(body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -631,7 +631,7 @@ namespace Petstore
             /// </param>
             public static void CreateUsersWithListInput(this ISwaggerPetstore operations, IList<User> body = default(IList<User>))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).CreateUsersWithListInputAsync(body), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.CreateUsersWithListInputAsync(body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -665,7 +665,7 @@ namespace Petstore
             /// </param>
             public static string LoginUser(this ISwaggerPetstore operations, string username = default(string), string password = default(string))
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).LoginUserAsync(username, password), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.LoginUserAsync(username, password).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -699,7 +699,7 @@ namespace Petstore
             /// </param>
             public static void LogoutUser(this ISwaggerPetstore operations)
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).LogoutUserAsync(), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.LogoutUserAsync().GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -727,7 +727,7 @@ namespace Petstore
             /// </param>
             public static User GetUserByName(this ISwaggerPetstore operations, string username)
             {
-                return Task.Factory.StartNew(s => ((ISwaggerPetstore)s).GetUserByNameAsync(username), operations, CancellationToken.None, TaskCreationOptions.None, TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                return operations.GetUserByNameAsync(username).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -767,7 +767,7 @@ namespace Petstore
             /// </param>
             public static void UpdateUser(this ISwaggerPetstore operations, string username, User body = default(User))
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).UpdateUserAsync(username, body), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.UpdateUserAsync(username, body).GetAwaiter().GetResult();
             }
 
             /// <summary>
@@ -807,7 +807,7 @@ namespace Petstore
             /// </param>
             public static void DeleteUser(this ISwaggerPetstore operations, string username)
             {
-                Task.Factory.StartNew(s => ((ISwaggerPetstore)s).DeleteUserAsync(username), operations, CancellationToken.None, TaskCreationOptions.None,  TaskScheduler.Default).Unwrap().GetAwaiter().GetResult();
+                operations.DeleteUserAsync(username).GetAwaiter().GetResult();
             }
 
             /// <summary>

--- a/Samples/petstore/Python/swaggerpetstore/models/order.py
+++ b/Samples/petstore/Python/swaggerpetstore/models/order.py
@@ -21,7 +21,7 @@ class Order(Model):
     :type ship_date: datetime
     :param status: Order Status. Possible values include: 'placed',
      'approved', 'delivered'
-    :type status: str
+    :type status: str or :class:`enum <petstore.models.enum>`
     :param complete:
     :type complete: bool
     """

--- a/Samples/petstore/Python/swaggerpetstore/models/pet.py
+++ b/Samples/petstore/Python/swaggerpetstore/models/pet.py
@@ -23,7 +23,7 @@ class Pet(Model):
     :type tags: list of :class:`Tag <petstore.models.Tag>`
     :param status: pet status in the store. Possible values include:
      'available', 'pending', 'sold'
-    :type status: str
+    :type status: str or :class:`enum <petstore.models.enum>`
     """
 
     _validation = {

--- a/Samples/petstore/Ruby/generated/petstore/models/order.rb
+++ b/Samples/petstore/Ruby/generated/petstore/models/order.rb
@@ -19,8 +19,8 @@ module Petstore
       # @return [DateTime]
       attr_accessor :ship_date
 
-      # @return Order Status. Possible values include: 'placed', 'approved',
-      # 'delivered'
+      # @return [Enum] Order Status. Possible values include: 'placed',
+      # 'approved', 'delivered'
       attr_accessor :status
 
       # @return [Boolean]

--- a/Samples/petstore/Ruby/generated/petstore/models/pet.rb
+++ b/Samples/petstore/Ruby/generated/petstore/models/pet.rb
@@ -24,8 +24,8 @@ module Petstore
       # @return [Array<Tag>]
       attr_accessor :tags
 
-      # @return pet status in the store. Possible values include: 'available',
-      # 'pending', 'sold'
+      # @return [Enum] pet status in the store. Possible values include:
+      # 'available', 'pending', 'sold'
       attr_accessor :status
 
 

--- a/Samples/petstore/Ruby/generated/petstore/swagger_petstore.rb
+++ b/Samples/petstore/Ruby/generated/petstore/swagger_petstore.rb
@@ -16,12 +16,11 @@ module Petstore
     # @param base_url [String] the base URI of the service.
     # @param options [Array] filters to be applied to the HTTP requests.
     #
-    def initialize(credentials, base_url = nil, options = nil)
+    def initialize(credentials = nil, base_url = nil, options = nil)
       super(credentials, options)
       @base_url = base_url || 'http://petstore.swagger.io/v2'
 
-      fail ArgumentError, 'credentials is nil' if credentials.nil?
-      fail ArgumentError, 'invalid type of credentials input parameter' unless credentials.is_a?(MsRest::ServiceClientCredentials)
+      fail ArgumentError, 'invalid type of credentials input parameter' unless credentials.is_a?(MsRest::ServiceClientCredentials) unless credentials.nil?
       @credentials = credentials
 
       add_telemetry

--- a/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Ruby/Templates/ServiceClientTemplate.cshtml
@@ -47,11 +47,11 @@ module @Settings.Namespace
     #
     @if (!Model.IsCustomBaseUri)
     {
-    @:def initialize(credentials, base_url = nil, options = nil)
+    @:def initialize(credentials = nil, base_url = nil, options = nil)
     }
     else
     {
-    @:def initialize(credentials, options = nil)
+    @:def initialize(credentials = nil, options = nil)
     }
       super(credentials, options)
       @if (!Model.IsCustomBaseUri)
@@ -63,8 +63,7 @@ module @Settings.Namespace
       @:@@base_url = '@Model.BaseUrl'
       }
       @EmptyLine
-      fail ArgumentError, 'credentials is nil' if credentials.nil?
-      fail ArgumentError, 'invalid type of credentials input parameter' unless credentials.is_a?(MsRest::ServiceClientCredentials)
+      fail ArgumentError, 'invalid type of credentials input parameter' unless credentials.is_a?(MsRest::ServiceClientCredentials) unless credentials.nil?
       @@credentials = credentials
       @EmptyLine
       @foreach (var operation in Model.Operations.Where( each => !each.IsCodeModelMethodGroup))


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-ruby/issues/613 

As mentioned in the issue, even though there is no security/security definition provided in the swagger files, our autorest code actually generates the template with credentials. More than that, it makes credentials a non nullable parameter. This simply is not required. (If we do compare this situation with similar node sdk, the credentials is merely an optional parameter). 

So, there are 2 possible solutions to this problem:
1. Check for the presence of security related information in the swagger file and then decide if the credentials must be added. Though I feel this approach is correct, currently the security related information is not passsed from servicedefinition object to code model object. This would be a bigger code change and the possibility of someone using autorest to generate code for their service (which does not need any authentication) is very less. So, I am not taking this approach. 

2. The second approach is much simpler and aligns with the node approach is to make the credentials parameter nil by default. Also, if we do verify the places (in this file, in service azure client - ms-rest-azure and service client - ms-rest), there are lines specifically written to check if the credentials object is nil. Thus, there is no danger in making this parameter nil by default. 

@veronicagg @vishrutshah @salameer Please review.