### PR TITLE
updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,8 +3,6 @@ PackageTest/NugetPackageTest/Generated
 src/generator/AutoRest.NodeJS.Tests/AcceptanceTests/*.js
 
 ## Ignore user-specific files, temporary files, build results, etc.
-AutoRest/**/Templates/*.cs
-src/**/Templates/**/*.cs
 compare-results/*
 
 # User-specific files


### PR DESCRIPTION
no longer ignore Template\*.cs, otherwise their (non-)existence isn't enforced by git
(also seems to fix a VS17 crash)