### PR TITLE
Json mode for validation messages

### DIFF
--- a/src/core/AutoRest.Core/AutoRestController.cs
+++ b/src/core/AutoRest.Core/AutoRestController.cs
@@ -74,13 +74,15 @@ namespace AutoRest.Core
                 throw ErrorManager.CreateError(Resources.ErrorGeneratingClientModel, exception);
             }
 
-            var plugin = ExtensionsLoader.GetPlugin();
-
-            if (!Settings.Instance.Json)
+            if (Settings.Instance.JsonValidationMessages)
             {
-                Console.ResetColor();
-                Console.WriteLine(plugin.CodeGenerator.UsageInstructions);
+                return; // no code gen in Json validation mode
             }
+
+            var plugin = ExtensionsLoader.GetPlugin();
+            
+            Console.ResetColor();
+            Console.WriteLine(plugin.CodeGenerator.UsageInstructions);
 
             Settings.Instance.Validate();
             try

--- a/src/core/AutoRest.Core/AutoRestController.cs
+++ b/src/core/AutoRest.Core/AutoRestController.cs
@@ -76,8 +76,11 @@ namespace AutoRest.Core
 
             var plugin = ExtensionsLoader.GetPlugin();
 
-            Console.ResetColor();
-            Console.WriteLine(plugin.CodeGenerator.UsageInstructions);
+            if (!Settings.Instance.Json)
+            {
+                Console.ResetColor();
+                Console.WriteLine(plugin.CodeGenerator.UsageInstructions);
+            }
 
             Settings.Instance.Validate();
             try

--- a/src/core/AutoRest.Core/Logging/FileObjectPath.cs
+++ b/src/core/AutoRest.Core/Logging/FileObjectPath.cs
@@ -1,0 +1,31 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using YamlDotNet.RepresentationModel;
+
+namespace AutoRest.Core.Logging
+{
+    /// <summary>
+    /// Represents a path into an object stored in a file.
+    /// </summary>
+    public class FileObjectPath
+    {
+        public FileObjectPath(Uri filePath, ObjectPath objectPath)
+        {
+            FilePath = filePath;
+            ObjectPath = objectPath;
+        }
+
+        public Uri FilePath { get; }
+
+        public ObjectPath ObjectPath { get; }
+
+        // https://tools.ietf.org/id/draft-pbryan-zyp-json-ref-03.html
+        public string JsonReference => $"{FilePath}#{ObjectPath.JsonPointer}";
+
+        public string ReadablePath => $"{FilePath}#{ObjectPath.ReadablePath}";
+    }
+}

--- a/src/core/AutoRest.Core/Logging/JsonValidationLogListener.cs
+++ b/src/core/AutoRest.Core/Logging/JsonValidationLogListener.cs
@@ -1,0 +1,31 @@
+﻿using AutoRest.Core.Validation;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AutoRest.Core.Logging
+{
+    public class JsonValidationLogListener : ILogListener
+    {
+        private List<Dictionary<string, string>> rawMessageCollection = new List<Dictionary<string, string>>();
+
+        public void Log(LogMessage message)
+        {
+            var validationMessage = message as ValidationMessage;
+            if (validationMessage != null && message.Severity > Category.Debug)
+            {
+                var rawMessage = new Dictionary<string, string>();
+                rawMessage["type"] = validationMessage.Severity.ToString();
+                rawMessage["code"] = validationMessage.Type.Name;
+                rawMessage["message"] = validationMessage.Message;
+                rawMessage["jsonpath"] = validationMessage.Path.JsonPath;
+                rawMessageCollection.Add(rawMessage);
+            }
+        }
+
+        public string GetValidationMessagesAsJson() => JsonConvert.SerializeObject(rawMessageCollection, Formatting.Indented);
+    }
+}

--- a/src/core/AutoRest.Core/Logging/JsonValidationLogListener.cs
+++ b/src/core/AutoRest.Core/Logging/JsonValidationLogListener.cs
@@ -1,10 +1,9 @@
-﻿using AutoRest.Core.Validation;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Validation;
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Globalization;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace AutoRest.Core.Logging
 {
@@ -19,9 +18,14 @@ namespace AutoRest.Core.Logging
             {
                 var rawMessage = new Dictionary<string, string>();
                 rawMessage["type"] = validationMessage.Severity.ToString();
-                rawMessage["code"] = validationMessage.Type.Name;
+                rawMessage["code"] = validationMessage.Rule.GetType().Name;
                 rawMessage["message"] = validationMessage.Message;
                 rawMessage["jsonref"] = validationMessage.Path.JsonReference;
+                rawMessage["json-path"] = validationMessage.Path.ReadablePath;
+                rawMessage["id"] = validationMessage.Rule.Id;
+                rawMessage["validationCategory"] = validationMessage.Rule.ValidationCategory.ToString();
+                rawMessage["providerNamespace"] = "providerNamespace_WAT";
+                rawMessage["resourceType"] = "resourceType_WAT";
                 rawMessageCollection.Add(rawMessage);
             }
         }

--- a/src/core/AutoRest.Core/Logging/JsonValidationLogListener.cs
+++ b/src/core/AutoRest.Core/Logging/JsonValidationLogListener.cs
@@ -21,7 +21,7 @@ namespace AutoRest.Core.Logging
                 rawMessage["type"] = validationMessage.Severity.ToString();
                 rawMessage["code"] = validationMessage.Type.Name;
                 rawMessage["message"] = validationMessage.Message;
-                rawMessage["jsonpath"] = validationMessage.Path.JsonPath;
+                rawMessage["jsonref"] = validationMessage.Path.JsonReference;
                 rawMessageCollection.Add(rawMessage);
             }
         }

