### PR TITLE
Update macOS & Linux install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,48 +4,57 @@
 
 The **AutoRest** tool generates client libraries for accessing RESTful web services. Input to *AutoRest* is a spec that describes the REST API using the [Open API Initiative](https://github.com/OAI/OpenAPI-Specification) format.
 
-##Getting AutoRest
+## Getting AutoRest
+### Windows
+##### Nuget
 The AutoRest tools can be installed with Nuget for use in a Visual Studio project:
 [![AutoRest NuGet](https://img.shields.io/nuget/v/autorest.svg?style=flat-square)](https://www.nuget.org/packages/autorest/)
-
+##### Chocolatey
 Alternatively it can be installed from [Chocolatey](https://chocolatey.org/) by running:
 [![AutoRest Chocolatey](https://img.shields.io/chocolatey/v/autorest.svg?style=flat-square)](https://chocolatey.org/packages/AutoRest)
 
     choco install autorest
-    
+
+##### MyGet
 Nightlies are available via MyGet:
 [![AutoRest MyGet](https://img.shields.io/myget/autorest/vpre/autorest.svg?style=flat-square)](https://www.myget.org/gallery/autorest)
 
-AutoRest can be run on macOS and *nix using [Mono](http://www.mono-project.com/download):
+### macOS & Linux
+##### Homebrew
+The easiest way for macOS users to get AutoRest is via [Homebrew](https://brew.sh/):
+    
+    brew update && brew install autorest
 
-  # Download & Unpack Autorest
-  curl -LO https://github.com/Azure/autorest/releases/download/AutoRest-0.16.0/autorest.0.16.0.zip && \
-  unzip autorest.0.16.0.zip -d autorest/ && \
-  cd autorest && \
+##### Mono
+It can also run on macOS and Linux using [Mono](http://www.mono-project.com/download):
+```
+# Download & Unpack Autorest
+curl -LO https://github.com/Azure/autorest/releases/download/AutoRest-0.16.0/autorest.0.16.0.zip && unzip autorest.0.16.0.zip -d autorest/ && cd autorest
 
-  # Download Swagger.json example
-  curl -O https://raw.githubusercontent.com/Azure/autorest/master/Samples/petstore/petstore.json && \
+# Download Swagger.json example
+curl -O https://raw.githubusercontent.com/Azure/autorest/master/Samples/petstore/petstore.json
 
-  # Run AutoRest using mono
-  mono AutoRest.exe \
-    -CodeGenerator CSharp \
-    -Input petstore.json \
-    -OutputDirectory CSharp_PetStore -Namespace PetStore
+# Run AutoRest using mono
+mono AutoRest.exe \
+  -CodeGenerator CSharp \
+  -Input petstore.json \
+  -OutputDirectory CSharp_PetStore -Namespace PetStore
+```
+##### Docker
+Or using [Docker](https://docs.docker.com/engine/installation):
+```
+# Download Swagger.json example
+curl -O https://raw.githubusercontent.com/Azure/autorest/master/Samples/petstore/petstore.json
 
-Or [Docker](https://docs.docker.com/engine/installation):
+# Download latest AutoRest Docker image
+docker pull azuresdk/autorest:latest
 
-  # Download Swagger.json example
-  `curl -O https://raw.githubusercontent.com/Azure/autorest/master/Samples/petstore/petstore.json`
-
-  # Download latest AutoRest Docker image
-  `docker pull azuresdk/autorest:latest`
-
-  # Run AutoRest using Docker, mounting the current folder (pwd) into /home inside the container
-  `docker run -it --rm -v $(pwd):/home azuresdk/autorest:latest autorest \
-    -CodeGenerator CSharp \
-    -Input /home/petstore.json \
-    -OutputDirectory /home/CSharp_PetStore -Namespace PetStore`
-
+# Run AutoRest using Docker, mounting the current folder (pwd) into /home inside the container
+docker run -it --rm -v $(pwd):/home azuresdk/autorest:latest autorest \
+  -CodeGenerator CSharp \
+  -Input /home/petstore.json \
+  -OutputDirectory /home/CSharp_PetStore -Namespace PetStore
+```
 ## Building AutoRest
 AutoRest is developed primarily in C# but generates code for multiple languages. See [this link](docs/developer/guide/building-code.md) to build and test AutoRest.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,8 +26,8 @@
 
 <p>The <strong>AutoRest</strong> tool generates client libraries for accessing RESTful web services. Input to <em>AutoRest</em> is a spec that describes the REST API using the <a href="https://github.com/OAI/OpenAPI-Specification">Open API Initiative</a> format.</p>
 
-<h2>
-<a id="getting-autorest" class="anchor" href="#getting-autorest" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Getting AutoRest</h2>
+<h2><a id="getting-autorest" class="anchor" href="#getting-autorest" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Getting AutoRest</h2>
+<h3><a id="getting-autorest-windows" class="anchor" href="#getting-autorest-windows" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>Windows</h3>
 
 <p>The AutoRest tools can be installed with Nuget for use in a Visual Studio project:
 <a href="https://www.nuget.org/packages/autorest/"><img src="https://img.shields.io/nuget/v/autorest.svg?style=flat-square" alt="AutoRest NuGet"></a></p>
@@ -35,13 +35,17 @@
 <p>Alternatively it can be installed from <a href="https://chocolatey.org/">Chocolatey</a> by running:
 <a href="https://chocolatey.org/packages/AutoRest"><img src="https://img.shields.io/chocolatey/v/autorest.svg?style=flat-square" alt="AutoRest Chocolatey"></a></p>
 
-<pre><code>choco install autorest
-</code></pre>
+<pre><code>choco install autorest</code></pre>
 
 <p>Nightlies are available via MyGet:
 <a href="https://www.myget.org/gallery/autorest"><img src="https://img.shields.io/myget/autorest/vpre/autorest.svg?style=flat-square" alt="AutoRest MyGet"></a></p>
 
-<p>AutoRest can be run on macOS and *nix using <a href="http://www.mono-project.com/download">Mono</a>:</p>
+<h3><a id="getting-autorest-macos-linux" class="anchor" href="#getting-autorest-macos-linux" aria-hidden="true"><span aria-hidden="true" class="octicon octicon-link"></span></a>macOS &amp; Linux</h3>
+
+<p>The easiest way for macOS users to get AutoRest is via <a href="https://brew.sh">Homebrew:</a></p>
+<pre><code>brew update &amp;&amp; brew install autorest</code></pre>
+
+<p>It can also run on macOS and Linux using <a href="http://www.mono-project.com/download">Mono</a>:</p>
 
 <pre>
 <code># Download & Unpack Autorest


### PR DESCRIPTION
* Add homebrew as option for macOS users
* Fix broken markdown syntax

---

Note: Since [homebrew-core/pull/8785](https://github.com/Homebrew/homebrew-core/pull/8785) finally got merged after a lot of back and forth, macOS users now have the easy option to install AutoRest using homebrew! 🎉 

```$ brew install autorest```

It downloads the latest `.nupkg` from nuget.