### PR TITLE
Remove Azure extensions configuration from __init__ in Python

### DIFF
--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
@@ -25,39 +25,23 @@ class AutoRestDurationTestServiceConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'https://localhost'
 
-        super(AutoRestDurationTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestDurationTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestdurationtestservice/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestDurationTestService(object):
@@ -72,24 +56,13 @@ class AutoRestDurationTestService(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestDurationTestServiceConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestDurationTestServiceConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/autorestparametergroupingtestservice/auto_rest_parameter_grouping_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/autorestparametergroupingtestservice/auto_rest_parameter_grouping_test_service.py
@@ -25,39 +25,23 @@ class AutoRestParameterGroupingTestServiceConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'https://localhost'
 
-        super(AutoRestParameterGroupingTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestParameterGroupingTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestparametergroupingtestservice/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestParameterGroupingTestService(object):
@@ -72,24 +56,13 @@ class AutoRestParameterGroupingTestService(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestParameterGroupingTestServiceConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestParameterGroupingTestServiceConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureReport/autorestreportserviceforazure/auto_rest_report_service_for_azure.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureReport/autorestreportserviceforazure/auto_rest_report_service_for_azure.py
@@ -26,39 +26,23 @@ class AutoRestReportServiceForAzureConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestReportServiceForAzureConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestReportServiceForAzureConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestreportserviceforazure/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestReportServiceForAzure(object):
@@ -70,24 +54,13 @@ class AutoRestReportServiceForAzure(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestReportServiceForAzureConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestReportServiceForAzureConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureReport/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureReport/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureResource/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureResource/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
@@ -26,39 +26,23 @@ class AutoRestResourceFlatteningTestServiceConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestResourceFlatteningTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestResourceFlatteningTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestresourceflatteningtestservice/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestResourceFlatteningTestService(object):
@@ -70,24 +54,13 @@ class AutoRestResourceFlatteningTestService(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestResourceFlatteningTestServiceConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestResourceFlatteningTestServiceConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureResource/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureResource/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/auto_rest_azure_special_parameters_test_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/auto_rest_azure_special_parameters_test_client.py
@@ -38,22 +38,11 @@ class AutoRestAzureSpecialParametersTestClientConfiguration(AzureConfiguration):
     :param api_version: The api version, which appears in the query, the value
      is always '2015-07-01-preview'
     :type api_version: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-07-01-preview', accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, subscription_id, api_version='2015-07-01-preview', base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -63,12 +52,10 @@ class AutoRestAzureSpecialParametersTestClientConfiguration(AzureConfiguration):
             raise TypeError("Parameter 'subscription_id' must be str.")
         if api_version is not None and not isinstance(api_version, str):
             raise TypeError("Optional parameter 'api_version' must be str.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestAzureSpecialParametersTestClientConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestAzureSpecialParametersTestClientConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestazurespecialparameterstestclient/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
@@ -76,9 +63,6 @@ class AutoRestAzureSpecialParametersTestClientConfiguration(AzureConfiguration):
         self.credentials = credentials
         self.subscription_id = subscription_id
         self.api_version = api_version
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestAzureSpecialParametersTestClient(object):
@@ -113,24 +97,13 @@ class AutoRestAzureSpecialParametersTestClient(object):
     :param api_version: The api version, which appears in the query, the value
      is always '2015-07-01-preview'
     :type api_version: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-07-01-preview', accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, subscription_id, api_version='2015-07-01-preview', base_url=None):
 
-        self.config = AutoRestAzureSpecialParametersTestClientConfiguration(credentials, subscription_id, api_version, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestAzureSpecialParametersTestClientConfiguration(credentials, subscription_id, api_version, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/setup.py
@@ -22,7 +22,7 @@ VERSION = "2015-07-01-preview"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
@@ -28,21 +28,10 @@ class AutoRestParameterizedHostTestClientConfiguration(AzureConfiguration):
     :param host: A string value that is used as a global part of the
      parameterized host
     :type host: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, host, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, filepath=None):
+            self, credentials, host):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -50,20 +39,15 @@ class AutoRestParameterizedHostTestClientConfiguration(AzureConfiguration):
             raise ValueError("Parameter 'host' must not be None.")
         if not isinstance(host, str):
             raise TypeError("Parameter 'host' must be str.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         base_url = 'http://{accountName}{host}'
 
-        super(AutoRestParameterizedHostTestClientConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestParameterizedHostTestClientConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestparameterizedhosttestclient/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
         self.host = host
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestParameterizedHostTestClient(object):
@@ -81,23 +65,12 @@ class AutoRestParameterizedHostTestClient(object):
     :param host: A string value that is used as a global part of the
      parameterized host
     :type host: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, host, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, filepath=None):
+            self, credentials, host):
 
-        self.config = AutoRestParameterizedHostTestClientConfiguration(credentials, host, accept_language, long_running_operation_retry_timeout, generate_client_request_id, filepath)
+        self.config = AutoRestParameterizedHostTestClientConfiguration(credentials, host)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/autorestheadtestservice/auto_rest_head_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/autorestheadtestservice/auto_rest_head_test_service.py
@@ -24,39 +24,23 @@ class AutoRestHeadTestServiceConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestHeadTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestHeadTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestheadtestservice/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestHeadTestService(object):
@@ -71,24 +55,13 @@ class AutoRestHeadTestService(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestHeadTestServiceConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestHeadTestServiceConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/autorestheadexceptiontestservice/auto_rest_head_exception_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/autorestheadexceptiontestservice/auto_rest_head_exception_test_service.py
@@ -24,39 +24,23 @@ class AutoRestHeadExceptionTestServiceConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestHeadExceptionTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestHeadExceptionTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestheadexceptiontestservice/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestHeadExceptionTestService(object):
@@ -71,24 +55,13 @@ class AutoRestHeadExceptionTestService(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestHeadExceptionTestServiceConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestHeadExceptionTestServiceConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/autorestlongrunningoperationtestservice/auto_rest_long_running_operation_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/autorestlongrunningoperationtestservice/auto_rest_long_running_operation_test_service.py
@@ -28,39 +28,23 @@ class AutoRestLongRunningOperationTestServiceConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestLongRunningOperationTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestLongRunningOperationTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestlongrunningoperationtestservice/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestLongRunningOperationTestService(object):
@@ -81,24 +65,13 @@ class AutoRestLongRunningOperationTestService(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestLongRunningOperationTestServiceConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestLongRunningOperationTestServiceConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/autorestpagingtestservice/auto_rest_paging_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/autorestpagingtestservice/auto_rest_paging_test_service.py
@@ -25,39 +25,23 @@ class AutoRestPagingTestServiceConfiguration(AzureConfiguration):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestPagingTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestPagingTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestpagingtestservice/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
 
         self.credentials = credentials
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class AutoRestPagingTestService(object):
@@ -72,24 +56,13 @@ class AutoRestPagingTestService(object):
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials
      object<msrestazure.azure_active_directory>`
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, base_url=None):
 
-        self.config = AutoRestPagingTestServiceConfiguration(credentials, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = AutoRestPagingTestServiceConfiguration(credentials, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/setup.py
@@ -22,7 +22,7 @@ VERSION = "1.0.0"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/setup.py
@@ -22,7 +22,7 @@ VERSION = "2015-05-01-preview"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/storage_management_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/storage_management_client.py
@@ -32,22 +32,11 @@ class StorageManagementClientConfiguration(AzureConfiguration):
     :type subscription_id: str
     :param api_version: Client Api Version.
     :type api_version: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-05-01-preview', accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, subscription_id, api_version='2015-05-01-preview', base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -57,12 +46,10 @@ class StorageManagementClientConfiguration(AzureConfiguration):
             raise TypeError("Parameter 'subscription_id' must be str.")
         if api_version is not None and not isinstance(api_version, str):
             raise TypeError("Optional parameter 'api_version' must be str.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'https://management.azure.com'
 
-        super(StorageManagementClientConfiguration, self).__init__(base_url, filepath)
+        super(StorageManagementClientConfiguration, self).__init__(base_url)
 
         self.add_user_agent('storagemanagementclient/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
@@ -70,9 +57,6 @@ class StorageManagementClientConfiguration(AzureConfiguration):
         self.credentials = credentials
         self.subscription_id = subscription_id
         self.api_version = api_version
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class StorageManagementClient(object):
@@ -95,24 +79,13 @@ class StorageManagementClient(object):
     :type subscription_id: str
     :param api_version: Client Api Version.
     :type api_version: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-05-01-preview', accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, subscription_id, api_version='2015-05-01-preview', base_url=None):
 
-        self.config = StorageManagementClientConfiguration(credentials, subscription_id, api_version, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = StorageManagementClientConfiguration(credentials, subscription_id, api_version, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftazuretesturl/microsoft_azure_test_url.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftazuretesturl/microsoft_azure_test_url.py
@@ -29,22 +29,11 @@ class MicrosoftAzureTestUrlConfiguration(AzureConfiguration):
     :type subscription_id: str
     :param api_version: API Version with value '2014-04-01-preview'.
     :type api_version: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2014-04-01-preview', accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, subscription_id, api_version='2014-04-01-preview', base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -54,12 +43,10 @@ class MicrosoftAzureTestUrlConfiguration(AzureConfiguration):
             raise TypeError("Parameter 'subscription_id' must be str.")
         if api_version is not None and not isinstance(api_version, str):
             raise TypeError("Optional parameter 'api_version' must be str.")
-        if accept_language is not None and not isinstance(accept_language, str):
-            raise TypeError("Optional parameter 'accept_language' must be str.")
         if not base_url:
             base_url = 'https://management.azure.com/'
 
-        super(MicrosoftAzureTestUrlConfiguration, self).__init__(base_url, filepath)
+        super(MicrosoftAzureTestUrlConfiguration, self).__init__(base_url)
 
         self.add_user_agent('microsoftazuretesturl/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
@@ -67,9 +54,6 @@ class MicrosoftAzureTestUrlConfiguration(AzureConfiguration):
         self.credentials = credentials
         self.subscription_id = subscription_id
         self.api_version = api_version
-        self.accept_language = accept_language
-        self.long_running_operation_retry_timeout = long_running_operation_retry_timeout
-        self.generate_client_request_id = generate_client_request_id
 
 
 class MicrosoftAzureTestUrl(object):
@@ -88,24 +72,13 @@ class MicrosoftAzureTestUrl(object):
     :type subscription_id: str
     :param api_version: API Version with value '2014-04-01-preview'.
     :type api_version: str
-    :param accept_language: Gets or sets the preferred language for the
-     response.
-    :type accept_language: str
-    :param long_running_operation_retry_timeout: Gets or sets the retry
-     timeout in seconds for Long Running Operations. Default value is 30.
-    :type long_running_operation_retry_timeout: int
-    :param generate_client_request_id: When set to true a unique
-     x-ms-client-request-id value is generated and included in each request.
-     Default is true.
-    :type generate_client_request_id: bool
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2014-04-01-preview', accept_language='en-US', long_running_operation_retry_timeout=30, generate_client_request_id=True, base_url=None, filepath=None):
+            self, credentials, subscription_id, api_version='2014-04-01-preview', base_url=None):
 
-        self.config = MicrosoftAzureTestUrlConfiguration(credentials, subscription_id, api_version, accept_language, long_running_operation_retry_timeout, generate_client_request_id, base_url, filepath)
+        self.config = MicrosoftAzureTestUrlConfiguration(credentials, subscription_id, api_version, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/setup.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/setup.py
@@ -22,7 +22,7 @@ VERSION = "2014-04-01-preview"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["msrest>=0.4.0", "msrestazure>=0.4.0"]
+REQUIRES = ["msrestazure>=0.4.7"]
 
 setup(
     name=NAME,

--- a/src/generator/AutoRest.Python.Azure.Tests/requirements.txt
+++ b/src/generator/AutoRest.Python.Azure.Tests/requirements.txt
@@ -1,2 +1,2 @@
 requests==2.10.0
-msrestazure==0.4.3
+msrestazure==0.4.7

--- a/src/generator/AutoRest.Python.Azure/CodeGeneratorPya.cs
+++ b/src/generator/AutoRest.Python.Azure/CodeGeneratorPya.cs
@@ -17,7 +17,7 @@ namespace AutoRest.Python.Azure
 {
     public class CodeGeneratorPya : CodeGeneratorPy
     {
-        private const string ClientRuntimePackage = "msrestazure version 0.4.0";
+        private const string ClientRuntimePackage = "msrestazure version 0.4.7";
 
         public override string UsageInstructions => string.Format(CultureInfo.InvariantCulture,
             Resources.UsageInformation, ClientRuntimePackage);

--- a/src/generator/AutoRest.Python.Azure/Model/CodeModelPya.cs
+++ b/src/generator/AutoRest.Python.Azure/Model/CodeModelPya.cs
@@ -69,7 +69,7 @@ namespace AutoRest.Python.Azure.Model
             }
         }
 
-        public override string SetupRequires => "\"msrest>=0.4.0\", \"msrestazure>=0.4.0\"";
+        public override string SetupRequires => "\"msrestazure>=0.4.7\"";
 
         public override bool NeedsExtraImport => true;
 

--- a/src/generator/AutoRest.Python.Azure/Model/CodeModelPya.cs
+++ b/src/generator/AutoRest.Python.Azure/Model/CodeModelPya.cs
@@ -63,7 +63,7 @@ namespace AutoRest.Python.Azure.Model
                 var param = string.Join(", ", requireParams);
                 if (!string.IsNullOrEmpty(param))
                 {
-                    param += ", ";
+                    param = ", " + param;
                 }
                 return param;
             }

--- a/src/generator/AutoRest.Python.Azure/Templates/AzureServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Python.Azure/Templates/AzureServiceClientTemplate.cshtml
@@ -65,11 +65,10 @@ class @(Model.Name)Configuration(AzureConfiguration):
 { 
 @:    :param str base_url: Service URL
 }
-    :param str filepath: Existing config
     """
 @EmptyLine
     def __init__(
-            self, @(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : "base_url=None, ")filepath=None):
+            self@(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : ", base_url=None")):
 @EmptyLine
         @Model.ValidateRequiredParameters
 
@@ -84,7 +83,7 @@ else
 }
 
 @EmptyLine
-        super(@(Model.Name)Configuration, self).__init__(base_url, filepath)
+        super(@(Model.Name)Configuration, self).__init__(base_url)
 @EmptyLine
         self.add_user_agent('@Model.UserAgent/{}'.format(VERSION))
         self.add_user_agent('Azure-SDK-For-Python')
@@ -127,13 +126,12 @@ class @(Model.Name)(object):
 {
 @:    :param str base_url: Service URL
 }
-    :param str filepath: Existing config
     """
 @EmptyLine
     def __init__(
-            self, @(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : "base_url=None, ")filepath=None):
+            self@(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : ", base_url=None")):
 @EmptyLine
-        self.config = @(Model.Name)Configuration(@(Model.ConfigConstructorParameters)@(Model.IsCustomBaseUri ? "" : "base_url, ")filepath)
+        self.config = @(Model.Name)Configuration(@(Model.ConfigConstructorParameters))
         self._client = ServiceClient(@(Settings.AddCredentials ? "self.config.credentials" : PythonConstants.None), self.config)
 @EmptyLine
 @if (Model.ModelTemplateModels.Any(each => !each.Extensions.ContainsKey(AzureExtensions.ExternalExtension)))

--- a/src/generator/AutoRest.Python.Azure/TransformerPya.cs
+++ b/src/generator/AutoRest.Python.Azure/TransformerPya.cs
@@ -32,7 +32,7 @@ namespace AutoRest.Python.Azure
             AzureExtensions.ParseODataExtension(codeModel);
             SwaggerExtensions.FlattenModels(codeModel);
             ParameterGroupExtensionHelper.AddParameterGroups(codeModel);
-            AzureExtensions.AddAzureProperties(codeModel);
+            AddAzureProperties(codeModel);
             AzureExtensions.SetDefaultResponses(codeModel);
             CorrectFilterParameters(codeModel);
 
@@ -233,6 +233,29 @@ namespace AutoRest.Python.Azure
                 {
                     filterParameter.ModelType = New<PrimaryType>(KnownPrimaryType.String);
                 }
+            }
+        }
+
+        /// <summary>
+        /// Creates azure specific properties.
+        /// </summary>
+        /// <param name="codeModelient"></param>
+        private static void AddAzureProperties(CodeModel codeModel)
+        {
+            var acceptLanguage = codeModel.Properties
+                .FirstOrDefault(p => AzureExtensions.AcceptLanguage.EqualsIgnoreCase(p.SerializedName));
+
+            AzureExtensions.AddAzureProperties(codeModel);
+            codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "long_running_operation_retry_timeout"));
+            codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "generate_client_request_id"));
+            codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "accept_language"));
+
+            if (acceptLanguage != null) // && acceptLanguage.DefaultValue != "en-US"
+            {
+                acceptLanguage.IsReadOnly = true;
+                acceptLanguage.IsRequired = false;
+                acceptLanguage.ModelType = New<PrimaryType>(KnownPrimaryType.String);
+                codeModel.Add(acceptLanguage);
             }
         }
     }

--- a/src/generator/AutoRest.Python.Azure/TransformerPya.cs
+++ b/src/generator/AutoRest.Python.Azure/TransformerPya.cs
@@ -119,10 +119,6 @@ namespace AutoRest.Python.Azure
                 }
             }
 
-            if (!ignoreNextLink && !findNextLink)
-            {
-                throw new KeyNotFoundException($"Couldn't find the nextLink property specified by extension on operation {methodName} and property {body.SerializedName}");
-            }
             if (!findItem)
             {
                 throw new KeyNotFoundException("Couldn't find the item property specified by extension");

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyArray/autorestswaggerbatarrayservice/auto_rest_swagger_bat_array_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyArray/autorestswaggerbatarrayservice/auto_rest_swagger_bat_array_service.py
@@ -22,16 +22,15 @@ class AutoRestSwaggerBATArrayServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestSwaggerBATArrayServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestSwaggerBATArrayServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestswaggerbatarrayservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestSwaggerBATArrayService(object):
     :vartype array: .operations.ArrayOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestSwaggerBATArrayServiceConfiguration(base_url, filepath)
+        self.config = AutoRestSwaggerBATArrayServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyBoolean/autorestbooltestservice/auto_rest_bool_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyBoolean/autorestbooltestservice/auto_rest_bool_test_service.py
@@ -22,16 +22,15 @@ class AutoRestBoolTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestBoolTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestBoolTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestbooltestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestBoolTestService(object):
     :vartype bool_model: .operations.BoolModelOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestBoolTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestBoolTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyByte/autorestswaggerbatbyteservice/auto_rest_swagger_bat_byte_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyByte/autorestswaggerbatbyteservice/auto_rest_swagger_bat_byte_service.py
@@ -22,16 +22,15 @@ class AutoRestSwaggerBATByteServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestSwaggerBATByteServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestSwaggerBATByteServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestswaggerbatbyteservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestSwaggerBATByteService(object):
     :vartype byte: .operations.ByteOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestSwaggerBATByteServiceConfiguration(base_url, filepath)
+        self.config = AutoRestSwaggerBATByteServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/autorestcomplextestservice/auto_rest_complex_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/autorestcomplextestservice/auto_rest_complex_test_service.py
@@ -31,16 +31,15 @@ class AutoRestComplexTestServiceConfiguration(Configuration):
     :ivar api_version: API ID.
     :type api_version: str
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestComplexTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestComplexTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestcomplextestservice/{}'.format(VERSION))
 
@@ -71,13 +70,12 @@ class AutoRestComplexTestService(object):
     :vartype readonlyproperty: .operations.ReadonlypropertyOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestComplexTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestComplexTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDate/autorestdatetestservice/auto_rest_date_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDate/autorestdatetestservice/auto_rest_date_test_service.py
@@ -22,16 +22,15 @@ class AutoRestDateTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'https://localhost'
 
-        super(AutoRestDateTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestDateTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestdatetestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestDateTestService(object):
     :vartype date_model: .operations.DateModelOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestDateTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestDateTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTime/autorestdatetimetestservice/auto_rest_date_time_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTime/autorestdatetimetestservice/auto_rest_date_time_test_service.py
@@ -22,16 +22,15 @@ class AutoRestDateTimeTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'https://localhost'
 
-        super(AutoRestDateTimeTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestDateTimeTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestdatetimetestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestDateTimeTestService(object):
     :vartype datetime_model: .operations.DatetimeModelOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestDateTimeTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestDateTimeTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/autorestrfc1123datetimetestservice/auto_rest_rfc1123_date_time_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/autorestrfc1123datetimetestservice/auto_rest_rfc1123_date_time_test_service.py
@@ -22,16 +22,15 @@ class AutoRestRFC1123DateTimeTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'https://localhost'
 
-        super(AutoRestRFC1123DateTimeTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestRFC1123DateTimeTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestrfc1123datetimetestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestRFC1123DateTimeTestService(object):
     :vartype datetimerfc1123: .operations.Datetimerfc1123Operations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestRFC1123DateTimeTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestRFC1123DateTimeTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDictionary/autorestswaggerbatdictionaryservice/auto_rest_swagger_ba_tdictionary_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDictionary/autorestswaggerbatdictionaryservice/auto_rest_swagger_ba_tdictionary_service.py
@@ -22,16 +22,15 @@ class AutoRestSwaggerBATdictionaryServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestSwaggerBATdictionaryServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestSwaggerBATdictionaryServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestswaggerbatdictionaryservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestSwaggerBATdictionaryService(object):
     :vartype dictionary: .operations.DictionaryOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestSwaggerBATdictionaryServiceConfiguration(base_url, filepath)
+        self.config = AutoRestSwaggerBATdictionaryServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
@@ -22,16 +22,15 @@ class AutoRestDurationTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'https://localhost'
 
-        super(AutoRestDurationTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestDurationTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestdurationtestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestDurationTestService(object):
     :vartype duration: .operations.DurationOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestDurationTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestDurationTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFile/autorestswaggerbatfileservice/auto_rest_swagger_bat_file_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFile/autorestswaggerbatfileservice/auto_rest_swagger_bat_file_service.py
@@ -22,16 +22,15 @@ class AutoRestSwaggerBATFileServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestSwaggerBATFileServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestSwaggerBATFileServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestswaggerbatfileservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestSwaggerBATFileService(object):
     :vartype files: .operations.FilesOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestSwaggerBATFileServiceConfiguration(base_url, filepath)
+        self.config = AutoRestSwaggerBATFileServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFormData/autorestswaggerbatformdataservice/auto_rest_swagger_bat_form_data_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFormData/autorestswaggerbatformdataservice/auto_rest_swagger_bat_form_data_service.py
@@ -22,16 +22,15 @@ class AutoRestSwaggerBATFormDataServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestSwaggerBATFormDataServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestSwaggerBATFormDataServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestswaggerbatformdataservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestSwaggerBATFormDataService(object):
     :vartype formdata: .operations.FormdataOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestSwaggerBATFormDataServiceConfiguration(base_url, filepath)
+        self.config = AutoRestSwaggerBATFormDataServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyInteger/autorestintegertestservice/auto_rest_integer_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyInteger/autorestintegertestservice/auto_rest_integer_test_service.py
@@ -22,16 +22,15 @@ class AutoRestIntegerTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestIntegerTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestIntegerTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestintegertestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestIntegerTestService(object):
     :vartype int_model: .operations.IntModelOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestIntegerTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestIntegerTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyNumber/autorestnumbertestservice/auto_rest_number_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyNumber/autorestnumbertestservice/auto_rest_number_test_service.py
@@ -22,16 +22,15 @@ class AutoRestNumberTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'https://localhost'
 
-        super(AutoRestNumberTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestNumberTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestnumbertestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestNumberTestService(object):
     :vartype number: .operations.NumberOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestNumberTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestNumberTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyString/autorestswaggerbatservice/auto_rest_swagger_bat_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyString/autorestswaggerbatservice/auto_rest_swagger_bat_service.py
@@ -23,16 +23,15 @@ class AutoRestSwaggerBATServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestSwaggerBATServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestSwaggerBATServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestswaggerbatservice/{}'.format(VERSION))
 
@@ -49,13 +48,12 @@ class AutoRestSwaggerBATService(object):
     :vartype enum: .operations.EnumOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestSwaggerBATServiceConfiguration(base_url, filepath)
+        self.config = AutoRestSwaggerBATServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
@@ -24,11 +24,10 @@ class AutoRestParameterizedHostTestClientConfiguration(Configuration):
     :param host: A string value that is used as a global part of the
      parameterized host
     :type host: str
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, host, filepath=None):
+            self, host):
 
         if host is None:
             raise ValueError("Parameter 'host' must not be None.")
@@ -36,7 +35,7 @@ class AutoRestParameterizedHostTestClientConfiguration(Configuration):
             raise TypeError("Parameter 'host' must be str.")
         base_url = 'http://{accountName}{host}'
 
-        super(AutoRestParameterizedHostTestClientConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestParameterizedHostTestClientConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestparameterizedhosttestclient/{}'.format(VERSION))
 
@@ -55,13 +54,12 @@ class AutoRestParameterizedHostTestClient(object):
     :param host: A string value that is used as a global part of the
      parameterized host
     :type host: str
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, host, filepath=None):
+            self, host):
 
-        self.config = AutoRestParameterizedHostTestClientConfiguration(host, filepath)
+        self.config = AutoRestParameterizedHostTestClientConfiguration(host)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autorestparameterizedcustomhosttestclient/auto_rest_parameterized_custom_host_test_client.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autorestparameterizedcustomhosttestclient/auto_rest_parameterized_custom_host_test_client.py
@@ -26,11 +26,10 @@ class AutoRestParameterizedCustomHostTestClientConfiguration(Configuration):
     :param dns_suffix: A string value that is used as a global part of the
      parameterized host. Default value 'host'.
     :type dns_suffix: str
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, subscription_id, dns_suffix, filepath=None):
+            self, subscription_id, dns_suffix):
 
         if subscription_id is None:
             raise ValueError("Parameter 'subscription_id' must not be None.")
@@ -42,7 +41,7 @@ class AutoRestParameterizedCustomHostTestClientConfiguration(Configuration):
             raise TypeError("Parameter 'dns_suffix' must be str.")
         base_url = '{vault}{secret}{dnsSuffix}'
 
-        super(AutoRestParameterizedCustomHostTestClientConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestParameterizedCustomHostTestClientConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestparameterizedcustomhosttestclient/{}'.format(VERSION))
 
@@ -64,13 +63,12 @@ class AutoRestParameterizedCustomHostTestClient(object):
     :param dns_suffix: A string value that is used as a global part of the
      parameterized host. Default value 'host'.
     :type dns_suffix: str
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, subscription_id, dns_suffix, filepath=None):
+            self, subscription_id, dns_suffix):
 
-        self.config = AutoRestParameterizedCustomHostTestClientConfiguration(subscription_id, dns_suffix, filepath)
+        self.config = AutoRestParameterizedCustomHostTestClientConfiguration(subscription_id, dns_suffix)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Header/autorestswaggerbatheaderservice/auto_rest_swagger_bat_header_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Header/autorestswaggerbatheaderservice/auto_rest_swagger_bat_header_service.py
@@ -22,16 +22,15 @@ class AutoRestSwaggerBATHeaderServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestSwaggerBATHeaderServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestSwaggerBATHeaderServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestswaggerbatheaderservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestSwaggerBATHeaderService(object):
     :vartype header: .operations.HeaderOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestSwaggerBATHeaderServiceConfiguration(base_url, filepath)
+        self.config = AutoRestSwaggerBATHeaderServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Http/autoresthttpinfrastructuretestservice/auto_rest_http_infrastructure_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Http/autoresthttpinfrastructuretestservice/auto_rest_http_infrastructure_test_service.py
@@ -29,16 +29,15 @@ class AutoRestHttpInfrastructureTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestHttpInfrastructureTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestHttpInfrastructureTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autoresthttpinfrastructuretestservice/{}'.format(VERSION))
 
@@ -65,13 +64,12 @@ class AutoRestHttpInfrastructureTestService(object):
     :vartype multiple_responses: .operations.MultipleResponsesOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestHttpInfrastructureTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestHttpInfrastructureTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ModelFlattening/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ModelFlattening/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
@@ -22,16 +22,15 @@ class AutoRestResourceFlatteningTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestResourceFlatteningTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestResourceFlatteningTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestresourceflatteningtestservice/{}'.format(VERSION))
 
@@ -43,13 +42,12 @@ class AutoRestResourceFlatteningTestService(object):
     :vartype config: AutoRestResourceFlatteningTestServiceConfiguration
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestResourceFlatteningTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestResourceFlatteningTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ParameterFlattening/autorestparameterflattening/auto_rest_parameter_flattening.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ParameterFlattening/autorestparameterflattening/auto_rest_parameter_flattening.py
@@ -23,16 +23,15 @@ class AutoRestParameterFlatteningConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestParameterFlatteningConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestParameterFlatteningConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestparameterflattening/{}'.format(VERSION))
 
@@ -47,13 +46,12 @@ class AutoRestParameterFlattening(object):
     :vartype availability_sets: .operations.AvailabilitySetsOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestParameterFlatteningConfiguration(base_url, filepath)
+        self.config = AutoRestParameterFlatteningConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Report/autorestreportservice/auto_rest_report_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Report/autorestreportservice/auto_rest_report_service.py
@@ -22,16 +22,15 @@ class AutoRestReportServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestReportServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestReportServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestreportservice/{}'.format(VERSION))
 
@@ -43,13 +42,12 @@ class AutoRestReportService(object):
     :vartype config: AutoRestReportServiceConfiguration
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestReportServiceConfiguration(base_url, filepath)
+        self.config = AutoRestReportServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/RequiredOptional/autorestrequiredoptionaltestservice/auto_rest_required_optional_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/RequiredOptional/autorestrequiredoptionaltestservice/auto_rest_required_optional_test_service.py
@@ -29,11 +29,10 @@ class AutoRestRequiredOptionalTestServiceConfiguration(Configuration):
     :param optional_global_query: number of items to skip
     :type optional_global_query: int
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, required_global_path, required_global_query, optional_global_query=None, base_url=None, filepath=None):
+            self, required_global_path, required_global_query, optional_global_query=None, base_url=None):
 
         if required_global_path is None:
             raise ValueError("Parameter 'required_global_path' must not be None.")
@@ -46,7 +45,7 @@ class AutoRestRequiredOptionalTestServiceConfiguration(Configuration):
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestRequiredOptionalTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestRequiredOptionalTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestrequiredoptionaltestservice/{}'.format(VERSION))
 
@@ -73,13 +72,12 @@ class AutoRestRequiredOptionalTestService(object):
     :param optional_global_query: number of items to skip
     :type optional_global_query: int
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, required_global_path, required_global_query, optional_global_query=None, base_url=None, filepath=None):
+            self, required_global_path, required_global_query, optional_global_query=None, base_url=None):
 
-        self.config = AutoRestRequiredOptionalTestServiceConfiguration(required_global_path, required_global_query, optional_global_query, base_url, filepath)
+        self.config = AutoRestRequiredOptionalTestServiceConfiguration(required_global_path, required_global_query, optional_global_query, base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Url/autoresturltestservice/auto_rest_url_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Url/autoresturltestservice/auto_rest_url_test_service.py
@@ -29,11 +29,10 @@ class AutoRestUrlTestServiceConfiguration(Configuration):
     :param global_string_query: should contain value null
     :type global_string_query: str
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, global_string_path, global_string_query=None, base_url=None, filepath=None):
+            self, global_string_path, global_string_query=None, base_url=None):
 
         if global_string_path is None:
             raise ValueError("Parameter 'global_string_path' must not be None.")
@@ -44,7 +43,7 @@ class AutoRestUrlTestServiceConfiguration(Configuration):
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestUrlTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestUrlTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autoresturltestservice/{}'.format(VERSION))
 
@@ -71,13 +70,12 @@ class AutoRestUrlTestService(object):
     :param global_string_query: should contain value null
     :type global_string_query: str
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, global_string_path, global_string_query=None, base_url=None, filepath=None):
+            self, global_string_path, global_string_query=None, base_url=None):
 
-        self.config = AutoRestUrlTestServiceConfiguration(global_string_path, global_string_query, base_url, filepath)
+        self.config = AutoRestUrlTestServiceConfiguration(global_string_path, global_string_query, base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/autoresturlmutlicollectionformattestservice/auto_rest_url_mutli_collection_format_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/autoresturlmutlicollectionformattestservice/auto_rest_url_mutli_collection_format_test_service.py
@@ -22,16 +22,15 @@ class AutoRestUrlMutliCollectionFormatTestServiceConfiguration(Configuration):
     attributes.
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestUrlMutliCollectionFormatTestServiceConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestUrlMutliCollectionFormatTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autoresturlmutlicollectionformattestservice/{}'.format(VERSION))
 
@@ -46,13 +45,12 @@ class AutoRestUrlMutliCollectionFormatTestService(object):
     :vartype queries: .operations.QueriesOperations
 
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, base_url=None, filepath=None):
+            self, base_url=None):
 
-        self.config = AutoRestUrlMutliCollectionFormatTestServiceConfiguration(base_url, filepath)
+        self.config = AutoRestUrlMutliCollectionFormatTestServiceConfiguration(base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Validation/autorestvalidationtest/auto_rest_validation_test.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Validation/autorestvalidationtest/auto_rest_validation_test.py
@@ -27,11 +27,10 @@ class AutoRestValidationTestConfiguration(Configuration):
     :param api_version: Required string following pattern \\d{2}-\\d{2}-\\d{4}
     :type api_version: str
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, subscription_id, api_version, base_url=None, filepath=None):
+            self, subscription_id, api_version, base_url=None):
 
         if subscription_id is None:
             raise ValueError("Parameter 'subscription_id' must not be None.")
@@ -44,7 +43,7 @@ class AutoRestValidationTestConfiguration(Configuration):
         if not base_url:
             base_url = 'http://localhost'
 
-        super(AutoRestValidationTestConfiguration, self).__init__(base_url, filepath)
+        super(AutoRestValidationTestConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestvalidationtest/{}'.format(VERSION))
 
@@ -63,13 +62,12 @@ class AutoRestValidationTest(object):
     :param api_version: Required string following pattern \\d{2}-\\d{2}-\\d{4}
     :type api_version: str
     :param str base_url: Service URL
-    :param str filepath: Existing config
     """
 
     def __init__(
-            self, subscription_id, api_version, base_url=None, filepath=None):
+            self, subscription_id, api_version, base_url=None):
 
-        self.config = AutoRestValidationTestConfiguration(subscription_id, api_version, base_url, filepath)
+        self.config = AutoRestValidationTestConfiguration(subscription_id, api_version, base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}

--- a/src/generator/AutoRest.Python/Model/CodeModelPy.cs
+++ b/src/generator/AutoRest.Python/Model/CodeModelPy.cs
@@ -87,7 +87,7 @@ namespace AutoRest.Python.Model
                 var param = string.Join(", ", requireParams);
                 if (!string.IsNullOrEmpty(param))
                 {
-                    param += ", ";
+                    param = ", " + param;
                 }
                 return param;
             }
@@ -104,9 +104,9 @@ namespace AutoRest.Python.Model
                     configParams.Add(property.Name);
                 }
                 var param = string.Join(", ", configParams);
-                if (!param.IsNullOrEmpty())
+                if (!IsCustomBaseUri)
                 {
-                    param += ", ";
+                    param += (param.IsNullOrEmpty() ? "" : ", ") + "base_url";
                 }
                 return param;
             }

--- a/src/generator/AutoRest.Python/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Python/Templates/ServiceClientTemplate.cshtml
@@ -56,11 +56,10 @@ class @(Model.Name)Configuration(Configuration):
 { 
 @:    :param str base_url: Service URL
 }
-    :param str filepath: Existing config
     """
 @EmptyLine
     def __init__(
-            self, @(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : "base_url=None, ")filepath=None):
+            self@(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : ", base_url=None")):
 @EmptyLine
         @Model.ValidateRequiredParameters
 
@@ -75,7 +74,7 @@ else
 }
 
 @EmptyLine
-        super(@(Model.Name)Configuration, self).__init__(base_url, filepath)
+        super(@(Model.Name)Configuration, self).__init__(base_url)
 @EmptyLine
         self.add_user_agent('@Model.UserAgent/{}'.format(VERSION))
 @if (Model.Properties.Any() || Model.ConstantProperties.Any())
@@ -117,13 +116,12 @@ class @(Model.Name)(object):
 {
 @:    :param str base_url: Service URL
 }
-    :param str filepath: Existing config
     """
 @EmptyLine
     def __init__(
-            self, @(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : "base_url=None, ")filepath=None):
+            self@(Model.RequiredConstructorParameters)@(Model.IsCustomBaseUri ? "" : ", base_url=None")):
 @EmptyLine
-        self.config = @(Model.Name)Configuration(@(Model.ConfigConstructorParameters)@(Model.IsCustomBaseUri ? "" : "base_url, ")filepath)
+        self.config = @(Model.Name)Configuration(@(Model.ConfigConstructorParameters))
         self._client = ServiceClient(@(Settings.AddCredentials? "self.config.credentials" : PythonConstants.None), self.config)
 @EmptyLine
 @if (Model.ModelTemplateModels.Any())


### PR DESCRIPTION
Peer programming with @annatisch

Details are here: https://github.com/Azure/msrestazure-for-python/issues/13

But the idea is that we currently have two ways to configure Azure Extensions:
- Solution 1
```python
client = Client(credentials, subscription_id, long_running_operation_retry_timeout=666)
```
- Solution 2
```python
client = Client(credentials, subscription_id)
client.config.long_running_operation_timeout = 666
```

This PRs remove solution 1. It's breaking, but acceptable to me:
- `long_running_operation_retry_timeout` never worked (https://github.com/Azure/azure-sdk-for-python/issues/962). So it's not breaking something that never worked.
- `accept_language` and `generate_client_request_id ` disapear, but not very used, I'm not worried.
- Code shorter, simpler, and new extensions will be easier to introduce.
- There is no loss of features,

We also remove the `nextLink` check that was specific to Python.