--- a/src/core/AutoRest.Core/Logging/LogMessage.cs
+++ b/src/core/AutoRest.Core/Logging/LogMessage.cs
@@ -14,7 +14,7 @@ namespace AutoRest.Core.Logging
     /// </summary>
     public class LogMessage
     {
-        public LogMessage(Category severity, string message, ObjectPath path = null)
+        public LogMessage(Category severity, string message, FileObjectPath path = null)
         {
             Severity = severity;
             Message = message;
@@ -41,7 +41,7 @@ namespace AutoRest.Core.Logging
         /// <summary>
         /// The JSON document path to the element being validated.
         /// </summary>
-        public ObjectPath Path { get; }
+        public FileObjectPath Path { get; }
 
         /// <summary>
         /// Additional data, set only if `Settings.Instance.Verbose` is set.

--- a/src/core/AutoRest.Core/Logging/ObjectPath.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPath.cs
@@ -28,7 +28,7 @@ namespace AutoRest.Core.Logging
 
         public IEnumerable<ObjectPathPart> Path { get; }
         
-        public string XPath => "#" + string.Concat(Path.Select(p => p.XPath));
+        public string JsonPath => "$" + string.Concat(Path.Select(p => p.JsonPath));
 
         public string ReadablePath => "#" + string.Concat(Path.Select(p => p.ReadablePath));
 

--- a/src/core/AutoRest.Core/Logging/ObjectPath.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPath.cs
@@ -29,12 +29,12 @@ namespace AutoRest.Core.Logging
         public IEnumerable<ObjectPathPart> Path { get; }
 
         // https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-04
-        public string JsonPointer => "#" + string.Concat(Path.Select(p => p.JsonPointer));
+        public string JsonPointer => string.Concat(Path.Select(p => p.JsonPointer));
 
         // http://goessner.net/articles/JsonPath/, https://github.com/jayway/JsonPath
         public string JsonPath => "$" + string.Concat(Path.Select(p => p.JsonPath));
 
-        public string ReadablePath => "#" + string.Concat(Path.Select(p => p.ReadablePath));
+        public string ReadablePath => string.Concat(Path.Select(p => p.ReadablePath));
 
         public YamlNode SelectNode(YamlNode node)
         {

--- a/src/core/AutoRest.Core/Logging/ObjectPath.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPath.cs
@@ -27,7 +27,11 @@ namespace AutoRest.Core.Logging
         public ObjectPath AppendProperty(string property) => Append(new ObjectPathPartProperty(property));
 
         public IEnumerable<ObjectPathPart> Path { get; }
-        
+
+        // https://tools.ietf.org/html/draft-ietf-appsawg-json-pointer-04
+        public string JsonPointer => "#" + string.Concat(Path.Select(p => p.JsonPointer));
+
+        // http://goessner.net/articles/JsonPath/, https://github.com/jayway/JsonPath
         public string JsonPath => "$" + string.Concat(Path.Select(p => p.JsonPath));
 
         public string ReadablePath => "#" + string.Concat(Path.Select(p => p.ReadablePath));

--- a/src/core/AutoRest.Core/Logging/ObjectPathPart.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPathPart.cs
@@ -7,7 +7,7 @@ namespace AutoRest.Core.Logging
 {
     public abstract class ObjectPathPart
     {
-        public abstract string XPath { get; }
+        public abstract string JsonPath { get; }
 
         public abstract string ReadablePath { get; }
 

--- a/src/core/AutoRest.Core/Logging/ObjectPathPart.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPathPart.cs
@@ -7,6 +7,8 @@ namespace AutoRest.Core.Logging
 {
     public abstract class ObjectPathPart
     {
+        public abstract string JsonPointer { get; }
+
         public abstract string JsonPath { get; }
 
         public abstract string ReadablePath { get; }

--- a/src/core/AutoRest.Core/Logging/ObjectPathPartIndex.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPathPartIndex.cs
@@ -17,9 +17,9 @@ namespace AutoRest.Core.Logging
 
         public int Index { get; }
 
-        public override string XPath => $"[{Index + 1}]";
+        public override string JsonPath => $"[{Index + 1}]";
 
-        public override string ReadablePath => XPath;
+        public override string ReadablePath => JsonPath;
 
         public override YamlNode SelectNode(ref YamlNode node)
         {

--- a/src/core/AutoRest.Core/Logging/ObjectPathPartIndex.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPathPartIndex.cs
@@ -17,6 +17,8 @@ namespace AutoRest.Core.Logging
 
         public int Index { get; }
 
+        public override string JsonPointer => $"/{Index + 1}";
+
         public override string JsonPath => $"[{Index + 1}]";
 
         public override string ReadablePath => JsonPath;

--- a/src/core/AutoRest.Core/Logging/ObjectPathPartProperty.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPathPartProperty.cs
@@ -1,16 +1,21 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using AutoRest.Core.Utilities;
+using System.Text.RegularExpressions;
 using YamlDotNet.RepresentationModel;
 
 namespace AutoRest.Core.Logging
 {
     public class ObjectPathPartProperty : ObjectPathPart
     {
+        // conservative approximation
+        private static readonly Regex regexValidES3DotNotationPropertyName = new Regex(@"^(?!do|if|in|for|int|new|try|var|byte|case|char|else|enum|goto|long|null|this|true|void|with|break|catch|class|const|false|final|float|short|super|throw|while|delete|double|export|import|native|public|return|static|switch|throws|typeof|boolean|default|extends|finally|package|private|abstract|continue|debugger|function|volatile|interface|protected|transient|implements|instanceof|synchronized)[a-zA-Z_][a-zA-Z_0-9]*$");
+
         public ObjectPathPartProperty(string property)
         {
             Property = property;
@@ -18,7 +23,7 @@ namespace AutoRest.Core.Logging
 
         public string Property { get; }
 
-        public override string JsonPath => Property.All(char.IsLetter) ? $".{Property}" : $"['{Property.Replace("'", @"\'")}']";
+        public override string JsonPath => regexValidES3DotNotationPropertyName.IsMatch(Property) ? $".{Property}" : $"[{JsonConvert.SerializeObject(Property)}]";
 
         public override string ReadablePath => Property.StartsWith("/") ? Property : $"/{Property}";
 

--- a/src/core/AutoRest.Core/Logging/ObjectPathPartProperty.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPathPartProperty.cs
@@ -23,6 +23,8 @@ namespace AutoRest.Core.Logging
 
         public string Property { get; }
 
+        public override string JsonPointer => $"/{Property.Replace("~", "~0").Replace("/", "~1")}";
+
         public override string JsonPath => regexValidES3DotNotationPropertyName.IsMatch(Property) ? $".{Property}" : $"[{JsonConvert.SerializeObject(Property)}]";
 
         public override string ReadablePath => Property.StartsWith("/") ? Property : $"/{Property}";

--- a/src/core/AutoRest.Core/Logging/ObjectPathPartProperty.cs
+++ b/src/core/AutoRest.Core/Logging/ObjectPathPartProperty.cs
@@ -11,8 +11,6 @@ namespace AutoRest.Core.Logging
 {
     public class ObjectPathPartProperty : ObjectPathPart
     {
-        private static string SanitizeXPathProperty(string property) => property.Replace("/", "~1");
-
         public ObjectPathPartProperty(string property)
         {
             Property = property;
@@ -20,7 +18,7 @@ namespace AutoRest.Core.Logging
 
         public string Property { get; }
 
-        public override string XPath => $"/{SanitizeXPathProperty(Property)}";
+        public override string JsonPath => Property.All(char.IsLetter) ? $".{Property}" : $"['{Property.Replace("'", @"\'")}']";
 
         public override string ReadablePath => Property.StartsWith("/") ? Property : $"/{Property}";
 

--- a/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
+++ b/src/core/AutoRest.Core/Parsing/YamlExtensions.cs
@@ -145,7 +145,7 @@ namespace AutoRest.Core.Parsing
             }
 
             // nothing worked
-            throw new Exception($"{path.XPath} has incomaptible values ({a}, {b}).");
+            throw new Exception($"{path.JsonPath} has incomaptible values ({a}, {b}).");
         }
 
         public static YamlMappingNode MergeWith(this YamlMappingNode self, YamlMappingNode other)

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -282,8 +282,8 @@ Licensed under the MIT License. See License.txt in the project root for license 
         /// <summary>
         /// If set to true, collect and print out validation messages as single JSON blob.
         /// </summary>
-        [SettingsAlias("json")]
-        public bool Json { get; set; }
+        [SettingsAlias("JsonValidationMessages")]
+        public bool JsonValidationMessages { get; set; }
 
         /// <summary>
         /// If set to true, print out debug messages.

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -280,6 +280,12 @@ Licensed under the MIT License. See License.txt in the project root for license 
         public bool Verbose { get; set; }
 
         /// <summary>
+        /// If set to true, collect and print out validation messages as single JSON blob.
+        /// </summary>
+        [SettingsAlias("json")]
+        public bool Json { get; set; }
+
+        /// <summary>
         /// If set to true, print out debug messages.
         /// </summary>
         [SettingsAlias("debug")]

--- a/src/core/AutoRest.Core/Validation/ComparisonContext.cs
+++ b/src/core/AutoRest.Core/Validation/ComparisonContext.cs
@@ -37,6 +37,7 @@ namespace AutoRest.Core.Validation
 
         public DataDirection Direction { get; set; } = DataDirection.None;
 
+        public Uri File { get; set; }
         public ObjectPath Path { get { return _path.Peek(); } }
 
         public void PushIndex(int index) { _path.Push(Path.AppendIndex(index)); }
@@ -47,17 +48,17 @@ namespace AutoRest.Core.Validation
 
         public void LogInfo(MessageTemplate template, params object[] formatArguments)
         {
-            _messages.Add(new ComparisonMessage(template, Path, Category.Info, formatArguments));
+            _messages.Add(new ComparisonMessage(template, new FileObjectPath(File, Path), Category.Info, formatArguments));
         }
 
         public void LogError(MessageTemplate template, params object[] formatArguments)
         {
-            _messages.Add(new ComparisonMessage(template, Path, Category.Error, formatArguments));
+            _messages.Add(new ComparisonMessage(template, new FileObjectPath(File, Path), Category.Error, formatArguments));
         }
 
         public void LogBreakingChange(MessageTemplate template, params object[] formatArguments)
         {
-            _messages.Add(new ComparisonMessage(template, Path, Strict ? Category.Error : Category.Warning, formatArguments));
+            _messages.Add(new ComparisonMessage(template, new FileObjectPath(File, Path), Strict ? Category.Error : Category.Warning, formatArguments));
         }
 
         public IEnumerable<ComparisonMessage> Messages {  get { return _messages; } }

--- a/src/core/AutoRest.Core/Validation/ComparisonMessage.cs
+++ b/src/core/AutoRest.Core/Validation/ComparisonMessage.cs
@@ -14,9 +14,9 @@ namespace AutoRest.Core.Validation
     /// </summary>
     public class ComparisonMessage : LogMessage
     {
-        public ComparisonMessage(MessageTemplate template, ObjectPath path, Category severity)
+        public ComparisonMessage(MessageTemplate template, FileObjectPath path, Category severity)
             : this(template, path, severity, new string[0]) { }
-        public ComparisonMessage(MessageTemplate template, ObjectPath path, Category severity, params object[] formatArguments)
+        public ComparisonMessage(MessageTemplate template, FileObjectPath path, Category severity, params object[] formatArguments)
             : base(severity, $"Comparison: {template.Id} - {string.Format(CultureInfo.CurrentCulture, template.Message, formatArguments)}", path)
         {
             Id = template.Id;

--- a/src/core/AutoRest.Core/Validation/PropertyNameResolver.cs
+++ b/src/core/AutoRest.Core/Validation/PropertyNameResolver.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using AutoRest.Core.Utilities;
+using Newtonsoft.Json;
 using System.Linq;
 using System.Reflection;
 
@@ -13,13 +14,6 @@ namespace AutoRest.Core.Validation
         /// <returns>The [JsonProperty] name of property if it exists, or the property name</returns>
         public static string JsonName(PropertyInfo prop)
             => prop?.GetCustomAttributes<JsonPropertyAttribute>(true).Select(p => p.PropertyName).FirstOrDefault()
-            ?? prop.Name;
-
-        /// <summary>
-        /// Returns the name of the property
-        /// </summary>
-        /// <param name="prop"></param>
-        /// <returns>The name of the property</returns>
-        public static string PropertyName(PropertyInfo prop) => prop.Name;
+            ?? prop.Name.ToCamelCase();
     }
 }

--- a/src/core/AutoRest.Core/Validation/RecursiveObjectValidator.cs
+++ b/src/core/AutoRest.Core/Validation/RecursiveObjectValidator.cs
@@ -33,9 +33,9 @@ namespace AutoRest.Core.Validation
         /// Recursively validates <paramref name="entity"/> by traversing all of its properties
         /// </summary>
         /// <param name="entity">The object to validate</param>
-        public IEnumerable<LogMessage> GetValidationExceptions(object entity)
+        public IEnumerable<LogMessage> GetValidationExceptions(Uri filePath, object entity)
         {
-            return RecursiveValidate(entity, ObjectPath.Empty, new RuleContext(entity), Enumerable.Empty<Rule>());
+            return RecursiveValidate(entity, ObjectPath.Empty, new RuleContext(entity, filePath), Enumerable.Empty<Rule>());
         }
 
         /// <summary>

--- a/src/core/AutoRest.Core/Validation/RecursiveObjectValidator.cs
+++ b/src/core/AutoRest.Core/Validation/RecursiveObjectValidator.cs
@@ -20,12 +20,6 @@ namespace AutoRest.Core.Validation
         private Func<PropertyInfo, string> resolver;
 
         /// <summary>
-        /// Initializes the object validator. By default, it will use the property name when
-        /// returning the location of messages
-        /// </summary>
-        public RecursiveObjectValidator() : this(PropertyNameResolver.PropertyName) { }
-
-        /// <summary>
         /// Initializes the object validator with a custom <paramref name="resolver"/>
         /// that returns the name for a property when setting the location of messages
         /// </summary>

--- a/src/core/AutoRest.Core/Validation/Rule.cs
+++ b/src/core/AutoRest.Core/Validation/Rule.cs
@@ -3,6 +3,7 @@
 
 using System.Collections.Generic;
 using AutoRest.Core.Logging;
+using System;
 
 namespace AutoRest.Core.Validation
 {
@@ -14,6 +15,10 @@ namespace AutoRest.Core.Validation
         protected Rule()
         {
         }
+
+        public virtual string Id => "!!! implement me and make me abstract !!!";
+
+        public ValidationCategory ValidationCategory => ((ValidationCategory)0); // !!! implement me and make me abstract !!!
 
         /// <summary>
         /// The template message for this Rule. 

--- a/src/core/AutoRest.Core/Validation/RuleContext.cs
+++ b/src/core/AutoRest.Core/Validation/RuleContext.cs
@@ -1,5 +1,6 @@
 ﻿
 using AutoRest.Core.Logging;
+using System;
 
 namespace AutoRest.Core.Validation
 {
@@ -13,10 +14,11 @@ namespace AutoRest.Core.Validation
         /// Initializes a top level context for rules
         /// </summary>
         /// <param name="root"></param>
-        public RuleContext(object root) : this(null)
+        public RuleContext(object root, Uri file) : this(null)
         {
             this.Root = root;
             this.Value = root;
+            this.File = file;
         }
 
         /// <summary>
@@ -27,6 +29,7 @@ namespace AutoRest.Core.Validation
         {
             this.Parent = parent;
             this.Root = parent?.Root;
+            this.File = parent?.File;
         }
 
         /// <summary>
@@ -84,5 +87,7 @@ namespace AutoRest.Core.Validation
                 : Key == null
                     ? Parent.Path.AppendIndex(Index.Value)
                     : Parent.Path.AppendProperty(Key);
+
+        public Uri File { get; private set;  }
     }
 }

--- a/src/core/AutoRest.Core/Validation/TypedRule.cs
+++ b/src/core/AutoRest.Core/Validation/TypedRule.cs
@@ -30,7 +30,7 @@ namespace AutoRest.Core.Validation
             object[] formatParams;
             if (!IsValid(entity, context, out formatParams))
             {
-                yield return new ValidationMessage(context.Path, this, formatParams);
+                yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, formatParams);
             }
         }
 

--- a/src/core/AutoRest.Core/Validation/ValidationCategory.cs
+++ b/src/core/AutoRest.Core/Validation/ValidationCategory.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
 
 namespace AutoRest.Core.Validation
 {

--- a/src/core/AutoRest.Core/Validation/ValidationCategory.cs
+++ b/src/core/AutoRest.Core/Validation/ValidationCategory.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace AutoRest.Core.Validation
+{
+    [Flags]
+    public enum ValidationCategory
+    {
+        RPCViolation    = 1 << 0,
+        OneAPIViolation = 1 << 1,
+        SDKViolation    = 1 << 2,
+    }
+}

--- a/src/core/AutoRest.Core/Validation/ValidationMessage.cs
+++ b/src/core/AutoRest.Core/Validation/ValidationMessage.cs
@@ -14,9 +14,6 @@ namespace AutoRest.Core.Validation
     /// </summary>
     public class ValidationMessage : LogMessage
     {
-        public ValidationMessage(ObjectPath path, Rule rule)
-            : this(path, rule, new string[0]) { }
-
         public ValidationMessage(ObjectPath path, Rule rule, params object[] formatArguments)
             : base(rule.Severity, $"{rule.GetType().Name} - {string.Format(CultureInfo.CurrentCulture, rule.MessageTemplate, formatArguments)}", path)
         {

--- a/src/core/AutoRest.Core/Validation/ValidationMessage.cs
+++ b/src/core/AutoRest.Core/Validation/ValidationMessage.cs
@@ -14,7 +14,7 @@ namespace AutoRest.Core.Validation
     /// </summary>
     public class ValidationMessage : LogMessage
     {
-        public ValidationMessage(ObjectPath path, Rule rule, params object[] formatArguments)
+        public ValidationMessage(FileObjectPath path, Rule rule, params object[] formatArguments)
             : base(rule.Severity, $"{rule.GetType().Name} - {string.Format(CultureInfo.CurrentCulture, rule.MessageTemplate, formatArguments)}", path)
         {
             Type = rule.GetType();

--- a/src/core/AutoRest.Core/Validation/ValidationMessage.cs
+++ b/src/core/AutoRest.Core/Validation/ValidationMessage.cs
@@ -15,7 +15,7 @@ namespace AutoRest.Core.Validation
     public class ValidationMessage : LogMessage
     {
         public ValidationMessage(FileObjectPath path, Rule rule, params object[] formatArguments)
-            : base(rule.Severity, $"{rule.GetType().Name} - {string.Format(CultureInfo.CurrentCulture, rule.MessageTemplate, formatArguments)}", path)
+            : base(rule.Severity, $"{string.Format(CultureInfo.CurrentCulture, rule.MessageTemplate, formatArguments)}", path)
         {
             Type = rule.GetType();
         }

--- a/src/core/AutoRest.Core/Validation/ValidationMessage.cs
+++ b/src/core/AutoRest.Core/Validation/ValidationMessage.cs
@@ -17,13 +17,12 @@ namespace AutoRest.Core.Validation
         public ValidationMessage(FileObjectPath path, Rule rule, params object[] formatArguments)
             : base(rule.Severity, $"{string.Format(CultureInfo.CurrentCulture, rule.MessageTemplate, formatArguments)}", path)
         {
-            Type = rule.GetType();
+            Rule = rule;
         }
 
         /// <summary>
-        /// The class of the Validation message
+        /// The validation rule which triggered this message.
         /// </summary>
-        public Type Type { get; }
-
+        public Rule Rule { get; }
     }
 }

--- a/src/core/AutoRest/Program.cs
+++ b/src/core/AutoRest/Program.cs
@@ -38,7 +38,7 @@ namespace AutoRest
                         var jsonValidationLogListener = new JsonValidationLogListener();
 
                         // set up logging
-                        if (settings.Json)
+                        if (settings.JsonValidationMessages)
                         {
                             Logger.Instance.AddListener(jsonValidationLogListener);
                         }
@@ -95,12 +95,12 @@ namespace AutoRest
                         else
                         {
                             Core.AutoRestController.Generate();
-                            if (!Settings.Instance.DisableSimplifier && Settings.Instance.CodeGenerator.IndexOf("csharp", StringComparison.OrdinalIgnoreCase) > -1)
+                            if (!Settings.Instance.JsonValidationMessages && !Settings.Instance.DisableSimplifier && Settings.Instance.CodeGenerator.IndexOf("csharp", StringComparison.OrdinalIgnoreCase) > -1)
                             {
                                 new CSharpSimplifier().Run().ConfigureAwait(false).GetAwaiter().GetResult();
                             }
                         }
-                        if (settings.Json)
+                        if (settings.JsonValidationMessages)
                         {
                             Console.WriteLine(jsonValidationLogListener.GetValidationMessagesAsJson());
                         }

--- a/src/core/AutoRest/Program.cs
+++ b/src/core/AutoRest/Program.cs
@@ -35,11 +35,20 @@ namespace AutoRest
                     {
                         settings = Settings.Create(args);
 
+                        var jsonValidationLogListener = new JsonValidationLogListener();
+
                         // set up logging
-                        Logger.Instance.AddListener(new ConsoleLogListener(
-                            settings.Debug ? Category.Debug : Category.Warning,
-                            settings.ValidationLevel,
-                            settings.Verbose));
+                        if (settings.Json)
+                        {
+                            Logger.Instance.AddListener(jsonValidationLogListener);
+                        }
+                        else
+                        {
+                            Logger.Instance.AddListener(new ConsoleLogListener(
+                                settings.Debug ? Category.Debug : Category.Warning,
+                                settings.ValidationLevel,
+                                settings.Verbose));
+                        }
                         Logger.Instance.AddListener(new SignalingLogListener(Category.Error, _ => generationFailed = true));
 
                         // internal preprocesor
@@ -90,6 +99,10 @@ namespace AutoRest
                             {
                                 new CSharpSimplifier().Run().ConfigureAwait(false).GetAwaiter().GetResult();
                             }
+                        }
+                        if (settings.Json)
+                        {
+                            Console.WriteLine(jsonValidationLogListener.GetValidationMessagesAsJson());
                         }
                     }
                     catch (Exception exception)

--- a/src/dev/AutoRest.Preview/Linting.cs
+++ b/src/dev/AutoRest.Preview/Linting.cs
@@ -100,7 +100,7 @@ namespace AutoRest.Preview
                         highlights.Add(new Highlight {
                             Start = start,
                             End = start + len,
-                            Message = $"{message.Severity}: [{message.Path.XPath}] {message.Message}"
+                            Message = $"{message.Severity}: [{message.Path.JsonPath}] {message.Message}"
                         });
                     } catch  {
                         

--- a/src/dev/AutoRest.Preview/Linting.cs
+++ b/src/dev/AutoRest.Preview/Linting.cs
@@ -93,14 +93,14 @@ namespace AutoRest.Preview
                 {
                     try {
                         scintilla.IndicatorCurrent = INDICATOR_BASE + (int)message.Severity;
-                        var node = message.Path.SelectNode(doc);
+                        var node = message.Path.ObjectPath.SelectNode(doc);
                         var start = node.Start.Index;
                         var len = Math.Max(1, node.End.Index - start);
                         scintilla.IndicatorFillRange(start, len);
                         highlights.Add(new Highlight {
                             Start = start,
                             End = start + len,
-                            Message = $"{message.Severity}: [{message.Path.JsonPath}] {message.Message}"
+                            Message = $"{message.Severity}: [{message.Path.ObjectPath.JsonPath}] {message.Message}"
                         });
                     } catch  {
                         

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -156,10 +156,10 @@ namespace AutoRest.Swagger.Tests
             var messages = CompareSwagger("misc_checks_01.json").ToArray();
             var missing = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id);
             Assert.NotEmpty(missing);
-            var error = missing.Where(err => err.Path.JsonPointer.StartsWith("#/definitions/")).FirstOrDefault();
+            var error = missing.Where(err => err.Path.JsonReference.StartsWith("#/definitions/")).FirstOrDefault();
             Assert.NotNull(error);
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/definitions/Database/properties/b", error.Path.JsonPointer);
+            Assert.Equal("#/definitions/Database/properties/b", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -171,10 +171,10 @@ namespace AutoRest.Swagger.Tests
             var messages = CompareSwagger("misc_checks_01.json").ToArray();
             var missing = messages.Where(m => m.Id == ComparisonMessages.TypeFormatChanged.Id);
             Assert.NotEmpty(missing);
-            var error = missing.Where(err => err.Path.JsonPointer.StartsWith("#/definitions/")).FirstOrDefault();
+            var error = missing.Where(err => err.Path.JsonReference.StartsWith("#/definitions/")).FirstOrDefault();
             Assert.NotNull(error);
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/definitions/Database/properties/c", error.Path.JsonPointer);
+            Assert.Equal("#/definitions/Database/properties/c", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace AutoRest.Swagger.Tests
         public void UnreferencedDefinitionRemoved()
         {
             var messages = CompareSwagger("misc_checks_02.json").ToArray();
-            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPointer.StartsWith("#/definitions/Unreferenced"));
+            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonReference.StartsWith("#/definitions/Unreferenced"));
             Assert.Empty(missing);
         }
 
@@ -195,7 +195,7 @@ namespace AutoRest.Swagger.Tests
         public void UnreferencedTypeChanged()
         {
             var messages = CompareSwagger("misc_checks_02.json").ToArray();
-            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPointer.StartsWith("#/definitions/Database"));
+            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonReference.StartsWith("#/definitions/Database"));
             Assert.Empty(missing);
         }
 
@@ -210,7 +210,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Paths", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Paths", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Operations", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Operations", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -238,7 +238,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Operations/post", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Operations/post", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/a", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/a", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/x-ar", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters/get/x-ar", error.Path.JsonReference);
         }
 
 
@@ -281,7 +281,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/c", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/c", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -295,7 +295,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/x-cr", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters/get/x-cr", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/b", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/b", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Info, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/d", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/d", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -337,7 +337,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.Skip(1).First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/e", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/e", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -352,7 +352,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/f", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/f", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -379,7 +379,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(changed);
             var error = changed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/post/registry/properties/b", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters/post/registry/properties/b", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -393,7 +393,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(removed);
             var error = removed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/200", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(removed);
             var error = removed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/202", error.Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/202", error.Path.JsonReference);
         }
 
         /// <summary>
@@ -421,10 +421,10 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(2, removed.Length);
 
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/201", removed[0].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/201", removed[0].Path.JsonReference);
 
             Assert.Equal(Category.Error, removed[1].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[1].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[1].Path.JsonReference);
         }
 
         /// <summary>
@@ -434,10 +434,10 @@ namespace AutoRest.Swagger.Tests
         public void ResponseSchemaChanged()
         {
             var messages = CompareSwagger("operation_check_02.json").ToArray();
-            var removed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPointer.Contains("Responses")).ToArray();
+            var removed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonReference.Contains("Responses")).ToArray();
             Assert.Equal(1, removed.Length);
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[0].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[0].Path.JsonReference);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace AutoRest.Swagger.Tests
             var added = messages.Where(m => m.Id == ComparisonMessages.AddingHeader.Id).ToArray();
             Assert.Equal(1, added.Length);
             Assert.Equal(Category.Info, added[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-c", added[0].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-c", added[0].Path.JsonReference);
         }
 
         /// <summary>
@@ -463,7 +463,7 @@ namespace AutoRest.Swagger.Tests
             var removed = messages.Where(m => m.Id == ComparisonMessages.RemovingHeader.Id).ToArray();
             Assert.Equal(1, removed.Length);
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-a", removed[0].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-a", removed[0].Path.JsonReference);
         }
 
         /// <summary>
