### PR TITLE
validation suppressions

### DIFF
--- a/src/core/AutoRest.Core/Validation/Suppression.cs
+++ b/src/core/AutoRest.Core/Validation/Suppression.cs
@@ -1,0 +1,25 @@
+﻿using AutoRest.Core.Logging;
+using Newtonsoft.Json;
+
+namespace AutoRest.Core.Validation
+{
+    public class Suppression
+    {
+        [JsonProperty("what", Required=Required.Always)]
+        public string ID { get; set; }
+
+        [JsonProperty("why", Required = Required.Always)]
+        public string Reason { get; set; }
+
+        [JsonProperty("where", Required = Required.Always)]
+        public string Path { get; set; }
+
+        public bool Matches(LogMessage message)
+        {
+            var validationMessage = message as ValidationMessage;
+            return validationMessage != null
+                && validationMessage.Type.Name == ID
+                && validationMessage.Path.XPath == Path;
+        }
+    }
+}


### PR DESCRIPTION
Just a simple way to suppress printing validation messages to the console.
Usage: Add a file called `<input Swagger file>.suppressions` with content like
```
- what: UniqueResourcePaths
  why: I don't care about that
  where: "#/Paths"
- what: NonAppJsonTypeWarning
  why: I don't care about that either
  where: "#/SomewhereElse"
```
(meant to be replaced by *the configuration file* as soon as it exists - maybe this will influence the format used in there)