### PR TITLE
[Linter Rules] M2008 for x-ms-mutability extension

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -294,6 +294,24 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to When property is modeled as &quot;readOnly&quot;: true then x-ms-mutability extension can only have &quot;read&quot; value. When property is modeled as &quot;readOnly&quot;: false then applying x-ms-mutability extension with only &quot;read&quot; value is not allowed. Extension contains invalid values: &apos;{0}&apos;..
+        /// </summary>
+        public static string InvalidMutabilityValueForReadOnly {
+            get {
+                return ResourceManager.GetString("InvalidMutabilityValueForReadOnly", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Valid values for an x-ms-mutability extension are &apos;create&apos;, &apos;read&apos; and &apos;update&apos;. Applied extension contains invalid value(s): &apos;{0}&apos;..
+        /// </summary>
+        public static string InvalidMutabilityValues {
+            get {
+                return ResourceManager.GetString("InvalidMutabilityValues", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Only body parameters can have a schema defined..
         /// </summary>
         public static string InvalidSchemaParameter {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -279,4 +279,10 @@
   <data name="LongRunningResponseNotValid" xml:space="preserve">
     <value>An operation with x-ms-long-running-operation extension must have a valid terminal success status code. 200 or 201 for Put/Patch. 200, 201 or 204 for Post. 200 or 204 or both for Delete.</value>
   </data>
+  <data name="InvalidMutabilityValues" xml:space="preserve">
+    <value>Valid values for an x-ms-mutability extension are 'create', 'read' and 'update'. Applied extension contains invalid value(s): '{0}'.</value>
+  </data>
+  <data name="InvalidMutabilityValueForReadOnly" xml:space="preserve">
+    <value>When property is modeled as "readOnly": true then x-ms-mutability extension can only have "read" value. When property is modeled as "readOnly": false then applying x-ms-mutability extension with only "read" value is not allowed. Extension contains invalid values: '{0}'.</value>
+  </data>
 </root>

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/mutability-invalid-values-for-readonly.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/mutability-invalid-values-for-readonly.json
@@ -1,0 +1,97 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Mutability extension used with invalid values when modeled with readonly.",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "post": {
+        "operationId": "Noun_Verb",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "parameters": [
+          {
+            "name": "foo1",
+            "description": "Name of the domain.",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource Model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id",
+          "x-ms-mutability": [ "read" ]
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name",
+          "x-ms-mutability": [ "create", "read" ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Resource type",
+          "x-ms-mutability": [ "read" ]
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location",
+          "x-ms-mutability": [ "create", "read" ]
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags",
+          "x-ms-mutability": [ "create", "read", "update" ]
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/mutability-invalid-values.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Swagger/Validation/mutability-invalid-values.json
@@ -1,0 +1,86 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Mutability extension used with invalid values.",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "post": {
+        "operationId": "Noun_Verb",
+        "summary": "Foo path",
+        "description": "Foo operation",
+        "parameters": [
+          {
+            "name": "foo1",
+            "description": "Name of the domain.",
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "default": {
+            "description": "Unexpected error"
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Resource": {
+      "description": "The Resource Model definition.",
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id",
+          "x-ms-mutability": [ "readWrite" ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Resource name",
+          "x-ms-mutability": [ "read", "create", "update", "delete" ]
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags",
+          "x-ms-mutability": [ "create", "read", "update" ]
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "x-ms-azure-resource": true
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -243,6 +243,7 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
+<<<<<<< 4ba43929de05245bff3b39037de802bc1dd3c3b0
         public void OperationNameValidation()
         {
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "operation-name-not-valid.json"));
@@ -268,6 +269,20 @@ namespace AutoRest.Swagger.Tests
         {
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "long-running-invalid-response-delete.json"));
             messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation));
+        }
+
+        [Fact]
+        public void MutabilityNotModeledValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "mutability-invalid-values.json"));
+            messages.AssertOnlyValidationMessage(typeof(MutabilityValidValuesRule), 2);
+        }
+
+        [Fact]
+        public void MutabilityNotModeledWithReadOnlyValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "mutability-invalid-values-for-readonly.json"));
+            messages.AssertOnlyValidationMessage(typeof(MutabilityWithReadOnlyRule), 2);
         }
     }
 

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -243,7 +243,6 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-<<<<<<< 4ba43929de05245bff3b39037de802bc1dd3c3b0
         public void OperationNameValidation()
         {
             var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "operation-name-not-valid.json"));

--- a/src/modeler/AutoRest.Swagger/Model/SwaggerBase.cs
+++ b/src/modeler/AutoRest.Swagger/Model/SwaggerBase.cs
@@ -25,6 +25,8 @@ namespace AutoRest.Swagger.Model
         [CollectionRule(typeof(NextLinkPropertyMustExist))]
         [CollectionRule(typeof(PageableRequires200Response))]
         [CollectionRule(typeof(LongRunningResponseValidation))]
+        [CollectionRule(typeof(MutabilityValidValuesRule))]
+        [CollectionRule(typeof(MutabilityWithReadOnlyRule))]
         public Dictionary<string, object> Extensions { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityExtensionRule.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using AutoRest.Core.Validation;
+using AutoRest.Swagger.Model;
+using System.Collections.Generic;
+
+namespace AutoRest.Swagger.Validation
+{
+    public abstract class MutabilityExtensionRule : ExtensionRule
+    {
+        protected override string ExtensionName => "x-ms-mutability";
+
+        protected static Schema Get200ResponseSchema(RuleContext context)
+        {
+            OperationResponse response = context?.GetFirstAncestor<Operation>()?.Responses?.GetValueOrNull("200");
+            if (response == null)
+            {
+                return null;
+            }
+            var resolver = new SchemaResolver(context?.GetServiceDefinition());
+            return resolver.Unwrap(response.Schema);
+        }
+
+        public abstract override string MessageTemplate { get; }
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public abstract override Category Severity { get; }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityValidValuesRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityValidValuesRule.cs
@@ -1,0 +1,58 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using AutoRest.Core.Logging;
+using AutoRest.Core.Properties;
+using AutoRest.Core.Validation;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class MutabilityValidValuesRule : MutabilityExtensionRule
+    {
+        /// <summary>
+        /// Array of valid values for x-ms-mutability extension.
+        /// </summary>
+        protected readonly string[] ValidValues = { "create", "read", "update" };
+
+        /// <summary>
+        /// An x-ms-mutability extension passes this rule if it has only valid possible values.
+        /// </summary>
+        /// <param name="mutable">mutability extension object.</param>
+        /// <param name="context">Rule context.</param>
+        /// <param name="formatParameters">array of invalid parameters to be returned.</param>
+        /// <returns><c>true</c> if all values for x-ms-mutability are valid, otherwise <c>false</c>.</returns>
+        /// <remarks>This rule corresponds to M2006.</remarks>
+        public override bool IsValid(object mutable, RuleContext context, out object[] formatParameters) => ValidateMutabilityValues(mutable, context, out formatParameters);
+
+        /// <summary>
+        /// The template message for this Rule.
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.InvalidMutabilityValues;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Warning;
+
+        /// <summary>
+        /// Verify that mutability values are valid.
+        /// </summary>
+        /// <param name="mutable">mutability extension object.</param>
+        /// <param name="context">Rule context.</param>
+        /// <param name="formatParameters">array of invalid parameters to be returned.</param>
+        /// <returns><c>true</c> if all values for x-ms-mutability are valid, otherwise <c>false</c>.</returns>
+        private bool ValidateMutabilityValues(object mutable, RuleContext context, out object[] formatParameters)
+        {
+            string[] values = ((Newtonsoft.Json.Linq.JArray)mutable).ToObject<string[]>();
+            string[] invalidValues = values.Except(ValidValues, StringComparer.OrdinalIgnoreCase).ToArray();
+            formatParameters = invalidValues.Length == 0 ? new object[0] : new string[] { String.Join(",", invalidValues) };
+
+            return invalidValues.Length == 0;
+        }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityWithReadOnlyRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityWithReadOnlyRule.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using AutoRest.Core.Logging;
+using AutoRest.Core.Properties;
+using AutoRest.Core.Validation;
+using AutoRest.Swagger.Model;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class MutabilityWithReadOnlyRule : MutabilityValidValuesRule
+    {
+        /// <summary>
+        /// Array of valid values for x-ms-mutability extension when property is marked as "readonly": true.
+        /// </summary>
+        protected readonly string[] ValidValuesForReadOnlyProperty = { "read" };
+
+        /// <summary>
+        /// An x-ms-mutability extension passes this rule if it has only valid possible values in context of Read Only property.
+        /// </summary>
+        /// <param name="mutable">mutability extension object.</param>
+        /// <param name="context">Rule context.</param>
+        /// <param name="formatParameters">array of invalid parameters to be returned.</param>
+        /// <returns><c>true</c> if all values for x-ms-mutability are valid in context of Read Only property, otherwise <c>false</c>.</returns>
+        /// <remarks>This rule corresponds to M2006.</remarks>
+        public override bool IsValid(object mutable, RuleContext context, out object[] formatParameters) => 
+            ValidateMutabilityValuesWithReadOnlyProperty(mutable, context, out formatParameters);
+
+        /// <summary>
+        /// The template message for this Rule.
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.InvalidMutabilityValueForReadOnly;
+
+        /// <summary>
+        /// Verify that mutability values are valid in context of Read Only property.
+        /// </summary>
+        /// <param name="mutable">mutability extension object.</param>
+        /// <param name="context">Rule context.</param>
+        /// <param name="formatParameters">array of invalid parameters to be returned.</param>
+        /// <returns><c>true</c> if all values for x-ms-mutability are valid in context of Read Only property, otherwise <c>false</c>.</returns>
+        private bool ValidateMutabilityValuesWithReadOnlyProperty(object mutable, RuleContext context, out object[] formatParameters)
+        {
+            string[] values = ((Newtonsoft.Json.Linq.JArray)mutable).ToObject<string[]>();
+            string[] invalidValues = null;
+
+            var resolver = new SchemaResolver(context?.GetServiceDefinition());
+            Schema schema = resolver.Unwrap(context?.GetFirstAncestor<Schema>());
+
+            if (schema.ReadOnly)
+            {
+                // Property with "readOnly": true must only have "read" value in x-ms-mutability extension.
+                invalidValues = values.Except(ValidValuesForReadOnlyProperty, StringComparer.OrdinalIgnoreCase).ToArray();
+            }
+            else
+            {
+                // Property with "readOnly": false must have more than "read" value in x-ms-mutability extension.
+                if (values.Length == 1)
+                {
+                    invalidValues = values.Contains(ValidValuesForReadOnlyProperty[0], StringComparer.OrdinalIgnoreCase) ? 
+                        ValidValuesForReadOnlyProperty : new string[0];
+                }
+            }
+
+            bool isValid = invalidValues == null || invalidValues.Length == 0;
+            formatParameters = isValid ? new object[0] : new string[] { String.Join(",", invalidValues) };
+
+            return isValid;
+        }
+    }
+}


### PR DESCRIPTION
[swagger-checklist.md#naming---swagger-checklist](https://github.com/Azure/azure-rest-api-specs/blob/master/documentation/swagger-checklist.md#naming---swagger-checklist)

Rules Implemented: `M2008`

@sarangan12 & @amarzavery Please review as you get a chance. Thanks! 