@@ -473,10 +473,10 @@ namespace AutoRest.Swagger.Tests
         public void ResponseHeaderTypeChanged()
         {
             var messages = CompareSwagger("operation_check_03.json").ToArray();
-            var changed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPointer.Contains("Responses")).ToArray();
+            var changed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonReference.Contains("Responses")).ToArray();
             Assert.Equal(1, changed.Length);
             Assert.Equal(Category.Error, changed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-b", changed[0].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-b", changed[0].Path.JsonReference);
         }
 
         /// <summary>
@@ -486,7 +486,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void RequestArrayFormatChanged()
         {
-            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPointer.Contains("Parameters")).ToArray();
+            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonReference.Contains("Parameters")).ToArray();
             var changed = messages.Where(m => m.Id == ComparisonMessages.ArrayCollectionFormatChanged.Id).ToArray();
 
             Assert.Equal(4, changed.Length);
@@ -494,10 +494,10 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[1].Severity);
             Assert.Equal(Category.Error, changed[2].Severity);
             Assert.Equal(Category.Error, changed[3].Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/a", changed[0].Path.JsonPointer);
-            Assert.Equal("#/paths/~1api~1Parameters/get/b", changed[1].Path.JsonPointer);
-            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/a", changed[2].Path.JsonPointer);
-            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/b", changed[3].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters/get/a", changed[0].Path.JsonReference);
+            Assert.Equal("#/paths/~1api~1Parameters/get/b", changed[1].Path.JsonReference);
+            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/a", changed[2].Path.JsonReference);
+            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/b", changed[3].Path.JsonReference);
         }
 
         /// <summary>
