### PR TITLE
Safer structural equality

### DIFF
--- a/src/core/AutoRest.Core/Model/CompositeType.cs
+++ b/src/core/AutoRest.Core/Model/CompositeType.cs
@@ -180,33 +180,7 @@ namespace AutoRest.Core.Model
 
         [JsonIgnore]
         public override bool IsConstant => ComposedProperties.Any() && ComposedProperties.All(p => p.IsConstant);
-
-        /// <summary>
-        /// Determines whether the specified model type is structurally equal to this object.
-        /// </summary>
-        /// <param name="other">The object to compare with this object.</param>
-        /// <returns>true if the specified object is functionally equal to this object; otherwise, false.</returns>
-        public override bool StructurallyEquals(IModelType other)
-        {
-            if (ReferenceEquals(other as CompositeType, null))
-            {
-                return false;
-            }
-            if (ReferenceEquals(other as CompositeType, this))
-            {
-                return true;
-            }
-
-            return base.StructurallyEquals(other) &&
-                ComposedProperties.SequenceEqual((other as CompositeType).ComposedProperties, 
-                new Utilities.EqualityComparer<Property>((a, b) => 
-                    a.Name == b.Name && 
-                    a.ModelType.StructurallyEquals(b.ModelType) && 
-                    a.IsReadOnly == b.IsReadOnly && 
-                    a.IsConstant == b.IsConstant && 
-                    a.IsRequired == b.IsRequired));
-        }
-
+        
         [JsonIgnore]
         public override IEnumerable<IChild> Children => Properties;
 

--- a/src/core/AutoRest.Core/Model/DictionaryType.cs
+++ b/src/core/AutoRest.Core/Model/DictionaryType.cs
@@ -33,22 +33,5 @@ namespace AutoRest.Core.Model
         {
             // not needed, right?
         }
-
-        /// <summary>
-        /// Determines whether the specified model type is structurally equal to this object.
-        /// </summary>
-        /// <param name="other">The object to compare with this object.</param>
-        /// <returns>true if the specified object is functionally equal to this object; otherwise, false.</returns>
-        public override bool StructurallyEquals(IModelType other)
-        {
-            if (ReferenceEquals(other as DictionaryType, null))
-            {
-                return false;
-            }
-
-            return base.StructurallyEquals(other) && 
-                   ValueType.StructurallyEquals((other as DictionaryType).ValueType) &&
-                   SupportsAdditionalProperties == (other as DictionaryType).SupportsAdditionalProperties;
-        }
     }
 }

--- a/src/core/AutoRest.Core/Model/EnumType.cs
+++ b/src/core/AutoRest.Core/Model/EnumType.cs
@@ -80,8 +80,8 @@ namespace AutoRest.Core.Model
                 return false;
             }
 
-            return base.StructurallyEquals(other) && 
-                Values.OrderBy(t => t).SequenceEqual(Values.OrderBy(t => t)) &&
+            return Name == other.Name &&
+                Values.OrderBy(t => t).SequenceEqual((other as EnumType).Values.OrderBy(t => t), new Utilities.EqualityComparer<EnumValue>((a, b) => a.Name == b.Name)) &&
                 ModelAsString == (other as EnumType).ModelAsString;
         }
 

--- a/src/core/AutoRest.Core/Model/IModelType.cs
+++ b/src/core/AutoRest.Core/Model/IModelType.cs
@@ -142,8 +142,17 @@ namespace AutoRest.Core.Model
         /// <returns>true if the specified object is functionally equal to this object; otherwise, false.</returns>
         public virtual bool StructurallyEquals(IModelType other)
         {
-            var ta = JsonConvert.SerializeObject(this);
-            var tb = JsonConvert.SerializeObject(other);
+            if (ReferenceEquals(other, null))
+            {
+                return false;
+            }
+            if (ReferenceEquals(other, this))
+            {
+                return true;
+            }
+
+            var ta = JsonConvert.SerializeObject(this, CodeModelSettings.SerializerSettings);
+            var tb = JsonConvert.SerializeObject(other, CodeModelSettings.SerializerSettings);
             return ta == tb;
         }
 

--- a/src/core/AutoRest.Core/Model/IModelType.cs
+++ b/src/core/AutoRest.Core/Model/IModelType.cs
@@ -142,12 +142,9 @@ namespace AutoRest.Core.Model
         /// <returns>true if the specified object is functionally equal to this object; otherwise, false.</returns>
         public virtual bool StructurallyEquals(IModelType other)
         {
-            if (ReferenceEquals(other, null))
-            {
-                return false;
-            }
-
-            return GetType() == other.GetType() && Name.Equals(other.Name);
+            var ta = JsonConvert.SerializeObject(this);
+            var tb = JsonConvert.SerializeObject(other);
+            return ta == tb;
         }
 
         /// <summary>

