### PR TITLE
[linter Rules] Swagger rules M2005 - long running operation must have valid terminal status codes

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -312,6 +312,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to An operation with x-ms-long-running-operation extension must have a valid terminal success status code. 200 or 201 for Put/Patch. 200, 201 or 204 for Post. 200 or 204 or both for Delete..
+        /// </summary>
+        public static string LongRunningResponseNotValid {
+            get {
+                return ResourceManager.GetString("LongRunningResponseNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Consider adding a &apos;description&apos; element, essential for maintaining reference documentation..
         /// </summary>
         public static string MissingDescription {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -275,5 +275,7 @@
   </data>
   <data name="OperationNameNotValid" xml:space="preserve">
     <value>'GET' operation must use method name 'Get' or Method name start with 'List', 'PUT' operation must use method name 'Create', 'PATCH' operation must use method name 'Update' and 'DELETE' operation must use method name 'Delete'.</value>
+  <data name="LongRunningResponseNotValid" xml:space="preserve">
+    <value>An operation with x-ms-long-running-operation extension must have a valid terminal success status code. 200 or 201 for Put/Patch. 200, 201 or 204 for Post. 200 or 204 or both for Delete.</value>
   </data>
 </root>

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -275,6 +275,7 @@
   </data>
   <data name="OperationNameNotValid" xml:space="preserve">
     <value>'GET' operation must use method name 'Get' or Method name start with 'List', 'PUT' operation must use method name 'Create', 'PATCH' operation must use method name 'Update' and 'DELETE' operation must use method name 'Delete'.</value>
+  </data>
   <data name="LongRunningResponseNotValid" xml:space="preserve">
     <value>An operation with x-ms-long-running-operation extension must have a valid terminal success status code. 200 or 201 for Put/Patch. 200, 201 or 204 for Post. 200 or 204 or both for Delete.</value>
   </data>

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/long-running-invalid-response-delete.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/long-running-invalid-response-delete.json
@@ -1,0 +1,50 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "LongRunningResponseForDeleteValidation",
+    "description": "The 200 or 204 response code is not modeled for a long running delete operation",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "delete": {
+        "operationId": "Foo_Delete",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "x-ms-long-running-operation": true,
+        "responses": {
+          "202": {
+            "description": "Accepted."
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/long-running-invalid-response-post.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/long-running-invalid-response-post.json
@@ -1,0 +1,50 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "LongRunningResponseForPostValidation",
+    "description": "The 200, 201 or 204 response code is not modeled for a long running post operation",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "post": {
+        "operationId": "Foo_Post",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "x-ms-long-running-operation": true,
+        "responses": {
+          "202": {
+            "description": "Accepted."
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/long-running-invalid-response-put.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/long-running-invalid-response-put.json
@@ -1,0 +1,50 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "LongRunningResponseForPutValidation",
+    "description": "The 200 or 201 response code is not modeled for a long running put operation",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "put": {
+        "operationId": "Foo_Create",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "x-ms-long-running-operation": true,
+        "responses": {
+          "202": {
+            "description": "Accepted."
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/positive/long-running-valid-response.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/positive/long-running-valid-response.json
@@ -1,0 +1,95 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "LongRunningValidResponse",
+    "description": "long running put operations' responses are modeled correctly with aleast one successful terminal code",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "put": {
+        "operationId": "Foo_Create",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "x-ms-long-running-operation": true,
+        "responses": {
+          "200": {
+            "description": "OK.",
+            "schema": {
+              "$ref": "#/definitions/StorageAccount"
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "Foo_Post",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "x-ms-long-running-operation": true,
+        "responses": {
+          "201": {
+            "description": "Created."
+          }
+        }
+      },
+      "delete": {
+        "operationId": "Foo_Delete",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "x-ms-long-running-operation": true,
+        "responses": {
+          "204": {
+            "description": "No Content."
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "StorageAccount": {
+      "properties": {
+        "kind": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Gets the Kind.",
+          "enum": [
+            "Storage",
+            "BlobStorage"
+          ],
+          "x-ms-enum": {
+            "name": "Kind",
+            "modelAsString": false
+          }
+        }
+      },
+      "description": "The storage account."
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -9,7 +9,6 @@ using System.Collections.Generic;
 using AutoRest.Core.Validation;
 using AutoRest.Core.Logging;
 using AutoRest.Core;
-using AutoRest.Core.Utilities.Collections;
 using AutoRest.Swagger.Validation;
 using static AutoRest.Core.Utilities.DependencyInjection;
 
@@ -248,6 +247,27 @@ namespace AutoRest.Swagger.Tests
         {
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "operation-name-not-valid.json"));
             messages.AssertOnlyValidationMessage(typeof(OperationNameValidation), 3);
+        }
+
+        [Fact]
+        public void LongRunningResponseForPutValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "long-running-invalid-response-put.json"));
+            messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation));
+        }
+
+        [Fact]
+        public void LongRunningResponseForPostValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "long-running-invalid-response-post.json"));
+            messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation));
+        }
+
+        [Fact]
+        public void LongRunningResponseForDeleteValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "long-running-invalid-response-delete.json"));
+            messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation));
         }
     }
 

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -304,6 +304,16 @@ namespace AutoRest.Swagger.Tests
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "positive", "pageable-nextlink-defined-allof.json"));
             Assert.Empty(messages.Where(m => m.Severity >= Category.Warning));
         }
