### PR TITLE
Cache version strings after first generation.

### DIFF
--- a/src/generator/AutoRest.Go/CodeNamerGo.cs
+++ b/src/generator/AutoRest.Go/CodeNamerGo.cs
@@ -36,7 +36,7 @@ namespace AutoRest.Go
 
         // CommonInitialisms are those "words" within a name that Golint expects to be uppercase.
         // See https://github.com/golang/lint/blob/master/lint.go for detail.
-        private static string[] CommonInitialisms => new string[] {
+        private string[] CommonInitialisms => new string[] {
                                                             "Acl",
                                                             "Api",
                                                             "Ascii",
@@ -76,7 +76,7 @@ namespace AutoRest.Go
                                                             "Xss",
                                                         };
 
-        public static string[] UserDefinedNames => new string[] {
+        public string[] UserDefinedNames => new string[] {
                                                             "UserAgent",
                                                             "Version",
                                                             "APIVersion",

--- a/src/generator/AutoRest.Go/CodeNamerGo.cs
+++ b/src/generator/AutoRest.Go/CodeNamerGo.cs
@@ -11,6 +11,7 @@ using AutoRest.Core.Utilities;
 using AutoRest.Core.Utilities.Collections;
 using AutoRest.Core.Model;
 using AutoRest.Go.Model;
+using System.Text;
 
 namespace AutoRest.Go
 {
@@ -412,20 +413,12 @@ namespace AutoRest.Go
         // camelCase or PascalCase.
         private string EnsureNameCase(string name)
         {
-            List<string> words = new List<string>();
-            new List<string>(name.ToWords())
-                .ForEach(s =>
-                {
-                    if (CommonInitialisms.Contains(s))
-                    {
-                        words.Add(s.ToUpper());
-                    }
-                    else
-                    {
-                        words.Add(s);
-                    }
-                });
-            return String.Join(String.Empty, words.ToArray());
+            var builder = new StringBuilder();
+            foreach(var s in name.ToWords())
+            {
+                builder.Append(CommonInitialisms.Contains(s) ? s.ToUpper() : s);
+            }
+            return builder.ToString();
         }
 
         public static string[] SDKVersionFromPackageVersion(string v)

--- a/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
@@ -21,13 +21,16 @@ const (
     major = "@(Model.Version[0])"
     minor = "@(Model.Version[1])"
     patch = "@(Model.Version[2])"
-    // Always begin a "tag" with a dash (as per http://semver.org)
-    tag   = "-beta"
+    tag   = "@(Model.Version[3])"
 
     userAgentFormat = "Azure-SDK-For-Go/%s arm-%s/%s"
 )
 
-var userAgent string
+// cached results of UserAgent and Version to prevent repeated operations.
+var (
+    userAgent string
+    version string
+)
 
 @EmptyLine
 // UserAgent returns the UserAgent string to use when sending http.Requests.
@@ -39,8 +42,6 @@ func UserAgent() string {
 }
 
 @EmptyLine
-var version string
-
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
     if version == "" {

--- a/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
@@ -13,7 +13,9 @@ package @Model.Namespace
 
 @EmptyLine
 import (
+    "bytes"
     "fmt"
+    "strings"
 )
 @EmptyLine
 

--- a/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
@@ -24,18 +24,32 @@ const (
     // Always begin a "tag" with a dash (as per http://semver.org)
     tag   = "-beta"
 
-    semVerFormat = "%s.%s.%s%s"
     userAgentFormat = "Azure-SDK-For-Go/%s arm-%s/%s"
 )
+
+var userAgent string
 
 @EmptyLine
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-    return fmt.Sprintf(userAgentFormat, Version(), "@(Model.Namespace)", "@(Model.ApiVersion)")
+    if userAgent == "" {
+        userAgent = fmt.Sprintf(userAgentFormat, Version(), "@(Model.Namespace)", "@(Model.ApiVersion)")
+    }
+    return userAgent
 }
 
 @EmptyLine
+var version string
+
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-    return fmt.Sprintf(semVerFormat, major, minor, patch, tag)
+    if version == "" {
+        versionBuilder := bytes.NewBufferString(fmt.Sprintf("%d.%d.%d", major, minor, patch))
+        if tag != "" {
+            versionBuilder.WriteRune('-')
+            versionBuilder.WriteString(strings.TrimPrefix(tag, "-"))
+        }
+        version = string(versionBuilder.Bytes())
+    }
+    return version
 }

--- a/src/generator/AutoRest.Go/TransformerGo.cs
+++ b/src/generator/AutoRest.Go/TransformerGo.cs
@@ -102,7 +102,7 @@ namespace AutoRest.Go
             cmg.EnumTypes.Cast<EnumTypeGo>().OrderBy(etg => etg.Name.Value)
                 .ForEach(em =>
                 {
-                    if (em.Values.Where(v => topLevelNames.Contains(v.Name) || CodeNamerGo.UserDefinedNames.Contains(v.Name)).Count() > 0)
+                    if (em.Values.Where(v => topLevelNames.Contains(v.Name) || CodeNamerGo.Instance.UserDefinedNames.Contains(v.Name)).Count() > 0)
                     {
                         em.HasUniqueNames = false;
                     }
@@ -136,7 +136,7 @@ namespace AutoRest.Go
                     name = $"{name}Type";
                 }
 
-                if (CodeNamerGo.UserDefinedNames.Contains(name))
+                if (CodeNamerGo.Instance.UserDefinedNames.Contains(name))
                 {
                     name = $"{name}{cmg.Namespace.Capitalize()}";
                 }

--- a/src/generator/AutoRest.Go/TransformerGo.cs
+++ b/src/generator/AutoRest.Go/TransformerGo.cs
@@ -102,7 +102,7 @@ namespace AutoRest.Go
             cmg.EnumTypes.Cast<EnumTypeGo>().OrderBy(etg => etg.Name.Value)
                 .ForEach(em =>
                 {
-                    if (em.Values.Where(v => topLevelNames.Contains(v.Name) || CodeNamerGo.Instance.UserDefinedNames.Contains(v.Name)).Count() > 0)
+                    if (em.Values.Where(v => topLevelNames.Contains(v.Name) || CodeNamerGo.UserDefinedNames.Contains(v.Name)).Count() > 0)
                     {
                         em.HasUniqueNames = false;
                     }
@@ -136,7 +136,7 @@ namespace AutoRest.Go
                     name = $"{name}Type";
                 }
 
-                if (CodeNamerGo.Instance.UserDefinedNames.Contains(name))
+                if (CodeNamerGo.UserDefinedNames.Contains(name))
                 {
                     name = $"{name}{cmg.Namespace.Capitalize()}";
                 }


### PR DESCRIPTION
Also, rewrite CodeNamerGo method to be more readable and have fewer
allocations.