--- a/src/core/AutoRest.Core/Model/PrimaryType.cs
+++ b/src/core/AutoRest.Core/Model/PrimaryType.cs
@@ -71,22 +71,5 @@ namespace AutoRest.Core.Model
         {
             // not needed, right?
         }
-
-        /// <summary>
-        /// Determines whether the specified model type is structurally equal to this object.
-        /// </summary>
-        /// <param name="other">The object to compare with this object.</param>
-        /// <returns>true if the specified object is functionally equal to this object; otherwise, false.</returns>
-        public override bool StructurallyEquals(IModelType other)
-        {
-            if (ReferenceEquals(other as PrimaryType, null))
-            {
-                return false;
-            }
-
-            return base.StructurallyEquals(other) && 
-                KnownPrimaryType == (other as PrimaryType).KnownPrimaryType &&
-                Format == (other as PrimaryType).Format;
-        }
     }
 }

--- a/src/core/AutoRest.Core/Model/Response.cs
+++ b/src/core/AutoRest.Core/Model/Response.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using AutoRest.Core.Utilities;
 using System.Collections.Generic;
 using System.Globalization;
 

--- a/src/core/AutoRest.Core/Model/Response.cs
+++ b/src/core/AutoRest.Core/Model/Response.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using AutoRest.Core.Utilities;
 using System.Collections.Generic;
 using System.Globalization;
 

--- a/src/core/AutoRest.Core/Model/SequenceType.cs
+++ b/src/core/AutoRest.Core/Model/SequenceType.cs
@@ -28,21 +28,5 @@ namespace AutoRest.Core.Model
         /// Gets or sets the element type of the collection.
         /// </summary>
         public virtual IModelType ElementType { get; set; }
-
-        /// <summary>
-        /// Determines whether the specified model type is structurally equal to this object.
-        /// </summary>
-        /// <param name="other">The object to compare with this object.</param>
-        /// <returns>true if the specified object is functionally equal to this object; otherwise, false.</returns>
-        public override bool StructurallyEquals(IModelType other)
-        {
-            if (ReferenceEquals(other as SequenceType, null))
-            {
-                return false;
-            }
-
-            return base.StructurallyEquals(other) && 
-                ElementType.StructurallyEquals((other as SequenceType).ElementType);
-        }
     }
 }

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Basic.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Basic.cs
@@ -23,10 +23,8 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
         /// Initializes a new instance of the Basic class.
         /// </summary>
         /// <param name="id">Basic Id</param>
-        /// <param name="name">Name property with a very
-        /// long description that
-        /// does not fit on a single line
-        /// and a line break.</param>
+        /// <param name="name">Name property with a very long description that
+        /// does not fit on a single line and a line break.</param>
         /// <param name="color">Possible values include: 'cyan', 'Magenta',
         /// 'YELLOW', 'blacK'</param>
         public Basic(int? id = default(int?), string name = default(string), string color = default(string))
@@ -43,10 +41,8 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
         public int? Id { get; set; }
 
         /// <summary>
-        /// Gets or sets name property with a very
-        /// long description that
-        /// does not fit on a single line
-        /// and a line break.
+        /// Gets or sets name property with a very long description that does
+        /// not fit on a single line and a line break.
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Basic.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Basic.cs
@@ -23,10 +23,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
         /// Initializes a new instance of the Basic class.
         /// </summary>
         /// <param name="id">Basic Id</param>
-        /// <param name="name">Name property with a very
-        /// long description that
-        /// does not fit on a single line
-        /// and a line break.</param>
+        /// <param name="name">Name property with a very long description that
+        /// does not fit on a single line and a line break.</param>
         /// <param name="color">Possible values include: 'cyan', 'Magenta',
         /// 'YELLOW', 'blacK'</param>
         public Basic(int? id = default(int?), string name = default(string), string color = default(string))
@@ -43,10 +41,8 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
         public int? Id { get; set; }
 
         /// <summary>
-        /// Gets or sets name property with a very
-        /// long description that
-        /// does not fit on a single line
-        /// and a line break.
+        /// Gets or sets name property with a very long description that does
+        /// not fit on a single line and a line break.
         /// </summary>
         [JsonProperty(PropertyName = "name")]
         public string Name { get; set; }

--- a/src/modeler/AutoRest.Swagger/SwaggerParser.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerParser.cs
@@ -51,7 +51,7 @@ namespace AutoRest.Swagger
             if (entityType == null && modelName == null)
             {
                 //first call to the recursive function. Hence we will process file references only.
-                references = currentDoc.SelectTokens("$..$ref").Where(p => !((string)p).StartsWith("#"));
+                references = currentDoc.SelectTokens("$..$ref").Where(p => !((string)p).StartsWith("#") && !((string)p).Contains("/example"));
             }
             else
             {


### PR DESCRIPTION
might be slower but
- is simpler
- fixes potential stack overflow exception on recursive types