@@ -507,7 +507,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void RequestTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPointer.Contains("Parameters")).ToArray();
+            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonReference.Contains("Parameters")).ToArray();
             var stricter = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsStronger.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -524,7 +524,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void ResponseArrayFormatChanged()
         {
-            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPointer.Contains("Responses")).ToArray();
+            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonReference.Contains("Responses")).ToArray();
             var changed = messages.Where(m => m.Id == ComparisonMessages.ArrayCollectionFormatChanged.Id).ToArray();
 
             Assert.Equal(4, changed.Length);
@@ -532,8 +532,8 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[1].Severity);
             Assert.Equal(Category.Error, changed[2].Severity);
             Assert.Equal(Category.Error, changed[3].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/a", changed[0].Path.JsonPointer);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/b", changed[1].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/a", changed[0].Path.JsonReference);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/b", changed[1].Path.JsonReference);
         }
 
         /// <summary>
@@ -542,7 +542,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void ResponseTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPointer.Contains("Responses")).ToArray();
+            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonReference.Contains("Responses")).ToArray();
             var relaxed = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsWeaker.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -569,12 +569,12 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[3].Severity);
             Assert.Equal(Category.Error, changed[4].Severity);
             Assert.Equal(Category.Error, changed[5].Severity);
-            Assert.Equal("#/parameters/a", changed[0].Path.JsonPointer);
-            Assert.Equal("#/parameters/b", changed[1].Path.JsonPointer);
-            Assert.Equal("#/parameters/e/properties/a", changed[2].Path.JsonPointer);
-            Assert.Equal("#/parameters/e/properties/b", changed[3].Path.JsonPointer);
-            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPointer);
-            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPointer);
+            Assert.Equal("#/parameters/a", changed[0].Path.JsonReference);
+            Assert.Equal("#/parameters/b", changed[1].Path.JsonReference);
+            Assert.Equal("#/parameters/e/properties/a", changed[2].Path.JsonReference);
+            Assert.Equal("#/parameters/e/properties/b", changed[3].Path.JsonReference);
+            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonReference);
+            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonReference);
         }
 
         /// <summary>
