### PR TITLE
Make Python tests less nervous about Exception string content

### DIFF
--- a/src/generator/AutoRest.Python.Tests/AcceptanceTests/validation_tests.py
+++ b/src/generator/AutoRest.Python.Tests/AcceptanceTests/validation_tests.py
@@ -111,14 +111,14 @@ class ValidationTests(unittest.TestCase):
             client.validation_of_body("123", 150, tempproduct)
         except ValidationError as err:
             self.assertEqual(err.rule, "minimum_ex")
-            self.assertEqual(err.target, "capacity")
+            self.assertIn("capacity", err.target)
 
         try:
             tempproduct=Product(child=ChildProduct(), capacity=100)
             client.validation_of_body("123", 150, tempproduct)
         except ValidationError as err:
             self.assertEqual(err.rule, "maximum_ex")
-            self.assertEqual(err.target, "capacity")
+            self.assertIn("capacity", err.target)
 
         try:
             tempproduct=Product(child=ChildProduct(),
@@ -126,7 +126,7 @@ class ValidationTests(unittest.TestCase):
             client.validation_of_body("123", 150, tempproduct)
         except ValidationError as err:
             self.assertEqual(err.rule, "max_items")
-            self.assertEqual(err.target, "display_names")
+            self.assertIn("display_names", err.target)
 
         client2 = AutoRestValidationTest(
             "abc123",


### PR DESCRIPTION
The new msrest for Python to be released tomorrow improves slightly the exception message if error occurs.
Instead of saying that "capacity is an unknown attribute" , the message will be now "Product.capacity is an unknown attribute" (adding class name in the error message). This improve debugging of SDK issue.

However, the current testsuite of Autorest is checking the exact content of the exception.

This PR improve the testing by testing : inclusion", and not "equality". IOW, as long as "capacity" is mentioned in the exception, the test pass. This allows this test to works on either the current msrest and the new one of tomorrow.

Please merge this asap, so I don't break the Autorest build for everybody while release Python msrest :(

FYI @annatisch