### PR TITLE
Fix bug in parameter grouping in some languages

### DIFF
--- a/src/generator/AutoRest.CSharp.Azure.Fluent/TransformerCsaf.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent/TransformerCsaf.cs
@@ -19,11 +19,11 @@ namespace AutoRest.CSharp.Azure.Fluent
             var codeModel = cs as CodeModelCsaf;
             Settings.Instance.AddCredentials = true;
 
-            // Do parameter transformations
-            TransformParameters(codeModel);
-
             // todo: these should be turned into individual transformers
             AzureExtensions.NormalizeAzureClientModel(codeModel);
+
+            // Do parameter transformations
+            TransformParameters(codeModel);
 
             // Fluent Specific stuff.
             NormalizeResourceTypes(codeModel);

--- a/src/generator/AutoRest.CSharp.Azure/TransformerCsa.cs
+++ b/src/generator/AutoRest.CSharp.Azure/TransformerCsa.cs
@@ -41,11 +41,11 @@ namespace AutoRest.CSharp.Azure
             // add the Credentials
             // PopulateAdditionalProperties(codeModel);
 
-            // Do parameter transformations
-            TransformParameters(codeModel);
-
             // todo: these should be turned into individual transformers
             AzureExtensions.NormalizeAzureClientModel(codeModel);
+
+            // Do parameter transformations
+            TransformParameters(codeModel);
 
             NormalizePaginatedMethods(codeModel);
             NormalizeODataMethods(codeModel);


### PR DESCRIPTION
  - The bug was that parameter group "transform" has to happen after the groups are
    processed. In CSharpAzure and CSharpFluent, it was happening too early and so the
    language specific capitalization rules wern't being applied.


Please note that I didn't add any tests -- if you want me to add some tests (or update existing ones) please point me in the direction of what testing I should do.