### PR TITLE
make sure {{EmptyLine}} is on own line

### DIFF
--- a/src/core/AutoRest.Core/Template.cs
+++ b/src/core/AutoRest.Core/Template.cs
@@ -31,7 +31,7 @@ namespace AutoRest.Core
         /// </summary>
         public string EmptyLine
         {
-            get { return TemplateConstants.EmptyLine + "\r\n"; }
+            get { return "\r\n" + TemplateConstants.EmptyLine + "\r\n"; }
         }
 
         /// <summary>
@@ -229,8 +229,7 @@ namespace AutoRest.Core
                 Indentation.Length - // - Space used for indent
                 prefix.Length - // - Prefix //'s length
                 1; // - Extra space between prefix and text
-            return string.Join(Environment.NewLine, comment.WordWrap(available)
-                .Select(s => string.Format(CultureInfo.InvariantCulture, "{0}{1}", prefix, s)));
+            return string.Join(Environment.NewLine, comment.WordWrap(available).Select(s => $"{prefix}{s}"));
         }
 
         protected string Indentation


### PR DESCRIPTION
fixes razor bug:
- sometimes, no "\r\n" is emitted with plain text lines (without apparent reason!) so the `{{EmptyLine}}` ends up together with something else
- subsequently, the entire line is emitted as nothing but a newline, swallowing the content that was next to `{{EmptyLine}}`