@@ -584,7 +584,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void GobalParamTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("param_check_01.json").Where(m => m.Path.JsonPointer.Contains("parameters")).ToArray();
+            var messages = CompareSwagger("param_check_01.json").Where(m => m.Path.JsonReference.Contains("parameters")).ToArray();
             var stricter = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsStronger.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -611,12 +611,12 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[3].Severity);
             Assert.Equal(Category.Error, changed[4].Severity);
             Assert.Equal(Category.Error, changed[5].Severity);
-            Assert.Equal("#/responses/200/properties/a", changed[0].Path.JsonPointer);
-            Assert.Equal("#/responses/200/properties/b", changed[1].Path.JsonPointer);
-            Assert.Equal("#/responses/201/properties/a", changed[2].Path.JsonPointer);
-            Assert.Equal("#/responses/201/properties/b", changed[3].Path.JsonPointer);
-            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPointer);
-            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPointer);
+            Assert.Equal("#/responses/200/properties/a", changed[0].Path.JsonReference);
+            Assert.Equal("#/responses/200/properties/b", changed[1].Path.JsonReference);
+            Assert.Equal("#/responses/201/properties/a", changed[2].Path.JsonReference);
+            Assert.Equal("#/responses/201/properties/b", changed[3].Path.JsonReference);
+            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonReference);
+            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonReference);
         }
 
         /// <summary>
@@ -625,7 +625,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void GlobalResponseTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("response_check_01.json").Where(m => m.Path.JsonPointer.Contains("responses")).ToArray();
+            var messages = CompareSwagger("response_check_01.json").Where(m => m.Path.JsonReference.Contains("responses")).ToArray();
             var relaxed = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsWeaker.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -156,10 +156,10 @@ namespace AutoRest.Swagger.Tests
             var messages = CompareSwagger("misc_checks_01.json").ToArray();
             var missing = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id);
             Assert.NotEmpty(missing);
-            var error = missing.Where(err => err.Path.XPath.StartsWith("#/definitions/")).FirstOrDefault();
+            var error = missing.Where(err => err.Path.JsonPath.StartsWith("#/definitions/")).FirstOrDefault();
             Assert.NotNull(error);
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/definitions/Database/properties/b", error.Path.XPath);
+            Assert.Equal("#/definitions/Database/properties/b", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -171,10 +171,10 @@ namespace AutoRest.Swagger.Tests
             var messages = CompareSwagger("misc_checks_01.json").ToArray();
             var missing = messages.Where(m => m.Id == ComparisonMessages.TypeFormatChanged.Id);
             Assert.NotEmpty(missing);
-            var error = missing.Where(err => err.Path.XPath.StartsWith("#/definitions/")).FirstOrDefault();
+            var error = missing.Where(err => err.Path.JsonPath.StartsWith("#/definitions/")).FirstOrDefault();
             Assert.NotNull(error);
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/definitions/Database/properties/c", error.Path.XPath);
+            Assert.Equal("#/definitions/Database/properties/c", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace AutoRest.Swagger.Tests
         public void UnreferencedDefinitionRemoved()
         {
             var messages = CompareSwagger("misc_checks_02.json").ToArray();
-            var missing = messages.Where(m => m.Id > 0 && m.Path.XPath.StartsWith("#/definitions/Unreferenced"));
+            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPath.StartsWith("#/definitions/Unreferenced"));
             Assert.Empty(missing);
         }
 
@@ -195,7 +195,7 @@ namespace AutoRest.Swagger.Tests
         public void UnreferencedTypeChanged()
         {
             var messages = CompareSwagger("misc_checks_02.json").ToArray();
-            var missing = messages.Where(m => m.Id > 0 && m.Path.XPath.StartsWith("#/definitions/Database"));
+            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPath.StartsWith("#/definitions/Database"));
             Assert.Empty(missing);
         }
 
@@ -210,7 +210,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Paths", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Paths", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Operations", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Operations", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -238,7 +238,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Operations/post", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Operations/post", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/a", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/a", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/x-ar", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters/get/x-ar", error.Path.JsonPath);
         }
 
 
@@ -281,7 +281,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/c", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/c", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -295,7 +295,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/x-cr", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters/get/x-cr", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/b", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/b", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Info, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/d", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/d", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -337,7 +337,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.Skip(1).First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/e", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/e", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -352,7 +352,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/f", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/f", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -379,7 +379,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(changed);
             var error = changed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/post/registry/properties/b", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters/post/registry/properties/b", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -393,7 +393,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(removed);
             var error = removed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(removed);
             var error = removed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/202", error.Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/202", error.Path.JsonPath);
         }
 
         /// <summary>
@@ -421,10 +421,10 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(2, removed.Length);
 
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/201", removed[0].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/201", removed[0].Path.JsonPath);
 
             Assert.Equal(Category.Error, removed[1].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[1].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[1].Path.JsonPath);
         }
 
         /// <summary>
