### PR TITLE
Code to generate SubResource Models

### DIFF
--- a/src/generator/AutoRest.Ruby.Azure/CodeGeneratorRba.cs
+++ b/src/generator/AutoRest.Ruby.Azure/CodeGeneratorRba.cs
@@ -62,7 +62,7 @@ namespace AutoRest.Ruby.Azure
             {
                 if ((model.Extensions.ContainsKey(AzureExtensions.ExternalExtension) &&
                     (bool)model.Extensions[AzureExtensions.ExternalExtension])
-                    || model.Name == "Resource" || model.Name == "SubResource")
+                    || model.Name == "Resource")
                 {
                     continue;
                 }

--- a/src/generator/AutoRest.Ruby.Azure/Model/CompositeTypeRba.cs
+++ b/src/generator/AutoRest.Ruby.Azure/Model/CompositeTypeRba.cs
@@ -42,7 +42,10 @@ namespace AutoRest.Ruby.Azure.Model
                 if (this.BaseModelType.Extensions.ContainsKey(AzureExtensions.ExternalExtension) ||
                     this.BaseModelType.Extensions.ContainsKey(AzureExtensions.AzureResourceExtension))
                 {
-                    typeName = "MsRestAzure::" + typeName;
+                    if (!typeName.Equals("SubResource"))
+                    {
+                        typeName = "MsRestAzure::" + typeName;
+                    }
                 }
 
                 return " < " + typeName;

--- a/src/generator/AutoRest.Ruby.Azure/Model/RequirementsRba.cs
+++ b/src/generator/AutoRest.Ruby.Azure/Model/RequirementsRba.cs
@@ -22,7 +22,7 @@ namespace AutoRest.Ruby.Azure.Model
         {
             return (model.Extensions.ContainsKey(AzureExtensions.ExternalExtension) && 
                     (bool) model.Extensions[AzureExtensions.ExternalExtension]) 
-                    || model.Name == "Resource" || model.Name == "SubResource";
+                    || model.Name == "Resource";
         }
 
         /// <summary>


### PR DESCRIPTION
Related to https://github.com/Azure/azure-sdk-for-ruby/issues/659 

Ran gulp regenerate:expected:samples, gulp regenerate:expected:samples:azure, regenerate:expected:ruby, regenerate:expected:rubyazure. No changes.  

@salameer @veronicagg @vishrutshah @devigned  Please review.

