### PR TITLE
new CompositeSwaggerModeller

### DIFF
--- a/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
+++ b/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
@@ -110,20 +110,37 @@ namespace AutoRest.Core.Parsing
                 }
 
                 // try merge objects otherwise
-                var aMember = a.Children[key] as YamlMappingNode;
-                var bMember = b.Children[key] as YamlMappingNode;
-                if (aMember == null || bMember == null)
+                var aMember = a.Children[key];
+                var bMember = b.Children[key];
+                if (aMember.Equals(bMember))
                 {
-                    throw new FormatException($"{subpath} has incomaptible types.");
+                    // objects identical
+                    result.Children.Add(key, aMember);
                 }
-                result.Children.Add(key, MergeYamlObjects(aMember, bMember, subpath));
+                else
+                {
+                    var aMemberMapping = a.Children[key] as YamlMappingNode;
+                    var bMemberMapping = b.Children[key] as YamlMappingNode;
+                    if (aMember == null || bMember == null)
+                    {
+                        throw new FormatException($"{subpath} has incomaptible types.");
+                    }
+                    result.Children.Add(key, MergeYamlObjects(aMemberMapping, bMemberMapping, subpath));
+                }
             }
             return result;
         }
 
         public static YamlMappingNode MergeWith(this YamlMappingNode self, YamlMappingNode other)
-        {
-            return MergeYamlObjects(self, other, ObjectPath.Empty);
-        }
+            => MergeYamlObjects(self, other, ObjectPath.Empty);
+
+        public static void Set(this YamlMappingNode self, string key, YamlNode value)
+            => self.Children[new YamlScalarNode(key)] = value;
+
+        public static YamlNode Get(this YamlMappingNode self, string key)
+            => self.Children[new YamlScalarNode(key)];
+
+        public static void Remove(this YamlMappingNode self, string key)
+            => self.Children.Remove(new YamlScalarNode(key));
     }
 }

--- a/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
+++ b/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
@@ -123,7 +123,7 @@ namespace AutoRest.Core.Parsing
                     var bMemberMapping = bMember as YamlMappingNode;
                     if (aMemberMapping == null || bMemberMapping == null)
                     {
-                        throw new FormatException($"{subpath.XPath} has incomaptible types.");
+                        throw new Exception($"{subpath.XPath} has incomaptible values ({aMember}, {bMember}).");
                     }
                     result.Children.Add(key, MergeYamlObjects(aMemberMapping, bMemberMapping, subpath));
                 }

--- a/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
+++ b/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
@@ -138,7 +138,7 @@ namespace AutoRest.Core.Parsing
             => self.Children[new YamlScalarNode(key)] = value;
 
         public static YamlNode Get(this YamlMappingNode self, string key)
-            => self.Children[new YamlScalarNode(key)];
+            => self.Children.ContainsKey(new YamlScalarNode(key)) ? self.Children[new YamlScalarNode(key)] : null;
 
         public static void Remove(this YamlMappingNode self, string key)
             => self.Children.Remove(new YamlScalarNode(key));

--- a/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
+++ b/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
@@ -119,11 +119,11 @@ namespace AutoRest.Core.Parsing
                 }
                 else
                 {
-                    var aMemberMapping = a.Children[key] as YamlMappingNode;
-                    var bMemberMapping = b.Children[key] as YamlMappingNode;
-                    if (aMember == null || bMember == null)
+                    var aMemberMapping = aMember as YamlMappingNode;
+                    var bMemberMapping = bMember as YamlMappingNode;
+                    if (aMemberMapping == null || bMemberMapping == null)
                     {
-                        throw new FormatException($"{subpath} has incomaptible types.");
+                        throw new FormatException($"{subpath.XPath} has incomaptible types.");
                     }
                     result.Children.Add(key, MergeYamlObjects(aMemberMapping, bMemberMapping, subpath));
                 }

--- a/src/modeler/AutoRest.CompositeSwagger.Tests/CompositeSwaggerModelerTests.cs
+++ b/src/modeler/AutoRest.CompositeSwagger.Tests/CompositeSwaggerModelerTests.cs
@@ -4,6 +4,8 @@ using AutoRest.Core;
 using AutoRest.Core.Logging;
 using Xunit;
 using static AutoRest.Core.Utilities.DependencyInjection;