@@ -434,10 +434,10 @@ namespace AutoRest.Swagger.Tests
         public void ResponseSchemaChanged()
         {
             var messages = CompareSwagger("operation_check_02.json").ToArray();
-            var removed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.XPath.Contains("Responses")).ToArray();
+            var removed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPath.Contains("Responses")).ToArray();
             Assert.Equal(1, removed.Length);
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[0].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[0].Path.JsonPath);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace AutoRest.Swagger.Tests
             var added = messages.Where(m => m.Id == ComparisonMessages.AddingHeader.Id).ToArray();
             Assert.Equal(1, added.Length);
             Assert.Equal(Category.Info, added[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-c", added[0].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-c", added[0].Path.JsonPath);
         }
 
         /// <summary>
@@ -463,7 +463,7 @@ namespace AutoRest.Swagger.Tests
             var removed = messages.Where(m => m.Id == ComparisonMessages.RemovingHeader.Id).ToArray();
             Assert.Equal(1, removed.Length);
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-a", removed[0].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-a", removed[0].Path.JsonPath);
         }
 
         /// <summary>
@@ -473,10 +473,10 @@ namespace AutoRest.Swagger.Tests
         public void ResponseHeaderTypeChanged()
         {
             var messages = CompareSwagger("operation_check_03.json").ToArray();
-            var changed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.XPath.Contains("Responses")).ToArray();
+            var changed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPath.Contains("Responses")).ToArray();
             Assert.Equal(1, changed.Length);
             Assert.Equal(Category.Error, changed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-b", changed[0].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-b", changed[0].Path.JsonPath);
         }
 
         /// <summary>
@@ -486,7 +486,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void RequestArrayFormatChanged()
         {
-            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.XPath.Contains("Parameters")).ToArray();
+            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPath.Contains("Parameters")).ToArray();
             var changed = messages.Where(m => m.Id == ComparisonMessages.ArrayCollectionFormatChanged.Id).ToArray();
 
             Assert.Equal(4, changed.Length);
@@ -494,10 +494,10 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[1].Severity);
             Assert.Equal(Category.Error, changed[2].Severity);
             Assert.Equal(Category.Error, changed[3].Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/a", changed[0].Path.XPath);
-            Assert.Equal("#/paths/~1api~1Parameters/get/b", changed[1].Path.XPath);
-            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/a", changed[2].Path.XPath);
-            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/b", changed[3].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Parameters/get/a", changed[0].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters/get/b", changed[1].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/a", changed[2].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/b", changed[3].Path.JsonPath);
         }
 
         /// <summary>
@@ -507,7 +507,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void RequestTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.XPath.Contains("Parameters")).ToArray();
+            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPath.Contains("Parameters")).ToArray();
             var stricter = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsStronger.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -524,7 +524,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void ResponseArrayFormatChanged()
         {
-            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.XPath.Contains("Responses")).ToArray();
+            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPath.Contains("Responses")).ToArray();
             var changed = messages.Where(m => m.Id == ComparisonMessages.ArrayCollectionFormatChanged.Id).ToArray();
 
             Assert.Equal(4, changed.Length);
@@ -532,8 +532,8 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[1].Severity);
             Assert.Equal(Category.Error, changed[2].Severity);
             Assert.Equal(Category.Error, changed[3].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/a", changed[0].Path.XPath);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/b", changed[1].Path.XPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/a", changed[0].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/b", changed[1].Path.JsonPath);
         }
 
         /// <summary>
@@ -542,7 +542,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void ResponseTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.XPath.Contains("Responses")).ToArray();
+            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPath.Contains("Responses")).ToArray();
             var relaxed = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsWeaker.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -569,12 +569,12 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[3].Severity);
             Assert.Equal(Category.Error, changed[4].Severity);
             Assert.Equal(Category.Error, changed[5].Severity);
-            Assert.Equal("#/parameters/a", changed[0].Path.XPath);
-            Assert.Equal("#/parameters/b", changed[1].Path.XPath);
-            Assert.Equal("#/parameters/e/properties/a", changed[2].Path.XPath);
-            Assert.Equal("#/parameters/e/properties/b", changed[3].Path.XPath);
-            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.XPath);
-            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.XPath);
+            Assert.Equal("#/parameters/a", changed[0].Path.JsonPath);
+            Assert.Equal("#/parameters/b", changed[1].Path.JsonPath);
+            Assert.Equal("#/parameters/e/properties/a", changed[2].Path.JsonPath);
+            Assert.Equal("#/parameters/e/properties/b", changed[3].Path.JsonPath);
+            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPath);
+            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPath);
         }
 
         /// <summary>
@@ -584,7 +584,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void GobalParamTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("param_check_01.json").Where(m => m.Path.XPath.Contains("parameters")).ToArray();
+            var messages = CompareSwagger("param_check_01.json").Where(m => m.Path.JsonPath.Contains("parameters")).ToArray();
             var stricter = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsStronger.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -611,12 +611,12 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[3].Severity);
             Assert.Equal(Category.Error, changed[4].Severity);
             Assert.Equal(Category.Error, changed[5].Severity);
-            Assert.Equal("#/responses/200/properties/a", changed[0].Path.XPath);
-            Assert.Equal("#/responses/200/properties/b", changed[1].Path.XPath);
-            Assert.Equal("#/responses/201/properties/a", changed[2].Path.XPath);
-            Assert.Equal("#/responses/201/properties/b", changed[3].Path.XPath);
-            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.XPath);
-            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.XPath);
+            Assert.Equal("#/responses/200/properties/a", changed[0].Path.JsonPath);
+            Assert.Equal("#/responses/200/properties/b", changed[1].Path.JsonPath);
+            Assert.Equal("#/responses/201/properties/a", changed[2].Path.JsonPath);
+            Assert.Equal("#/responses/201/properties/b", changed[3].Path.JsonPath);
+            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPath);
+            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPath);
         }
 
         /// <summary>
@@ -625,7 +625,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void GlobalResponseTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("response_check_01.json").Where(m => m.Path.XPath.Contains("responses")).ToArray();
+            var messages = CompareSwagger("response_check_01.json").Where(m => m.Path.JsonPath.Contains("responses")).ToArray();
             var relaxed = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsWeaker.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -156,10 +156,10 @@ namespace AutoRest.Swagger.Tests
             var messages = CompareSwagger("misc_checks_01.json").ToArray();
             var missing = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id);
             Assert.NotEmpty(missing);
-            var error = missing.Where(err => err.Path.JsonPath.StartsWith("#/definitions/")).FirstOrDefault();
+            var error = missing.Where(err => err.Path.JsonPointer.StartsWith("#/definitions/")).FirstOrDefault();
             Assert.NotNull(error);
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/definitions/Database/properties/b", error.Path.JsonPath);
+            Assert.Equal("#/definitions/Database/properties/b", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -171,10 +171,10 @@ namespace AutoRest.Swagger.Tests
             var messages = CompareSwagger("misc_checks_01.json").ToArray();
             var missing = messages.Where(m => m.Id == ComparisonMessages.TypeFormatChanged.Id);
             Assert.NotEmpty(missing);
-            var error = missing.Where(err => err.Path.JsonPath.StartsWith("#/definitions/")).FirstOrDefault();
+            var error = missing.Where(err => err.Path.JsonPointer.StartsWith("#/definitions/")).FirstOrDefault();
             Assert.NotNull(error);
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/definitions/Database/properties/c", error.Path.JsonPath);
+            Assert.Equal("#/definitions/Database/properties/c", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace AutoRest.Swagger.Tests
         public void UnreferencedDefinitionRemoved()
         {
             var messages = CompareSwagger("misc_checks_02.json").ToArray();
-            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPath.StartsWith("#/definitions/Unreferenced"));
+            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPointer.StartsWith("#/definitions/Unreferenced"));
             Assert.Empty(missing);
         }
 
@@ -195,7 +195,7 @@ namespace AutoRest.Swagger.Tests
         public void UnreferencedTypeChanged()
         {
             var messages = CompareSwagger("misc_checks_02.json").ToArray();
-            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPath.StartsWith("#/definitions/Database"));
+            var missing = messages.Where(m => m.Id > 0 && m.Path.JsonPointer.StartsWith("#/definitions/Database"));
             Assert.Empty(missing);
         }
 
