### PR TITLE
Uncommented base URL go tests

### DIFF
--- a/src/generator/AutoRest.Go.Tests/src/tests/runner.go
+++ b/src/generator/AutoRest.Go.Tests/src/tests/runner.go
@@ -64,11 +64,11 @@ func runTests(allPass *bool) {
 		"stringgroup",
 		"urlgroup",
 		"validationgroup",
-		//"custombaseurlgroup",
+		"custombaseurlgroup",
 		"filegroup",
 		// "formdatagroup",
 		"paginggroup",
-		//"morecustombaseurigroup",
+		"morecustombaseurigroup",
 	}
 
 	for _, suite := range testSuites {


### PR DESCRIPTION
After this https://github.com/Azure/go-autorest/pull/116 was merged, the tests should work properly. Lets see if CI agrees.
@jhendrixMSFT @marstr