### PR TITLE
[Linter Rules] M1005, M1006, M1007 & M1009

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -420,6 +420,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to &apos;GET&apos; operation must use method name &apos;Get&apos;, &apos;PUT&apos; operation must use method name &apos;Create&apos;, &apos;PATCH&apos; operation must use method name &apos;Update&apos; and &apos;DELETE&apos; operation must use method name &apos;Delete&apos;..
+        /// </summary>
+        public static string OperationNameNotValid {
+            get {
+                return ResourceManager.GetString("OperationNameNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Parameters &quot;subscriptionId&quot; and &quot;api-version&quot; are not allowed in the operations section.
         /// </summary>
         public static string OperationParametersNotAllowedMessage {

--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -420,7 +420,7 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to &apos;GET&apos; operation must use method name &apos;Get&apos;, &apos;PUT&apos; operation must use method name &apos;Create&apos;, &apos;PATCH&apos; operation must use method name &apos;Update&apos; and &apos;DELETE&apos; operation must use method name &apos;Delete&apos;..
+        ///    Looks up a localized string similar to &apos;GET&apos; operation must use method name &apos;Get&apos; or Method name start with &apos;List&apos;, &apos;PUT&apos; operation must use method name &apos;Create&apos;, &apos;PATCH&apos; operation must use method name &apos;Update&apos; and &apos;DELETE&apos; operation must use method name &apos;Delete&apos;..
         /// </summary>
         public static string OperationNameNotValid {
             get {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -273,4 +273,7 @@
   <data name="PathCannotBeNullOrEmpty" xml:space="preserve">
     <value>path cannot be null or an empty string or a string with white spaces while getting the parent directory</value>
   </data>
+  <data name="OperationNameNotValid" xml:space="preserve">
+    <value>'GET' operation must use method name 'Get', 'PUT' operation must use method name 'Create', 'PATCH' operation must use method name 'Update' and 'DELETE' operation must use method name 'Delete'.</value>
+  </data>
 </root>

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -274,6 +274,6 @@
     <value>path cannot be null or an empty string or a string with white spaces while getting the parent directory</value>
   </data>
   <data name="OperationNameNotValid" xml:space="preserve">
-    <value>'GET' operation must use method name 'Get', 'PUT' operation must use method name 'Create', 'PATCH' operation must use method name 'Update' and 'DELETE' operation must use method name 'Delete'.</value>
+    <value>'GET' operation must use method name 'Get' or Method name start with 'List', 'PUT' operation must use method name 'Create', 'PATCH' operation must use method name 'Update' and 'DELETE' operation must use method name 'Delete'.</value>
   </data>
 </root>

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/operation-name-not-valid.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/operation-name-not-valid.json
@@ -1,0 +1,85 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operation name not valid",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "get": {
+        "operationId": "Noun_NotNamedGet",
+        "summary": "Foo get path",
+        "description": "Foo operation",
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/foo1": {
+      "put": {
+        "operationId": "Noun_NotNamedCreate",
+        "summary": "Foo2 create path",
+        "description": "Foo2 operation",
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/foo2": {
+      "delete": {
+        "operationId": "Noun_NotNamedDelete",
+        "summary": "Foo2 delete path",
+        "description": "Foo2 operation",
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    },
+    "/foo3": {
+      "get": {
+        "operationId": "Noun_List",
+        "summary": "Foo3 path",
+        "description": "Foo3 list operation",
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/positive/clean-complex-spec.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/positive/clean-complex-spec.json
@@ -81,7 +81,7 @@
     "/pets/{petId}": {
       "get": {
         "summary": "Info for a specific pet",
-        "operationId": "showPetById",
+        "operationId": "getPetById",
         "description": "foo",
         "tags": [
           "pets"

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -242,6 +242,13 @@ namespace AutoRest.Swagger.Tests
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "pageable-no-200-response.json"));
             messages.Any(m => m.Type == typeof(PageableRequires200Response));
         }
+
+        [Fact]
+        public void OperationNameValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "operation-name-not-valid.json"));
+            messages.AssertOnlyValidationMessage(typeof(OperationNameValidation), 3);
+        }
     }
 
     #region Positive tests

--- a/src/modeler/AutoRest.Swagger/Model/Operation.cs
+++ b/src/modeler/AutoRest.Swagger/Model/Operation.cs
@@ -36,6 +36,7 @@ namespace AutoRest.Swagger.Model
         /// </summary>
         [Rule(typeof(OneUnderscoreInOperationId))]
         [Rule(typeof(OperationIdNounInVerb))]
+        [Rule(typeof(OperationNameValidation))]
         public string OperationId { get; set; }
 
         public string Summary

--- a/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
@@ -79,7 +79,6 @@ namespace AutoRest.Swagger.Model
         /// Key is actual path and the value is serializationProperty of http operations and operation objects.
         /// </summary>
         [Rule(typeof(UniqueResourcePaths))]
-        [CollectionRule(typeof(OperationNameValidation))]
         public Dictionary<string, Dictionary<string, Operation>> Paths { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
@@ -79,6 +79,7 @@ namespace AutoRest.Swagger.Model
         /// Key is actual path and the value is serializationProperty of http operations and operation objects.
         /// </summary>
         [Rule(typeof(UniqueResourcePaths))]
+        [CollectionRule(typeof(OperationNameValidation))]
         public Dictionary<string, Dictionary<string, Operation>> Paths { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
@@ -10,8 +10,10 @@ using AutoRest.Swagger.Model;
 
 namespace AutoRest.Swagger.Validation
 {
-    public class OperationNameValidation : TypedRule<Dictionary<string, Operation>>
+    public class OperationNameValidation : TypedRule<string>
     {
+        private const string NOUN_VERB_PATTERN = "^(\\w+)?_(\\w+)$";
+
         /// <summary>
         /// The template message for this Rule. 
         /// </summary>
@@ -41,44 +43,30 @@ namespace AutoRest.Swagger.Validation
         /// <remarks>
         /// Message will be shown at the path level.
         /// </remarks>
-        public override bool IsValid(Dictionary<string, Operation> operationDefinition)
+        public override bool IsValid(string entity, RuleContext context)
         {
-            bool areAllOperationNameValid = true;
-            foreach (KeyValuePair<string, Operation> entry in operationDefinition)
+            bool isOperationNameValid = true;
+            string httpVerb = context?.Parent?.Key;
+
+            if (httpVerb.Equals("GET", StringComparison.InvariantCultureIgnoreCase))
             {
-                bool isOperationNameValid = true;
-                string httpVerb = entry.Key;
-                string operationId = entry.Value.OperationId;
-
-                if (httpVerb.Equals("GET", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    isOperationNameValid = operationId.EndsWith("_Get") || operationId.Contains("_List");
-                }
-                else if (httpVerb.Equals("PUT", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    isOperationNameValid = operationId.EndsWith("_Create");
-                }
-                else if (httpVerb.Equals("PATCH", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    isOperationNameValid = operationId.EndsWith("_Update");
-                }
-                else if (httpVerb.Equals("DELETE", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    isOperationNameValid = operationId.EndsWith("_Delete");
-                }
-                else
-                {
-                    continue;
-                }
-
-                // If any of the operation name under the path is invalid, then areAllOperationNameValid is false
-                if (!isOperationNameValid && areAllOperationNameValid)
-                {
-                    areAllOperationNameValid = isOperationNameValid;
-                }
+                isOperationNameValid = (entity.Contains("_") && (entity.EndsWith("_Get") || entity.Contains("_List"))) || 
+                    (entity.StartsWith("get") || entity.StartsWith("list"));
+            }
+            else if (httpVerb.Equals("PUT", StringComparison.InvariantCultureIgnoreCase))
+            {
+                isOperationNameValid = (entity.Contains("_") && entity.EndsWith("_Create")) || entity.StartsWith("create");
+            }
+            else if (httpVerb.Equals("PATCH", StringComparison.InvariantCultureIgnoreCase))
+            {
+                isOperationNameValid = (entity.Contains("_") && entity.EndsWith("_Update")) || entity.StartsWith("update");
+            }
+            else if (httpVerb.Equals("DELETE", StringComparison.InvariantCultureIgnoreCase))
+            {
+                isOperationNameValid = (entity.Contains("_") && entity.EndsWith("_Delete")) || entity.StartsWith("update");
             }
 
-            return areAllOperationNameValid;
+            return isOperationNameValid;
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
@@ -23,13 +23,24 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
+        /// <remarks>
+        /// This rule corresponds to M1005, M1006, M1007 & M1009.
+        /// </remarks>
         public override Category Severity => Category.Warning;
 
         /// <summary>
-        /// An <paramref name="operationDefinition"/> fails this rule if it does not have the correct HTTP Verb.
+        /// This rule passes if the operation id of HTTP Method confirms to M1005, M1006, M1007 & M1009.
+        ///   e.g. For Get method User_Get or User_List
+        ///     or For Put method User_Create
+        ///     or For Patch method User_Update
+        ///     or For Delete method User_Delete
+        ///     are valid names.
         /// </summary>
-        /// <param name="operationDefinition">Operation Definition to validate</param>
-        /// <returns></returns>
+        /// <param name="operationDefinition">Dictionary of the path and respective operations.</param>
+        /// <returns><c>true</c> if operation name confimes to above rules, otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// Message will be shown at the path level.
+        /// </remarks>
         public override bool IsValid(Dictionary<string, Operation> operationDefinition)
         {
             bool areAllOperationNameValid = true;

--- a/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
@@ -1,0 +1,73 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using AutoRest.Core.Logging;
+using AutoRest.Core.Properties;
+using AutoRest.Core.Validation;
+using AutoRest.Swagger.Model;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class OperationNameValidation : TypedRule<Dictionary<string, Operation>>
+    {
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.OperationNameNotValid;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Warning;
+
+        /// <summary>
+        /// An <paramref name="operationDefinition"/> fails this rule if it does not have the correct HTTP Verb.
+        /// </summary>
+        /// <param name="operationDefinition">Operation Definition to validate</param>
+        /// <returns></returns>
+        public override bool IsValid(Dictionary<string, Operation> operationDefinition)
+        {
+            bool areAllOperationNameValid = true;
+            foreach (KeyValuePair<string, Operation> entry in operationDefinition)
+            {
+                bool isOperationNameValid = true;
+                string httpVerb = entry.Key;
+                string operationId = entry.Value.OperationId;
+
+                if (httpVerb.Equals("GET", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    isOperationNameValid = operationId.EndsWith("_Get") || operationId.Contains("_List");
+                }
+                else if (httpVerb.Equals("PUT", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    isOperationNameValid = operationId.EndsWith("_Create");
+                }
+                else if (httpVerb.Equals("PATCH", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    isOperationNameValid = operationId.EndsWith("_Update");
+                }
+                else if (httpVerb.Equals("DELETE", StringComparison.InvariantCultureIgnoreCase))
+                {
+                    isOperationNameValid = operationId.EndsWith("_Delete");
+                }
+                else
+                {
+                    continue;
+                }
+
+                // If any of the operation name under the path is invalid, then areAllOperationNameValid is false
+                if (!isOperationNameValid && areAllOperationNameValid)
+                {
+                    areAllOperationNameValid = isOperationNameValid;
+                }
+            }
+
+            return areAllOperationNameValid;
+        }
+    }
+}


### PR DESCRIPTION
[swagger-checklist.md#naming---swagger-checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#naming---swagger-checklist)

Rules Implemented: `M1005`, `M1006`, `M1007` & `M1009`

Enhanced Rule `M1005` by PR [849](https://github.com/Azure/azure-rest-api-specs/pull/849)

@sarangan12 & @amarzavery Please review as you get a chance. Thanks! 