@@ -210,7 +210,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Paths", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Paths", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -224,7 +224,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Operations", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Operations", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -238,7 +238,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Operations/post", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Operations/post", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -252,7 +252,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/a", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/a", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -266,7 +266,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/x-ar", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters/get/x-ar", error.Path.JsonPointer);
         }
 
 
@@ -281,7 +281,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/c", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/c", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -295,7 +295,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/x-cr", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters/get/x-cr", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -309,7 +309,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/b", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/b", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -323,7 +323,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Info, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/d", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/d", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -337,7 +337,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.Skip(1).First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/e", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/e", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -352,7 +352,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(missing);
             var error = missing.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/f", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters~1{a}/get/f", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -379,7 +379,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(changed);
             var error = changed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/post/registry/properties/b", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters/post/registry/properties/b", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -393,7 +393,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(removed);
             var error = removed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -407,7 +407,7 @@ namespace AutoRest.Swagger.Tests
             Assert.NotEmpty(removed);
             var error = removed.First();
             Assert.Equal(Category.Error, error.Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/202", error.Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/202", error.Path.JsonPointer);
         }
 
         /// <summary>
@@ -421,10 +421,10 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(2, removed.Length);
 
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/201", removed[0].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/201", removed[0].Path.JsonPointer);
 
             Assert.Equal(Category.Error, removed[1].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[1].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[1].Path.JsonPointer);
         }
 
         /// <summary>
@@ -434,10 +434,10 @@ namespace AutoRest.Swagger.Tests
         public void ResponseSchemaChanged()
         {
             var messages = CompareSwagger("operation_check_02.json").ToArray();
-            var removed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPath.Contains("Responses")).ToArray();
+            var removed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPointer.Contains("Responses")).ToArray();
             Assert.Equal(1, removed.Length);
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[0].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/400/properties/id", removed[0].Path.JsonPointer);
         }
 
         /// <summary>
@@ -450,7 +450,7 @@ namespace AutoRest.Swagger.Tests
             var added = messages.Where(m => m.Id == ComparisonMessages.AddingHeader.Id).ToArray();
             Assert.Equal(1, added.Length);
             Assert.Equal(Category.Info, added[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-c", added[0].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-c", added[0].Path.JsonPointer);
         }
 
         /// <summary>
@@ -463,7 +463,7 @@ namespace AutoRest.Swagger.Tests
             var removed = messages.Where(m => m.Id == ComparisonMessages.RemovingHeader.Id).ToArray();
             Assert.Equal(1, removed.Length);
             Assert.Equal(Category.Error, removed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-a", removed[0].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-a", removed[0].Path.JsonPointer);
         }
 
         /// <summary>
@@ -473,10 +473,10 @@ namespace AutoRest.Swagger.Tests
         public void ResponseHeaderTypeChanged()
         {
             var messages = CompareSwagger("operation_check_03.json").ToArray();
-            var changed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPath.Contains("Responses")).ToArray();
+            var changed = messages.Where(m => m.Id == ComparisonMessages.TypeChanged.Id && m.Path.JsonPointer.Contains("Responses")).ToArray();
             Assert.Equal(1, changed.Length);
             Assert.Equal(Category.Error, changed[0].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/x-b", changed[0].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/x-b", changed[0].Path.JsonPointer);
         }
 
         /// <summary>
@@ -486,7 +486,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void RequestArrayFormatChanged()
         {
-            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPath.Contains("Parameters")).ToArray();
+            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPointer.Contains("Parameters")).ToArray();
             var changed = messages.Where(m => m.Id == ComparisonMessages.ArrayCollectionFormatChanged.Id).ToArray();
 
             Assert.Equal(4, changed.Length);
@@ -494,10 +494,10 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[1].Severity);
             Assert.Equal(Category.Error, changed[2].Severity);
             Assert.Equal(Category.Error, changed[3].Severity);
-            Assert.Equal("#/paths/~1api~1Parameters/get/a", changed[0].Path.JsonPath);
-            Assert.Equal("#/paths/~1api~1Parameters/get/b", changed[1].Path.JsonPath);
-            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/a", changed[2].Path.JsonPath);
-            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/b", changed[3].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Parameters/get/a", changed[0].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters/get/b", changed[1].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/a", changed[2].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Parameters/put/a/properties/b", changed[3].Path.JsonPointer);
         }
 
         /// <summary>
@@ -507,7 +507,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void RequestTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPath.Contains("Parameters")).ToArray();
+            var messages = CompareSwagger("operation_check_04.json").Where(m => m.Path.JsonPointer.Contains("Parameters")).ToArray();
             var stricter = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsStronger.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -524,7 +524,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void ResponseArrayFormatChanged()
         {
-            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPath.Contains("Responses")).ToArray();
+            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPointer.Contains("Responses")).ToArray();
             var changed = messages.Where(m => m.Id == ComparisonMessages.ArrayCollectionFormatChanged.Id).ToArray();
 
             Assert.Equal(4, changed.Length);
@@ -532,8 +532,8 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[1].Severity);
             Assert.Equal(Category.Error, changed[2].Severity);
             Assert.Equal(Category.Error, changed[3].Severity);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/a", changed[0].Path.JsonPath);
-            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/b", changed[1].Path.JsonPath);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/a", changed[0].Path.JsonPointer);
+            Assert.Equal("#/paths/~1api~1Responses/get/200/properties/b", changed[1].Path.JsonPointer);
         }
 
         /// <summary>
@@ -542,7 +542,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void ResponseTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPath.Contains("Responses")).ToArray();
+            var messages = CompareSwagger("operation_check_05.json").Where(m => m.Path.JsonPointer.Contains("Responses")).ToArray();
             var relaxed = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsWeaker.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -569,12 +569,12 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[3].Severity);
             Assert.Equal(Category.Error, changed[4].Severity);
             Assert.Equal(Category.Error, changed[5].Severity);
-            Assert.Equal("#/parameters/a", changed[0].Path.JsonPath);
-            Assert.Equal("#/parameters/b", changed[1].Path.JsonPath);
-            Assert.Equal("#/parameters/e/properties/a", changed[2].Path.JsonPath);
-            Assert.Equal("#/parameters/e/properties/b", changed[3].Path.JsonPath);
-            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPath);
-            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPath);
+            Assert.Equal("#/parameters/a", changed[0].Path.JsonPointer);
+            Assert.Equal("#/parameters/b", changed[1].Path.JsonPointer);
+            Assert.Equal("#/parameters/e/properties/a", changed[2].Path.JsonPointer);
+            Assert.Equal("#/parameters/e/properties/b", changed[3].Path.JsonPointer);
+            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPointer);
+            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPointer);
         }
 
         /// <summary>
@@ -584,7 +584,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void GobalParamTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("param_check_01.json").Where(m => m.Path.JsonPath.Contains("parameters")).ToArray();
+            var messages = CompareSwagger("param_check_01.json").Where(m => m.Path.JsonPointer.Contains("parameters")).ToArray();
             var stricter = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsStronger.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();
@@ -611,12 +611,12 @@ namespace AutoRest.Swagger.Tests
             Assert.Equal(Category.Error, changed[3].Severity);
             Assert.Equal(Category.Error, changed[4].Severity);
             Assert.Equal(Category.Error, changed[5].Severity);
-            Assert.Equal("#/responses/200/properties/a", changed[0].Path.JsonPath);
-            Assert.Equal("#/responses/200/properties/b", changed[1].Path.JsonPath);
-            Assert.Equal("#/responses/201/properties/a", changed[2].Path.JsonPath);
-            Assert.Equal("#/responses/201/properties/b", changed[3].Path.JsonPath);
-            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPath);
-            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPath);
+            Assert.Equal("#/responses/200/properties/a", changed[0].Path.JsonPointer);
+            Assert.Equal("#/responses/200/properties/b", changed[1].Path.JsonPointer);
+            Assert.Equal("#/responses/201/properties/a", changed[2].Path.JsonPointer);
+            Assert.Equal("#/responses/201/properties/b", changed[3].Path.JsonPointer);
+            Assert.Equal("#/definitions/A/properties/a", changed[4].Path.JsonPointer);
+            Assert.Equal("#/definitions/A/properties/b", changed[5].Path.JsonPointer);
         }
 
         /// <summary>