+using System;
+
 namespace AutoRest.CompositeSwagger.Tests
 {
     [Collection("AutoRest Tests")]
@@ -86,7 +88,7 @@ namespace AutoRest.CompositeSwagger.Tests
                     Input = Path.Combine("Swagger", "composite-swagger-conflict-in-global-param.json")
                 };
                 Modeler modeler = new CompositeSwaggerModeler();
-                Assert.Throws<CodeGenerationException>(() => modeler.Build());
+                Assert.Throws<Exception>(() => modeler.Build());
             }
         }
 
@@ -101,7 +103,7 @@ namespace AutoRest.CompositeSwagger.Tests
                     Input = Path.Combine("Swagger", "composite-swagger-conflict-in-model.json")
                 };
                 Modeler modeler = new CompositeSwaggerModeler();
-                Assert.Throws<CodeGenerationException>(() => modeler.Build());
+                Assert.Throws<Exception>(() => modeler.Build());
             }
         }
 
@@ -116,7 +118,7 @@ namespace AutoRest.CompositeSwagger.Tests
                     Input = Path.Combine("Swagger", "composite-swagger-conflict-in-settings.json")
                 };
                 Modeler modeler = new CompositeSwaggerModeler();
-                Assert.Throws<CodeGenerationException>(() => modeler.Build());
+                Assert.Throws<Exception>(() => modeler.Build());
             }
         }
 

--- a/src/modeler/AutoRest.CompositeSwagger.Tests/Swagger/swagger-conflict-in-model.json
+++ b/src/modeler/AutoRest.CompositeSwagger.Tests/Swagger/swagger-conflict-in-model.json
@@ -56,7 +56,7 @@
         },
         "description": {
           "type": "string",
-          "description": "Description of product."
+          "description": "Description of the product."
         },
         "count": {
           "type": "number",

--- a/src/modeler/AutoRest.CompositeSwagger/CompositeSwaggerModeler.cs
+++ b/src/modeler/AutoRest.CompositeSwagger/CompositeSwaggerModeler.cs
@@ -65,10 +65,7 @@ namespace AutoRest.CompositeSwagger
 
             // construct merged swagger document
             var mergedSwagger = new YamlMappingNode();
-            mergedSwagger.Set("swagger", new YamlScalarNode("2.0"));
             mergedSwagger.Set("info", (Settings.FileSystem.ReadFileAsText(Settings.Input).ParseYaml() as YamlMappingNode)?.Get("info") as YamlMappingNode);
-            //mergedSwagger.Set("host", new YamlScalarNode("management.azure.com"));
-            mergedSwagger.Set("schemes", new YamlSequenceNode(new YamlScalarNode("https")));
 
             // merge child swaggers
             foreach (var childSwaggerPath in compositeSwaggerModel.Documents)
@@ -82,7 +79,9 @@ namespace AutoRest.CompositeSwagger
                 // remove info
                 var info = childSwagger.Get("info") as YamlMappingNode;
                 var version = info.Get("version");
-                childSwagger.Remove("info");
+                info.Remove("title");
+                info.Remove("description");
+                info.Remove("version");
 
                 // fix up api version
                 var apiVersionParam = (childSwagger.Get("parameters") as YamlMappingNode)?.Children?.FirstOrDefault(param => ((param.Value as YamlMappingNode)?.Get("name") as YamlScalarNode)?.Value == "api-version");
@@ -111,7 +110,7 @@ namespace AutoRest.CompositeSwagger
             }
             // remove apiVersion client property
             var mergedSwaggerApiVersionParam = (mergedSwagger.Get("parameters") as YamlMappingNode)?.Children?.FirstOrDefault(param => ((param.Value as YamlMappingNode)?.Get("name") as YamlScalarNode)?.Value == "api-version");