+
+        /// <summary>
+        /// Verifies that a x-ms-long-running extension response modeled correctly
+        /// </summary>
+        [Fact]
+        public void LongRunningResponseDefined()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "positive", "long-running-valid-response.json"));
+            messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation), 0);
+        }
     }
 
     #endregion

--- a/src/modeler/AutoRest.Swagger/Model/SwaggerBase.cs
+++ b/src/modeler/AutoRest.Swagger/Model/SwaggerBase.cs
@@ -24,6 +24,7 @@ namespace AutoRest.Swagger.Model
         [CollectionRule(typeof(NonEmptyClientName))]
         [CollectionRule(typeof(NextLinkPropertyMustExist))]
         [CollectionRule(typeof(PageableRequires200Response))]
+        [CollectionRule(typeof(LongRunningResponseValidation))]
         public Dictionary<string, object> Extensions { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
@@ -1,0 +1,131 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using AutoRest.Core.Logging;
+using AutoRest.Core.Validation;
+using AutoRest.Swagger.Model;
+
+namespace AutoRest.Swagger.Validation
+{
+    public abstract class LongRunningExtensionRule : ExtensionRule
+    {
+        protected override string ExtensionName => "x-ms-long-running-operation";
+
+        protected static bool IsValidResponseCodes(RuleContext context)
+        {
+            Dictionary<string, OperationResponse> responses = context?.GetFirstAncestor<Operation>()?.Responses;
+            var method = context?.Parent?.Parent?.Key;
+            var resolver = new SchemaResolver(context?.GetServiceDefinition());
+
+            if (method == null)
+            {
+                return false;
+            }
+
+            bool isPutPatchResponseCodesValid = true;
+            bool isPostResponseCodesValid = true;
+            bool isDeleteResponseCodesValid = true;
+
+            switch (method.ToLower())
+            {
+                case "put":
+                case "patch":
+                    isPutPatchResponseCodesValid = IsPutPatchResponseCodesValid(responses, resolver);
+                    break;
+                case "post":
+                    isPostResponseCodesValid = IsPostResponseCodesValid(responses, resolver);
+                    break;
+                case "delete":
+                    isDeleteResponseCodesValid = IsDeleteResponseCodesValid(responses, resolver);
+                    break;
+                default:
+                    break;
+
+            }
+
+            return isPutPatchResponseCodesValid && isPostResponseCodesValid && isDeleteResponseCodesValid;
+        }
+
+        public abstract override string MessageTemplate { get; }
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public abstract override Category Severity { get; }
+
+        /// <summary>
+        /// Validate that Put or Patch long running operations must have valid terminal status code 200 or 201.
+        /// </summary>
+        /// <param name="responses">Dictionary of responses for the operation.</param>
+        /// <param name="resolver">The schema reolver.</param>
+        /// <returns><c>true</c> if at least one valid terminal status code availabe, otherwise <c>false</c>.</returns>
+        private static bool IsPutPatchResponseCodesValid(Dictionary<string, OperationResponse> responses, SchemaResolver resolver)
+        {
+            OperationResponse response200 = responses?.GetValueOrNull("200");
+            OperationResponse response201 = responses?.GetValueOrNull("201");
+
+            if (response200 == null && response201 == null)
+            {
+                return false;
+            }
+
+            if (resolver.Unwrap(response200.Schema) == null && resolver.Unwrap(response201.Schema) == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Validate that Post long running operations must have valid terminal status code 200, 201 or 204.
+        /// </summary>
+        /// <param name="responses">Dictionary of responses for the operation.</param>
+        /// <param name="resolver">The schema reolver.</param>
+        /// <returns><c>true</c> if at least one valid terminal status code availabe, otherwise <c>false</c>.</returns>
+        private static bool IsPostResponseCodesValid(Dictionary<string, OperationResponse> responses, SchemaResolver resolver)
+        {
+            if (!IsPutPatchResponseCodesValid(responses, resolver))
+            {
+                OperationResponse response204 = responses?.GetValueOrNull("204");
+
+                if (response204 == null)
+                {
+                    return false;
+                }
+
+                if (resolver.Unwrap(response204.Schema) == null)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Validate that Delete long running operations must have valid terminal status code 200 or 204.
+        /// </summary>
+        /// <param name="responses">Dictionary of responses for the operation.</param>
+        /// <param name="resolver">The schema reolver.</param>
+        /// <returns><c>true</c> if at least one valid terminal status code availabe, otherwise <c>false</c>.</returns>
+        private static bool IsDeleteResponseCodesValid(Dictionary<string, OperationResponse> responses, SchemaResolver resolver)
+        {
+            OperationResponse response200 = responses?.GetValueOrNull("200");
+            OperationResponse response204 = responses?.GetValueOrNull("204");
+
+            if (response200 == null && response204 == null)
+            {
+                return false;
+            }
+
+            if (resolver.Unwrap(response200.Schema) == null && resolver.Unwrap(response204.Schema) == null)
+            {
+                return false;
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
@@ -70,7 +70,7 @@ namespace AutoRest.Swagger.Validation
                 return false;
             }
 
-            if (resolver.Unwrap(response200.Schema) == null && resolver.Unwrap(response201.Schema) == null)
+            if (resolver.Unwrap(response200?.Schema) == null && resolver.Unwrap(response201?.Schema) == null)
             {
                 return false;
             }
@@ -120,7 +120,7 @@ namespace AutoRest.Swagger.Validation
                 return false;
             }
 
-            if (resolver.Unwrap(response200.Schema) == null && resolver.Unwrap(response204.Schema) == null)
+            if (resolver.Unwrap(response200?.Schema) == null && resolver.Unwrap(response204?.Schema) == null)
             {
                 return false;
             }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
@@ -16,7 +16,6 @@ namespace AutoRest.Swagger.Validation
         {
             Dictionary<string, OperationResponse> responses = context?.GetFirstAncestor<Operation>()?.Responses;
             var method = context?.Parent?.Parent?.Key;
-            var resolver = new SchemaResolver(context?.GetServiceDefinition());
 
             if (method == null)
             {
@@ -31,13 +30,13 @@ namespace AutoRest.Swagger.Validation
             {
                 case "put":
                 case "patch":
-                    isPutPatchResponseCodesValid = IsPutPatchResponseCodesValid(responses, resolver);
+                    isPutPatchResponseCodesValid = IsPutPatchResponseCodesValid(responses);
                     break;
                 case "post":
-                    isPostResponseCodesValid = IsPostResponseCodesValid(responses, resolver);
+                    isPostResponseCodesValid = IsPostResponseCodesValid(responses);
                     break;
                 case "delete":
-                    isDeleteResponseCodesValid = IsDeleteResponseCodesValid(responses, resolver);
+                    isDeleteResponseCodesValid = IsDeleteResponseCodesValid(responses);
                     break;
                 default:
                     break;
@@ -58,9 +57,8 @@ namespace AutoRest.Swagger.Validation
         /// Validate that Put or Patch long running operations must have valid terminal status code 200 or 201.
         /// </summary>
         /// <param name="responses">Dictionary of responses for the operation.</param>
-        /// <param name="resolver">The schema reolver.</param>
         /// <returns><c>true</c> if at least one valid terminal status code availabe, otherwise <c>false</c>.</returns>
-        private static bool IsPutPatchResponseCodesValid(Dictionary<string, OperationResponse> responses, SchemaResolver resolver)
+        private static bool IsPutPatchResponseCodesValid(Dictionary<string, OperationResponse> responses)
         {
             OperationResponse response200 = responses?.GetValueOrNull("200");
             OperationResponse response201 = responses?.GetValueOrNull("201");
@@ -70,7 +68,7 @@ namespace AutoRest.Swagger.Validation
                 return false;
             }
 
-            if (resolver.Unwrap(response200?.Schema) == null && resolver.Unwrap(response201?.Schema) == null)
+            if (response200 == null && response201 == null)
             {
                 return false;
             }
@@ -82,20 +80,14 @@ namespace AutoRest.Swagger.Validation
         /// Validate that Post long running operations must have valid terminal status code 200, 201 or 204.
         /// </summary>
         /// <param name="responses">Dictionary of responses for the operation.</param>
-        /// <param name="resolver">The schema reolver.</param>
         /// <returns><c>true</c> if at least one valid terminal status code availabe, otherwise <c>false</c>.</returns>
-        private static bool IsPostResponseCodesValid(Dictionary<string, OperationResponse> responses, SchemaResolver resolver)
+        private static bool IsPostResponseCodesValid(Dictionary<string, OperationResponse> responses)
         {
-            if (!IsPutPatchResponseCodesValid(responses, resolver))
+            if (!IsPutPatchResponseCodesValid(responses))
             {
                 OperationResponse response204 = responses?.GetValueOrNull("204");
 
                 if (response204 == null)
-                {
-                    return false;
-                }
-
-                if (resolver.Unwrap(response204.Schema) == null)
                 {
                     return false;
                 }
@@ -108,9 +100,8 @@ namespace AutoRest.Swagger.Validation
         /// Validate that Delete long running operations must have valid terminal status code 200 or 204.
         /// </summary>
         /// <param name="responses">Dictionary of responses for the operation.</param>
-        /// <param name="resolver">The schema reolver.</param>
         /// <returns><c>true</c> if at least one valid terminal status code availabe, otherwise <c>false</c>.</returns>
-        private static bool IsDeleteResponseCodesValid(Dictionary<string, OperationResponse> responses, SchemaResolver resolver)
+        private static bool IsDeleteResponseCodesValid(Dictionary<string, OperationResponse> responses)
         {
             OperationResponse response200 = responses?.GetValueOrNull("200");
             OperationResponse response204 = responses?.GetValueOrNull("204");
@@ -120,7 +111,7 @@ namespace AutoRest.Swagger.Validation
                 return false;
             }
 
-            if (resolver.Unwrap(response200?.Schema) == null && resolver.Unwrap(response204?.Schema) == null)
+            if (response200 == null && response204 == null)
             {
                 return false;
             }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningExtensionRule.cs
@@ -40,7 +40,6 @@ namespace AutoRest.Swagger.Validation
                     break;
                 default:
                     break;
-
             }
 
             return isPutPatchResponseCodesValid && isPostResponseCodesValid && isDeleteResponseCodesValid;

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningResponseValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningResponseValidation.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using AutoRest.Core.Validation;
+using AutoRest.Core.Properties;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class LongRunningResponseValidation : LongRunningExtensionRule
+    {
+        /// <summary>
+        /// An x-ms-long-running-operation extension passes this rule if the operation that this extension has a valid response defined.
+        /// </summary>
+        /// <param name="longRunning">long running extension object.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns><c>true</c> if operation has valid response code modeled, otherwise <c>false</c>.</returns>
+        /// <remarks>This rule corresponds to M2005.</remarks>
+        public override bool IsValid(object longRunning, RuleContext context) => IsValidResponseCodes(context);
+
+        /// <summary>
+        /// The template message for this Rule.
+        /// </summary>
+        public override string MessageTemplate => Resources.LongRunningResponseNotValid;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Warning;
+    }
+}


### PR DESCRIPTION
[swagger-checklist.md#naming---swagger-checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#naming---swagger-checklist)

Rule Implemented: M2005

@sarangan12 & @amarzavery Please review as you get a chance. Thanks!