@@ -625,7 +625,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void GlobalResponseTypeConstraintsChanged()
         {
-            var messages = CompareSwagger("response_check_01.json").Where(m => m.Path.JsonPath.Contains("responses")).ToArray();
+            var messages = CompareSwagger("response_check_01.json").Where(m => m.Path.JsonPointer.Contains("responses")).ToArray();
             var relaxed = messages.Where(m => m.Id == ComparisonMessages.ConstraintIsWeaker.Id && m.Severity == Category.Error).ToArray();
             var breaking = messages.Where(m => m.Id == ComparisonMessages.ConstraintChanged.Id && m.Severity == Category.Error).ToArray();
             var info = messages.Where(m => m.Id > 0 && m.Severity == Category.Info).ToArray();

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -34,7 +34,7 @@ namespace AutoRest.Swagger.Tests
         internal static void AssertOnlyValidationMessage(this IEnumerable<ValidationMessage> messages, Type validationType, int count)
         {
             // checks that the collection has the right number of items and each is the correct type.
-            Assert.Equal(count, messages.Count(message => message.Type == validationType));
+            Assert.Equal(count, messages.Count(message => message.Rule.GetType() == validationType));
         }
     }
 
@@ -247,7 +247,7 @@ namespace AutoRest.Swagger.Tests
         public void Pageable200ResponseNotModeledValidation()
         {
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "pageable-no-200-response.json"));
-            messages.Any(m => m.Type == typeof(PageableRequires200Response));
+            messages.Any(m => m.Rule.GetType() == typeof(PageableRequires200Response));
         }
 
         [Fact]

--- a/src/modeler/AutoRest.Swagger/BuilderExtensions.cs
+++ b/src/modeler/AutoRest.Swagger/BuilderExtensions.cs
@@ -64,19 +64,19 @@ namespace AutoRest.Swagger
             switch (swaggerObject.Type)
             {
                 case DataType.Array:
-                    return (constraintName == Constraint.MinItems.ToString() ||
-                            constraintName == Constraint.MaxItems.ToString() ||
-                            constraintName == Constraint.UniqueItems.ToString());
+                    return (constraintName.EqualsIgnoreCase(Constraint.MinItems.ToString()) ||
+                            constraintName.EqualsIgnoreCase(Constraint.MaxItems.ToString()) ||
+                            constraintName.EqualsIgnoreCase(Constraint.UniqueItems.ToString()));
                 case DataType.Integer:
                 case DataType.Number:
-                    return constraintName == Constraint.ExclusiveMaximum.ToString() ||
-                           constraintName == Constraint.ExclusiveMinimum.ToString() ||
-                           constraintName == Constraint.MultipleOf.ToString() ||
-                           constraintName == "Minimum" || constraintName == "Maximum";
+                    return constraintName.EqualsIgnoreCase(Constraint.ExclusiveMaximum.ToString()) ||
+                           constraintName.EqualsIgnoreCase(Constraint.ExclusiveMinimum.ToString()) ||
+                           constraintName.EqualsIgnoreCase(Constraint.MultipleOf.ToString()) ||
+                           constraintName.EqualsIgnoreCase("minimum") || constraintName.EqualsIgnoreCase("maximum");
                 case DataType.String:
-                    return (constraintName == Constraint.MinLength.ToString() ||
-                            constraintName == Constraint.MaxLength.ToString() ||
-                            constraintName == Constraint.Pattern.ToString());
+                    return (constraintName.EqualsIgnoreCase(Constraint.MinLength.ToString()) ||
+                            constraintName.EqualsIgnoreCase(Constraint.MaxLength.ToString()) ||
+                            constraintName.EqualsIgnoreCase(Constraint.Pattern.ToString()));
                  default:
                     return false;
             }

--- a/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
@@ -144,6 +144,11 @@ namespace AutoRest.Swagger.Model
         public ExternalDoc ExternalDocs { get; set; }
 
         /// <summary>
+        /// Path to this Swagger.
+        /// </summary>
+        internal Uri FilePath { get; set; }
+
+        /// <summary>
         /// Compare a modified document node (this) to a previous one and look for breaking as well as non-breaking changes.
         /// </summary>
         /// <param name="context">The modified document context.</param>

--- a/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
@@ -80,7 +80,7 @@ namespace AutoRest.Swagger
             {
                 // Look for semantic errors and warnings in the document.
                 var validator = new RecursiveObjectValidator(PropertyNameResolver.JsonName);
-                foreach (var validationEx in validator.GetValidationExceptions(ServiceDefinition))
+                foreach (var validationEx in validator.GetValidationExceptions(ServiceDefinition.FilePath, ServiceDefinition))
                 {
                     Logger.Instance.Log(validationEx);
                 }
@@ -183,7 +183,7 @@ namespace AutoRest.Swagger
 
             // Look for semantic errors and warnings in the new document.
             var validator = new RecursiveObjectValidator(PropertyNameResolver.JsonName);
-            var LogMessages = validator.GetValidationExceptions(newDefintion).ToList();
+            var LogMessages = validator.GetValidationExceptions(newDefintion.FilePath, newDefintion).ToList();
 
             // Only compare versions if the new version is correct.
             var comparisonMessages = 

--- a/src/modeler/AutoRest.Swagger/SwaggerParser.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerParser.cs
@@ -139,7 +139,9 @@ namespace AutoRest.Swagger
                 settings.Converters.Add(new SchemaRequiredItemConverter());
                 settings.Converters.Add(new SecurityDefinitionConverter());
                 var swaggerService = JsonConvert.DeserializeObject<ServiceDefinition>(swaggerDocument, settings);
-
+                Uri filePath = null;
+                Uri.TryCreate(path, UriKind.RelativeOrAbsolute, out filePath);
+                swaggerService.FilePath = filePath;
                 return swaggerService;
             }
             catch (JsonException ex)

--- a/src/modeler/AutoRest.Swagger/Validation/ExtensionRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ExtensionRule.cs
@@ -25,7 +25,7 @@ namespace AutoRest.Swagger.Validation
             // Only try to validate an object with this extension rule if the extension name matches the key
             if (context.Key == ExtensionName && !IsValid(entity, context, out formatParams))
             {
-                yield return new ValidationMessage(context.Path, this, formatParams);
+                yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, formatParams);
             }
         }
 

--- a/src/modeler/AutoRest.Swagger/Validation/InvalidConstraint.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/InvalidConstraint.cs
@@ -27,17 +27,17 @@ namespace AutoRest.Swagger.Validation
             return (context.Parent?.Value as SwaggerObject).IsConstraintSupported(context.Key);
         }
 
-    /// <summary>
-    ///     The template message for this Rule.
-    /// </summary>
-    /// <remarks>
-    ///     This may contain placeholders '{0}' for parameterized messages.
-    /// </remarks>
+        /// <summary>
+        ///     The template message for this Rule.
+        /// </summary>
+        /// <remarks>
+        ///     This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
         public override string MessageTemplate => Resources.InvalidConstraint;
 
-            /// <summary>
-            ///     The severity of this message (ie, debug/info/warning/error/fatal, etc)
-            /// </summary>
-            public override Category Severity => Category.Warning;
-        }
+        /// <summary>
+        ///     The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Warning;
     }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/ModelTypeIncomplete.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ModelTypeIncomplete.cs
@@ -18,7 +18,7 @@ namespace AutoRest.Swagger.Validation
             {
                 if (schema.Description == null)
                 {
-                    yield return new ValidationMessage(context.Path, this, "description");
+                    yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, "description");
                 }
             }
         }


### PR DESCRIPTION
Here you go Mr. @amarzavery!
Use `-JsonValidationMessages` switch to get console output such as
```json5
[
  {
    "type": "Warning",
    "code": "LongRunningResponseValidation",
    "message": "An operation with x-ms-long-running-operation extension must have a valid terminal success status code. 200 or 201 for Put/Patch. 200, 201 or 204 for Post. 200 or 204 or both for Delete.",
    "jsonref": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-cdn/2016-10-02/swagger/cdn.json#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Cdn~1profiles~1{profileName}~1endpoints~1{endpointName}~1start/post/extensions/x-ms-long-running-operation"
  },
  {
    "type": "Warning",
    "code": "InvalidConstraint",
    "message": "Constraint is not supported for this type and will be ignored.",
    "jsonref": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-cdn/2016-10-02/swagger/cdn.json#/parameters/resourceGroupNameParameter/minLength"
  },
  {
    "type": "Warning",
    "code": "InvalidConstraint",
    "message": "Constraint is not supported for this type and will be ignored.",
    "jsonref": "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-cdn/2016-10-02/swagger/cdn.json#/parameters/resourceGroupNameParameter/pattern"
  }
]
```

Careful: Since logging to the console is disabled in that mode, there will be no console output if anything goes wrong.