-            var mergedSwaggerApiVersionParamName = (mergedSwaggerApiVersionParam?.Key as YamlScalarNode).Value;
+            var mergedSwaggerApiVersionParamName = (mergedSwaggerApiVersionParam?.Key as YamlScalarNode)?.Value;
             if (mergedSwaggerApiVersionParamName != null)
             {
                 (mergedSwagger.Get("parameters") as YamlMappingNode).Remove(mergedSwaggerApiVersionParamName);

--- a/src/modeler/AutoRest.CompositeSwagger/CompositeSwaggerModeler.cs
+++ b/src/modeler/AutoRest.CompositeSwagger/CompositeSwaggerModeler.cs
@@ -120,7 +120,7 @@ namespace AutoRest.CompositeSwagger
             using (NewContext)
             {
                 var swaggerModeler = new SwaggerModeler();
-                return swaggerModeler.Build(SwaggerParser.Parse(mergedSwagger.Serialize()));
+                return swaggerModeler.Build(SwaggerParser.Parse(Settings.Input, mergedSwagger.Serialize()));
             }
         }
         

--- a/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
@@ -56,12 +56,11 @@ namespace AutoRest.Swagger
         /// Default protocol when no protocol is specified in the schema
         /// </summary>
         public TransferProtocolScheme DefaultProtocol { get; set; }
-        
+
         /// <summary>
         /// Builds service model from swagger file.
         /// </summary>
         /// <returns></returns>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
         public override CodeModel Build()
         {
             Logger.Instance.Log(Category.Info, Resources.ParsingSwagger);
@@ -69,8 +68,14 @@ namespace AutoRest.Swagger
             {
                 throw ErrorManager.CreateError(Resources.InputRequired);
             }
-            ServiceDefinition = SwaggerParser.Load(Settings.Input, Settings.FileSystem);
+            var serviceDefinition = SwaggerParser.Load(Settings.Input, Settings.FileSystem);
+            return Build(serviceDefinition);
+        }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Maintainability", "CA1506:AvoidExcessiveClassCoupling")]
+        public CodeModel Build(ServiceDefinition serviceDefinition)
+        {
+            ServiceDefinition = serviceDefinition;
             if (!Settings.SkipValidation)
             {
                 // Look for semantic errors and warnings in the document.

--- a/src/modeler/AutoRest.Swagger/SwaggerParser.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerParser.cs
@@ -110,18 +110,24 @@ namespace AutoRest.Swagger
             return;
         }
 
+        public static string Normalize(string swaggerDocument)
+        {
+            if (!swaggerDocument.IsYaml()) // try parse as markdown if it is not YAML
+            {
+                Logger.Instance.Log(Category.Info, "Parsing as literate Swagger");
+                swaggerDocument = new LiterateYamlParser().Parse(swaggerDocument, true);
+            }
+            // normalize YAML to JSON since that's what we process
+            swaggerDocument = swaggerDocument.EnsureYamlIsJson();
+            swaggerDocument = ResolveExternalReferencesInJson(swaggerDocument);
+            return swaggerDocument;
+        }
+
         public static ServiceDefinition Parse(string swaggerDocument)
         {
             try
             {
-                if (!swaggerDocument.IsYaml()) // try parse as markdown if it is not YAML
-                {
-                    Logger.Instance.Log(Category.Info, "Parsing as literate Swagger");
-                    swaggerDocument = new LiterateYamlParser().Parse(swaggerDocument, true);
-                }
-                // normalize YAML to JSON since that's what we process
-                swaggerDocument = swaggerDocument.EnsureYamlIsJson();
-                swaggerDocument = ResolveExternalReferencesInJson(swaggerDocument);
+                swaggerDocument = Normalize(swaggerDocument);
                 var settings = new JsonSerializerSettings
                 {
                     TypeNameHandling = TypeNameHandling.None,


### PR DESCRIPTION
- does not rely on merging `CodeModel`s => extreme speedup (~10x for `NetworkManagementClient`)
- paves the way for configuration-based AutoRest (i.e. CompositeSwagger 2.0)
- makes pipeline way cleaner (together with @amarzavery's external ref resolver, the modeler truely only ever processes one service definition, i.e. there is no more "gather" data flow)