### PR TITLE
Fixed and improved UniqueResourcePaths linter rule

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -537,7 +537,7 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to More than one resource path is not allowed in a single spec.
+        ///    Looks up a localized string similar to More than one resource path is not allowed in a single spec (found: {0})..
         /// </summary>
         public static string UniqueResourcePathsWarning {
             get {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -268,7 +268,7 @@
     <value>Parameters "subscriptionId" or "api-version" are referenced but not defined in the parameters section of Service Definition</value>
   </data>
   <data name="UniqueResourcePathsWarning" xml:space="preserve">
-    <value>More than one resource path is not allowed in a single spec</value>
+    <value>More than one resource path is not allowed in a single spec (found: {0}).</value>
   </data>
   <data name="PathCannotBeNullOrEmpty" xml:space="preserve">
     <value>path cannot be null or an empty string or a string with white spaces while getting the parent directory</value>

--- a/src/modeler/AutoRest.Swagger/Validation/UniqueResourcePaths.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/UniqueResourcePaths.cs
@@ -26,9 +26,9 @@ namespace AutoRest.Swagger.Validation
                     .OfType<Match>()
                     .Select(match => match.Groups["resPath"].Value.ToString()))
                 .Distinct()
-                .ToList();
+                .ToArray();
             formatParameters = new [] { string.Join(", ", resources) };
-            return resources.Count <= 1;
+            return resources.Length <= 1;
         }
 
         /// <summary>


### PR DESCRIPTION
Before:
Raised false alarms (broken regex) but was also too relaxed in other regards.

Now:
Strict, better linter message.