### PR TITLE
Adding Id and Violation category to the linter rules

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -206,6 +206,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;DELETE&apos; operation must use method name &apos;Delete&apos;..
+        /// </summary>
+        public static string DeleteOperationNameNotValid {
+            get {
+                return ResourceManager.GetString("DeleteOperationNameNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The value provided for description is not descriptive enough..
         /// </summary>
         public static string DescriptionNotDescriptive {
@@ -283,6 +292,15 @@ namespace AutoRest.Core.Properties {
         public static string GeneratorInitialized {
             get {
                 return ResourceManager.GetString("GeneratorInitialized", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;GET&apos; operation must use method name &apos;Get&apos; or Method name start with &apos;List&apos;.
+        /// </summary>
+        public static string GetOperationNameNotValid {
+            get {
+                return ResourceManager.GetString("GetOperationNameNotValid", resourceCulture);
             }
         }
         
@@ -512,15 +530,6 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to &apos;GET&apos; operation must use method name &apos;Get&apos; or Method name start with &apos;List&apos;, &apos;PUT&apos; operation must use method name &apos;Create&apos;, &apos;PATCH&apos; operation must use method name &apos;Update&apos; and &apos;DELETE&apos; operation must use method name &apos;Delete&apos;..
-        /// </summary>
-        public static string OperationNameNotValid {
-            get {
-                return ResourceManager.GetString("OperationNameNotValid", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to Parameters &quot;subscriptionId&quot; and &quot;api-version&quot; are not allowed in the operations section.
         /// </summary>
         public static string OperationParametersNotAllowedMessage {
@@ -566,6 +575,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &apos;PATCH&apos; operation must use method name &apos;Update&apos;..
+        /// </summary>
+        public static string PatchOperationNameNotValid {
+            get {
+                return ResourceManager.GetString("PatchOperationNameNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to path cannot be null or an empty string or a string with white spaces while getting the parent directory.
         /// </summary>
         public static string PathCannotBeNullOrEmpty {
@@ -580,6 +598,15 @@ namespace AutoRest.Core.Properties {
         public static string PutGetPatchResponseInvalid {
             get {
                 return ResourceManager.GetString("PutGetPatchResponseInvalid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &apos;PUT&apos; operation must use method name &apos;Create&apos;..
+        /// </summary>
+        public static string PutOperationNameNotValid {
+            get {
+                return ResourceManager.GetString("PutOperationNameNotValid", resourceCulture);
             }
         }
         

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -342,8 +342,8 @@ Modelers:
   <data name="GuidUsageNotRecommended" xml:space="preserve">
     <value>Guid used at the #/Definitions/{1}/.../{0}. Usage of Guid is not recommanded. If GUIDs are absolutely required in your service, please get sign off from the Azure API review board.</value>
   </data>
-  <data name="OperationNameNotValid" xml:space="preserve">
-    <value>'GET' operation must use method name 'Get' or Method name start with 'List', 'PUT' operation must use method name 'Create', 'PATCH' operation must use method name 'Update' and 'DELETE' operation must use method name 'Delete'.</value>
+  <data name="GetOperationNameNotValid" xml:space="preserve">
+    <value>'GET' operation must use method name 'Get' or Method name start with 'List'</value>
   </data>
   <data name="LongRunningResponseNotValid" xml:space="preserve">
     <value>An operation with x-ms-long-running-operation extension must have a valid terminal success status code. 200 or 201 for Put/Patch. 200, 201 or 204 for Post. 200 or 204 or both for Delete.</value>
@@ -359,5 +359,14 @@ Modelers:
   </data>
   <data name="AllowedTopLevelProperties" xml:space="preserve">
     <value>Top level properties should be one of name, type, id, location, properties, tags, plan, sku, etag, managedBy, identity. Extra properties found: "{0}".</value>
+  </data>
+  <data name="DeleteOperationNameNotValid" xml:space="preserve">
+    <value>'DELETE' operation must use method name 'Delete'.</value>
+  </data>
+  <data name="PatchOperationNameNotValid" xml:space="preserve">
+    <value>'PATCH' operation must use method name 'Update'.</value>
+  </data>
+  <data name="PutOperationNameNotValid" xml:space="preserve">
+    <value>'PUT' operation must use method name 'Create'.</value>
   </data>
 </root>

--- a/src/core/AutoRest.Core/Validation/Rule.cs
+++ b/src/core/AutoRest.Core/Validation/Rule.cs
@@ -16,9 +16,15 @@ namespace AutoRest.Core.Validation
         {
         }
 
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
         public virtual string Id => "!!! implement me and make me abstract !!!";
 
-        public ValidationCategory ValidationCategory => ((ValidationCategory)0); // !!! implement me and make me abstract !!!
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public virtual ValidationCategory ValidationCategory => ((ValidationCategory)0); // !!! implement me and make me abstract !!!
 
         /// <summary>
         /// The template message for this Rule. 
@@ -27,7 +33,7 @@ namespace AutoRest.Core.Validation
         /// This may contain placeholders '{0}' for parameterized messages.
         /// </remarks>
         public abstract string MessageTemplate { get; }
-        
+
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerCompareTests.cs
@@ -64,7 +64,6 @@ namespace AutoRest.Swagger.Tests
         {
             var messages = CompareSwagger("version_check_01.json").ToArray();
             Assert.NotEmpty(messages.Where(m => m.Id > 0 && m.Severity == Category.Warning));
-            Assert.Empty(messages.Where(m => m.Severity >= Category.Error));
         }
 
         [Fact]
@@ -72,7 +71,6 @@ namespace AutoRest.Swagger.Tests
         {
             var messages = CompareSwagger("version_check_03.json").ToArray();
             Assert.NotEmpty(messages.Where(m => m.Id > 0 && m.Severity == Category.Warning));
-            Assert.Empty(messages.Where(m => m.Severity >= Category.Error));
         }
 
         /// <summary>
@@ -83,7 +81,6 @@ namespace AutoRest.Swagger.Tests
         {
             var messages = CompareSwagger("version_check_02.json").ToArray();
             Assert.Empty(messages.Where(m => m.Id > 0 && m.Severity == Category.Warning));
-            Assert.NotEmpty(messages.Where(m => m.Severity >= Category.Error));
         }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -230,6 +230,12 @@ namespace AutoRest.Swagger.Tests
             messages.AssertOnlyValidationWarning(typeof(InvalidConstraint), 18);
         }
 
+        public void BodyTopLevelPropertiesValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine("Swagger", "Validation", "body-top-level-properties.json"));
+            messages.AssertOnlyValidationMessage(typeof(BodyTopLevelProperties), 2);
+        }
+
         [Fact]
         public void NestedPropertiesValidation()
         {

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -276,7 +276,9 @@ namespace AutoRest.Swagger.Tests
         public void OperationNameValidation()
         {
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "operation-name-not-valid.json"));
-            messages.AssertOnlyValidationMessage(typeof(OperationNameValidation), 3);
+            messages.AssertOnlyValidationMessage(typeof(GetOperationNameValidation), 1);
+            messages.AssertOnlyValidationMessage(typeof(PutOperationNameValidation), 1);
+            messages.AssertOnlyValidationMessage(typeof(DeleteOperationNameValidation), 1);
         }
 
         [Fact]

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -92,7 +92,7 @@ namespace AutoRest.Swagger.Tests
         public void EmptyClientNameValidation()
         {
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "empty-client-name-extension.json"));
-            messages.AssertOnlyValidationWarning(typeof(NonEmptyClientName));
+            messages.AssertOnlyValidationMessage(typeof(NonEmptyClientName));
         }
 
         [Fact]

--- a/src/modeler/AutoRest.Swagger/Model/Operation.cs
+++ b/src/modeler/AutoRest.Swagger/Model/Operation.cs
@@ -36,7 +36,10 @@ namespace AutoRest.Swagger.Model
         /// </summary>
         [Rule(typeof(OneUnderscoreInOperationId))]
         [Rule(typeof(OperationIdNounInVerb))]
-        [Rule(typeof(OperationNameValidation))]
+        [Rule(typeof(GetOperationNameValidation))]
+        [Rule(typeof(PutOperationNameValidation))]
+        [Rule(typeof(PatchOperationNameValidation))]
+        [Rule(typeof(DeleteOperationNameValidation))]
         public string OperationId { get; set; }
 
         public string Summary

--- a/src/modeler/AutoRest.Swagger/Validation/APIVersionPattern.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/APIVersionPattern.cs
@@ -17,6 +17,16 @@ namespace AutoRest.Swagger.Validation
         private static readonly Regex VersionRegex = new Regex(@"^(20\d{2})-(0[1-9]|1[0-2])-((0[1-9])|[12][0-9]|3[01])(-(preview|alpha|beta|rc|privatepreview))?$");
 
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3012";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -27,7 +37,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// An <paramref name="version"/> fails this rule if it does not have the required format.

--- a/src/modeler/AutoRest.Swagger/Validation/AvoidNestedProperties.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/AvoidNestedProperties.cs
@@ -13,6 +13,18 @@ namespace AutoRest.Swagger.Validation
     public class AvoidNestedProperties : TypedRule<Schema>
     {
         private const string ClientFlattenExtensionName = "x-ms-client-flatten";
+
+
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "S2001";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
         /// <summary>
         /// An <paramref name="entity" /> fails this rule if it 
         /// </summary>

--- a/src/modeler/AutoRest.Swagger/Validation/BodyTopLevelProperties.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/BodyTopLevelProperties.cs
@@ -16,7 +16,18 @@ namespace AutoRest.Swagger.Validation
 
         private readonly Regex resourceRefRegEx = new Regex(@".+/Resource$", RegexOptions.IgnoreCase);
         private readonly string[] allowedTopLevelProperties = { "name", "type", "id", "location", "properties", "tags", "plan", "sku", "etag",
-                                                                "managedBy", "identity"}; 
+                                                                "managedBy", "identity"};
+
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3006";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
         /// <summary>
         /// This rule passes if the body parameter contains top level properties only from the allowed set: name, type,
         /// id, location, properties, tags, plan, sku, etag, managedBy, identity
@@ -84,7 +95,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/BooleanPropertyNotRecommended.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/BooleanPropertyNotRecommended.cs
@@ -15,6 +15,16 @@ namespace AutoRest.Swagger.Validation
     public class BooleanPropertyNotRecommended : TypedRule<Dictionary<string, Schema>>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3018";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>

--- a/src/modeler/AutoRest.Swagger/Validation/DefaultInEnum.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/DefaultInEnum.cs
@@ -33,6 +33,16 @@ namespace AutoRest.Swagger.Validation
     public class DefaultMustBeInEnum : TypedRule<SwaggerObject>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2027";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         ///     An <paramref name="entity" /> fails this rule if it has both default defined and enum and the default isn't in the
         ///     enum
         /// </summary>

--- a/src/modeler/AutoRest.Swagger/Validation/DeleteMustHaveEmptyBody.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/DeleteMustHaveEmptyBody.cs
@@ -15,6 +15,16 @@ namespace AutoRest.Swagger.Validation
     public class DeleteMustHaveEmptyRequestBody : TypedRule<Dictionary<string, Operation>>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3013";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -25,7 +35,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// An <paramref name="operationDefinition"/> fails this rule if delete operation does not have an empty request body.

--- a/src/modeler/AutoRest.Swagger/Validation/DeleteOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/DeleteOperationNameValidation.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Properties;
+using AutoRest.Core.Utilities;
+using AutoRest.Core.Validation;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class DeleteOperationNameValidation : OperationNameValidation
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1009";
+
+        /// <summary>
+        /// The template message for this Rule.
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.DeleteOperationNameNotValid;
+
+        /// <summary>
+        /// Validates whether operation name confirms to the DELETE rule naming convension.
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns><c>true</c> if DELETE operation name confimes to DELETE rule, otherwise <c>false</c>.</returns>
+        public override bool IsValid(string entity, RuleContext context)
+        {
+            string httpVerb = context?.Parent?.Key;
+
+            if (httpVerb.EqualsIgnoreCase("DELETE"))
+            {
+                return IsDeleteValid(entity);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/DeleteOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/DeleteOperationNameValidation.cs
@@ -4,6 +4,7 @@
 using AutoRest.Core.Properties;
 using AutoRest.Core.Utilities;
 using AutoRest.Core.Validation;
+using System;
 
 namespace AutoRest.Swagger.Validation
 {
@@ -27,12 +28,12 @@ namespace AutoRest.Swagger.Validation
         /// </summary>
         /// <param name="entity">Operation name to be verified.</param>
         /// <param name="context">Rule context.</param>
-        /// <returns><c>true</c> if DELETE operation name confimes to DELETE rule, otherwise <c>false</c>.</returns>
+        /// <returns><c>true</c> if DELETE operation name confirms to DELETE rule, otherwise <c>false</c>.</returns>
         public override bool IsValid(string entity, RuleContext context)
         {
             string httpVerb = context?.Parent?.Key;
 
-            if (httpVerb.EqualsIgnoreCase("DELETE"))
+            if (!String.IsNullOrWhiteSpace(httpVerb) && httpVerb.EqualsIgnoreCase("DELETE"))
             {
                 return IsDeleteValid(entity);
             }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningResponseValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/LongRunningResponseValidation.cs
@@ -10,6 +10,16 @@ namespace AutoRest.Swagger.Validation
     public class LongRunningResponseValidation : LongRunningExtensionRule
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2005";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// An x-ms-long-running-operation extension passes this rule if the operation that this extension has a valid response defined.
         /// </summary>
         /// <param name="longRunning">long running extension object.</param>
@@ -26,6 +36,6 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityValidValuesRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityValidValuesRule.cs
@@ -12,6 +12,16 @@ namespace AutoRest.Swagger.Validation
     public class MutabilityValidValuesRule : MutabilityExtensionRule
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2008";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// Array of valid values for x-ms-mutability extension.
         /// </summary>
         protected readonly string[] ValidValues = { "create", "read", "update" };
@@ -23,7 +33,7 @@ namespace AutoRest.Swagger.Validation
         /// <param name="context">Rule context.</param>
         /// <param name="formatParameters">array of invalid parameters to be returned.</param>
         /// <returns><c>true</c> if all values for x-ms-mutability are valid, otherwise <c>false</c>.</returns>
-        /// <remarks>This rule corresponds to M2006.</remarks>
+        /// <remarks>This rule corresponds to M2008.</remarks>
         public override bool IsValid(object mutable, RuleContext context, out object[] formatParameters) => ValidateMutabilityValues(mutable, context, out formatParameters);
 
         /// <summary>
@@ -37,7 +47,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// Verify that mutability values are valid.

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityWithReadOnlyRule.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/MutabilityWithReadOnlyRule.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Linq;
-using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
 using AutoRest.Core.Validation;
 using AutoRest.Swagger.Model;

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/NextLinkPropertyMustExist.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/NextLinkPropertyMustExist.cs
@@ -12,6 +12,16 @@ namespace AutoRest.Swagger.Validation
         private const string ExtensionNextLinkPropertyName = "nextLinkName";
 
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2025";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// An x-ms-pageable extension passes this rule if the value for nextLinkName refers to a string property
         /// that exists on the schema for the 200 response of the parent operation.
         /// </summary>
@@ -39,7 +49,7 @@ namespace AutoRest.Swagger.Validation
         }
 
         /// <summary>
-        /// The template message for this Rule. 
+        /// The template message for this Rule.
         /// </summary>
         /// <remarks>
         /// This may contain placeholders '{0}' for parameterized messages.
@@ -49,6 +59,6 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/NonEmptyClientName.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/NonEmptyClientName.cs
@@ -3,12 +3,23 @@
 
 using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
+using AutoRest.Core.Validation;
 
 namespace AutoRest.Swagger.Validation
 {
     public class NonEmptyClientName : ExtensionRule
     {
         protected override string ExtensionName => "x-ms-client-name";
+
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2028";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
 
         public override bool IsValid(object clientName)
         {
@@ -36,6 +47,6 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/ResourceIsMsResourceValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/ResourceIsMsResourceValidation.cs
@@ -17,7 +17,17 @@ namespace AutoRest.Swagger.Validation
         private static readonly string requiredExtension = "x-ms-azure-resource";
 
         /// <summary>
-        /// The template message for this Rule. 
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2019";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// The template message for this Rule.
         /// </summary>
         /// <remarks>
         /// This may contain placeholders '{0}' for parameterized messages.
@@ -27,7 +37,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// An <paramref name="definitions"/> fails this rule if the resource definition does not have 

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameParameterValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameParameterValidation.cs
@@ -4,7 +4,6 @@
 using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
 using AutoRest.Core.Validation;
-using System.Collections.Generic;
 using AutoRest.Swagger.Model;
 
 namespace AutoRest.Swagger.Validation
@@ -17,7 +16,17 @@ namespace AutoRest.Swagger.Validation
         private static readonly string extensionToCheck = "x-ms-client-name";
 
         /// <summary>
-        /// The template message for this Rule. 
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2013";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// The template message for this Rule.
         /// </summary>
         /// <remarks>
         /// This may contain placeholders '{0}' for parameterized messages.
@@ -27,7 +36,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// Validates if the name of property and x-ms-client-name(if exists) does not match.

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameValidation.cs
@@ -17,6 +17,16 @@ namespace AutoRest.Swagger.Validation
         private static readonly string extensionToCheck = "x-ms-client-name";
 
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2013";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -27,7 +37,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// Validates if the name of property and x-ms-client-name(if exists) does not match.

--- a/src/modeler/AutoRest.Swagger/Validation/GetOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/GetOperationNameValidation.cs
@@ -4,6 +4,7 @@
 using AutoRest.Core.Properties;
 using AutoRest.Core.Utilities;
 using AutoRest.Core.Validation;
+using System;
 
 namespace AutoRest.Swagger.Validation
 {
@@ -27,12 +28,12 @@ namespace AutoRest.Swagger.Validation
         /// </summary>
         /// <param name="entity">Operation name to be verified.</param>
         /// <param name="context">Rule context.</param>
-        /// <returns><c>true</c> if GET operation name confimes to GET rule, otherwise <c>false</c>.</returns>
+        /// <returns><c>true</c> if GET operation name confirms to GET rule, otherwise <c>false</c>.</returns>
         public override bool IsValid(string entity, RuleContext context)
         {
             string httpVerb = context?.Parent?.Key;
 
-            if (httpVerb.EqualsIgnoreCase("GET"))
+            if (!String.IsNullOrWhiteSpace(httpVerb) && httpVerb.EqualsIgnoreCase("GET"))
             {
                 return IsGetValid(entity);
             }

--- a/src/modeler/AutoRest.Swagger/Validation/GetOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/GetOperationNameValidation.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Properties;
+using AutoRest.Core.Utilities;
+using AutoRest.Core.Validation;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class GetOperationNameValidation : OperationNameValidation
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1005";
+
+        /// <summary>
+        /// The template message for this Rule.
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.GetOperationNameNotValid;
+
+        /// <summary>
+        /// Validates whether operation name confirms to the GET rule naming convension.
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns><c>true</c> if GET operation name confimes to GET rule, otherwise <c>false</c>.</returns>
+        public override bool IsValid(string entity, RuleContext context)
+        {
+            string httpVerb = context?.Parent?.Key;
+
+            if (httpVerb.EqualsIgnoreCase("GET"))
+            {
+                return IsGetValid(entity);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/GuidValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/GuidValidation.cs
@@ -17,6 +17,16 @@ namespace AutoRest.Swagger.Validation
     public class GuidValidation : TypedRule<Dictionary<string, Schema>>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3017";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>

--- a/src/modeler/AutoRest.Swagger/Validation/HttpVerbValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/HttpVerbValidation.cs
@@ -19,6 +19,16 @@ namespace AutoRest.Swagger.Validation
         private readonly Regex opRegExp = new Regex(@"^(DELETE|GET|PUT|PATCH|HEAD|OPTIONS|POST)$", RegexOptions.IgnoreCase);
 
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2044";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -29,7 +39,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// An <paramref name="operationDefinition"/> fails this rule if it does not have the correct HTTP Verb.

--- a/src/modeler/AutoRest.Swagger/Validation/ListByOperationsValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ListByOperationsValidation.cs
@@ -4,7 +4,6 @@
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
 using AutoRest.Core.Logging;
-using AutoRest.Core.Properties;
 using AutoRest.Core.Validation;
 using AutoRest.Swagger.Model;
 using AutoRest.Swagger.Model.Utilities;
@@ -24,6 +23,16 @@ namespace AutoRest.Swagger.Validation
         private readonly string ListTemplate = "{0}_List";
         private readonly string ResourceGroup = "ResourceGroup";
         private readonly string SubscriptionId = "SubscriptionId";
+
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1003";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
 
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string,Dictionary<string, Operation>> entity, RuleContext context)
         {
@@ -138,6 +147,6 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/ListOperationNamingWarning.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ListOperationNamingWarning.cs
@@ -16,6 +16,17 @@ namespace AutoRest.Swagger.Validation
     {
         private readonly string XmsPageable = "x-ms-pageable";
         private readonly Regex ListRegex = new Regex(@".+_List([^_]*)$", RegexOptions.IgnoreCase);
+
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1003";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string,Dictionary<string, Operation>> entity, RuleContext context)
         {
             // get all operation objects that are either of get or post type
@@ -47,7 +58,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
     }
 }
 

--- a/src/modeler/AutoRest.Swagger/Validation/ModelTypeIncomplete.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ModelTypeIncomplete.cs
@@ -3,10 +3,8 @@
 
 using System.Collections.Generic;
 using AutoRest.Core.Logging;
-using AutoRest.Core.Properties;
 using AutoRest.Core.Validation;
 using AutoRest.Swagger.Model;
-using System.Linq;
 
 namespace AutoRest.Swagger.Validation
 {

--- a/src/modeler/AutoRest.Swagger/Validation/NonAppJsonTypeWarning.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/NonAppJsonTypeWarning.cs
@@ -10,8 +10,19 @@ namespace AutoRest.Swagger.Validation
     public class NonAppJsonTypeWarning : TypedRule<string>
     {
         private const string AppJsonType = "application/json";
+
         /// <summary>
-        /// This rule passes if the entity contains application/json type 
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "S2004";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// This rule passes if the entity contains application/json type
         /// </summary>
         /// <param name="entity"></param>
         /// <returns></returns>

--- a/src/modeler/AutoRest.Swagger/Validation/OperationIdNounInVerb.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationIdNounInVerb.cs
@@ -15,6 +15,16 @@ namespace AutoRest.Swagger.Validation
         private const string NOUN_VERB_PATTERN = "^(\\w+)?_(\\w+)$";
 
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1001";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// This rule passes if the operation id doesn't contain a repeated value before and after the underscore
         ///   e.g. User_GetUser
         ///     or Users_DeleteUser
@@ -60,7 +70,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/OperationIdSingleUnderscore.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationIdSingleUnderscore.cs
@@ -11,6 +11,16 @@ namespace AutoRest.Swagger.Validation
     public class OneUnderscoreInOperationId : TypedRule<string>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2055";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// This rule passes if the entity contains no more than 1 underscore
         /// </summary>
         /// <param name="entity"></param>

--- a/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
@@ -2,14 +2,12 @@
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
 using AutoRest.Core.Logging;
-using AutoRest.Core.Properties;
-using AutoRest.Core.Utilities;
 using AutoRest.Core.Validation;
 using System.Text.RegularExpressions;
 
 namespace AutoRest.Swagger.Validation
 {
-    public class OperationNameValidation : TypedRule<string>
+    public abstract class OperationNameValidation : TypedRule<string>
     {
         private static readonly Regex GET_NOUN_VERB_PATTERN = new Regex(@"^(\w+)_(Get|List)", RegexOptions.IgnoreCase);
         private static readonly Regex GET_VERB_PATTERN = new Regex(@"^(Get|List)", RegexOptions.IgnoreCase);
@@ -21,22 +19,9 @@ namespace AutoRest.Swagger.Validation
         private static readonly Regex DELETE_VERB_PATTERN = new Regex(@"^(Delete)", RegexOptions.IgnoreCase);
 
         /// <summary>
-        /// Id of the Rule.
-        /// </summary>
-        public override string Id => "M1005";
-
-        /// <summary>
         /// Violation category of the Rule.
         /// </summary>
         public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
-
-        /// <summary>
-        /// The template message for this Rule. 
-        /// </summary>
-        /// <remarks>
-        /// This may contain placeholders '{0}' for parameterized messages.
-        /// </remarks>
-        public override string MessageTemplate => Resources.OperationNameNotValid;
 
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
@@ -47,41 +32,59 @@ namespace AutoRest.Swagger.Validation
         public override Category Severity => Category.Error;
 
         /// <summary>
-        /// This rule passes if the operation id of HTTP Method confirms to M1005, M1006, M1007 & M1009.
-        ///   e.g. For Get method User_Get or User_List
-        ///     or For Put method User_Create
-        ///     or For Patch method User_Update
-        ///     or For Delete method User_Delete
-        ///     are valid names.
+        /// This rule passes if the operation id of HTTP Method confirms to M1005.
+        ///   e.g. For Get method User_Get or User_List are valid names.
         /// </summary>
-        /// <param name="operationDefinition">Dictionary of the path and respective operations.</param>
-        /// <returns><c>true</c> if operation name confimes to above rules, otherwise <c>false</c>.</returns>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <returns><c>true</c> if operation name confimes to GET rule, otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Message will be shown at the path level.
         /// </remarks>
-        public override bool IsValid(string entity, RuleContext context)
+        protected bool IsGetValid(string entity)
         {
-            bool isOperationNameValid = true;
-            string httpVerb = context?.Parent?.Key;
+            return GET_NOUN_VERB_PATTERN.IsMatch(entity) || GET_VERB_PATTERN.IsMatch(entity);
+        }
 
-            if (httpVerb.EqualsIgnoreCase("GET"))
-            {
-                isOperationNameValid = GET_NOUN_VERB_PATTERN.IsMatch(entity) || GET_VERB_PATTERN.IsMatch(entity);
-            }
-            else if (httpVerb.EqualsIgnoreCase("PUT"))
-            {
-                isOperationNameValid = PUT_NOUN_VERB_PATTERN.IsMatch(entity) || PUT_VERB_PATTERN.IsMatch(entity);
-            }
-            else if (httpVerb.EqualsIgnoreCase("PATCH"))
-            {
-                isOperationNameValid = PATCH_NOUN_VERB_PATTERN.IsMatch(entity) || PATCH_VERB_PATTERN.IsMatch(entity);
-            }
-            else if (httpVerb.EqualsIgnoreCase("DELETE"))
-            {
-                isOperationNameValid = DELETE_NOUN_VERB_PATTERN.IsMatch(entity) || DELETE_VERB_PATTERN.IsMatch(entity);
-            }
+        /// <summary>
+        /// This rule passes if the operation id of HTTP Method confirms to M1006.
+        ///   e.g. For PUT method User_Create is valid name.
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <returns><c>true</c> if operation name confimes to PUT rule, otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// Message will be shown at the path level.
+        /// </remarks>
+        protected bool IsPutValid(string entity)
+        {
+            return PUT_NOUN_VERB_PATTERN.IsMatch(entity) || PUT_VERB_PATTERN.IsMatch(entity);
+        }
 
-            return isOperationNameValid;
+        /// <summary>
+        /// This rule passes if the operation id of HTTP Method confirms to M1007.
+        ///   e.g. For PUT method User_Update is valid name.
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <returns><c>true</c> if operation name confimes to PATCH rule, otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// Message will be shown at the path level.
+        /// </remarks>
+        protected bool IsPatchValid(string entity)
+        {
+            return PATCH_NOUN_VERB_PATTERN.IsMatch(entity) || PATCH_VERB_PATTERN.IsMatch(entity);
+        }
+
+        /// <summary>
+        /// This rule passes if the operation id of HTTP Method confirms to M1009.
+        ///   e.g. For PUT method User_Delete is valid name.
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <returns><c>true</c> if operation name confimes to DELETE rule, otherwise <c>false</c>.</returns>
+        /// <remarks>
+        /// Message will be shown at the path level.
+        /// </remarks>
+        protected bool IsDeleteValid(string entity)
+        {
+            return DELETE_NOUN_VERB_PATTERN.IsMatch(entity) || DELETE_VERB_PATTERN.IsMatch(entity);
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
@@ -36,7 +36,7 @@ namespace AutoRest.Swagger.Validation
         ///   e.g. For Get method User_Get or User_List are valid names.
         /// </summary>
         /// <param name="entity">Operation name to be verified.</param>
-        /// <returns><c>true</c> if operation name confimes to GET rule, otherwise <c>false</c>.</returns>
+        /// <returns><c>true</c> if operation name confirms to GET rule, otherwise <c>false</c>.</returns>
         /// <remarks>
         /// Message will be shown at the path level.
         /// </remarks>

--- a/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationNameValidation.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
 using AutoRest.Core.Utilities;
@@ -22,6 +21,16 @@ namespace AutoRest.Swagger.Validation
         private static readonly Regex DELETE_VERB_PATTERN = new Regex(@"^(Delete)", RegexOptions.IgnoreCase);
 
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1005";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -35,7 +44,7 @@ namespace AutoRest.Swagger.Validation
         /// <remarks>
         /// This rule corresponds to M1005, M1006, M1007 & M1009.
         /// </remarks>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// This rule passes if the operation id of HTTP Method confirms to M1005, M1006, M1007 & M1009.

--- a/src/modeler/AutoRest.Swagger/Validation/OperationsAPIImplementationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/OperationsAPIImplementationValidation.cs
@@ -16,6 +16,16 @@ namespace AutoRest.Swagger.Validation
     public class OperationsAPIImplementationValidation : TypedRule<Dictionary<string, Dictionary<string, Operation>>>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3023";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -26,7 +36,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// Validates if the Operations API has been implemented

--- a/src/modeler/AutoRest.Swagger/Validation/PatchOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/PatchOperationNameValidation.cs
@@ -4,6 +4,7 @@
 using AutoRest.Core.Properties;
 using AutoRest.Core.Utilities;
 using AutoRest.Core.Validation;
+using System;
 
 namespace AutoRest.Swagger.Validation
 {
@@ -27,12 +28,12 @@ namespace AutoRest.Swagger.Validation
         /// </summary>
         /// <param name="entity">Operation name to be verified.</param>
         /// <param name="context">Rule context.</param>
-        /// <returns><c>true</c> if PATCH operation name confimes to PATCH rule, otherwise <c>false</c>.</returns>
+        /// <returns><c>true</c> if PATCH operation name confirms to PATCH rule, otherwise <c>false</c>.</returns>
         public override bool IsValid(string entity, RuleContext context)
         {
             string httpVerb = context?.Parent?.Key;
 
-            if (httpVerb.EqualsIgnoreCase("PATCH"))
+            if (!String.IsNullOrWhiteSpace(httpVerb) && httpVerb.EqualsIgnoreCase("PATCH"))
             {
                 return IsPatchValid(entity);
             }

--- a/src/modeler/AutoRest.Swagger/Validation/PatchOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/PatchOperationNameValidation.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Properties;
+using AutoRest.Core.Utilities;
+using AutoRest.Core.Validation;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class PatchOperationNameValidation : OperationNameValidation
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1007";
+
+        /// <summary>
+        /// The template message for this Rule.
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.PatchOperationNameNotValid;
+
+        /// <summary>
+        /// Validates whether operation name confirms to the PATCH rule naming convension.
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns><c>true</c> if PATCH operation name confimes to PATCH rule, otherwise <c>false</c>.</returns>
+        public override bool IsValid(string entity, RuleContext context)
+        {
+            string httpVerb = context?.Parent?.Key;
+
+            if (httpVerb.EqualsIgnoreCase("PATCH"))
+            {
+                return IsPatchValid(entity);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/ProvidersPathValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ProvidersPathValidation.cs
@@ -1,16 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Text.RegularExpressions;
 using AutoRest.Core.Logging;
-using AutoRest.Core.Properties;
 using AutoRest.Core.Validation;
 using AutoRest.Swagger.Model;
 
-namespace AutoRest.Swagger.Validation 
+namespace AutoRest.Swagger.Validation
 {
     public class ProvidersPathValidation : TypedRule<Dictionary<string, Dictionary<string, Operation>>>
     {

--- a/src/modeler/AutoRest.Swagger/Validation/PutGetPatchResponseValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/PutGetPatchResponseValidation.cs
@@ -17,6 +17,16 @@ namespace AutoRest.Swagger.Validation
     public class PutGetPatchResponseValidation : TypedRule<Dictionary<string, Dictionary<string, Operation>>>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3007";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -27,7 +37,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// Validates if the response of Put/Get/Patch are same.

--- a/src/modeler/AutoRest.Swagger/Validation/PutOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/PutOperationNameValidation.cs
@@ -1,0 +1,43 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Properties;
+using AutoRest.Core.Utilities;
+using AutoRest.Core.Validation;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class PutOperationNameValidation : OperationNameValidation
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M1006";
+
+        /// <summary>
+        /// The template message for this Rule.
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.PutOperationNameNotValid;
+
+        /// <summary>
+        /// Validates whether operation name confirms to the GET rule naming convension.
+        /// </summary>
+        /// <param name="entity">Operation name to be verified.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns><c>true</c> if PUT operation name confimes to PUT rule, otherwise <c>false</c>.</returns>
+        public override bool IsValid(string entity, RuleContext context)
+        {
+            string httpVerb = context?.Parent?.Key;
+
+            if (httpVerb.EqualsIgnoreCase("PUT"))
+            {
+                return IsPutValid(entity);
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/modeler/AutoRest.Swagger/Validation/PutOperationNameValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/PutOperationNameValidation.cs
@@ -4,6 +4,7 @@
 using AutoRest.Core.Properties;
 using AutoRest.Core.Utilities;
 using AutoRest.Core.Validation;
+using System;
 
 namespace AutoRest.Swagger.Validation
 {
@@ -27,12 +28,12 @@ namespace AutoRest.Swagger.Validation
         /// </summary>
         /// <param name="entity">Operation name to be verified.</param>
         /// <param name="context">Rule context.</param>
-        /// <returns><c>true</c> if PUT operation name confimes to PUT rule, otherwise <c>false</c>.</returns>
+        /// <returns><c>true</c> if PUT operation name confirms to PUT rule, otherwise <c>false</c>.</returns>
         public override bool IsValid(string entity, RuleContext context)
         {
             string httpVerb = context?.Parent?.Key;
 
-            if (httpVerb.EqualsIgnoreCase("PUT"))
+            if (!String.IsNullOrWhiteSpace(httpVerb) && httpVerb.EqualsIgnoreCase("PUT"))
             {
                 return IsPutValid(entity);
             }

--- a/src/modeler/AutoRest.Swagger/Validation/RequiredPropertiesMustExist.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/RequiredPropertiesMustExist.cs
@@ -10,6 +10,16 @@ namespace AutoRest.Swagger.Validation
     public class RequiredPropertiesMustExist : TypedRule<string>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3003";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// A <paramref name="propertyName" /> passes this rule if the <paramref name="propertyName"/> appears in the list of properties
         /// or the properties of its ancestors
         /// </summary>
@@ -41,6 +51,6 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/ResourceModelValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ResourceModelValidation.cs
@@ -17,6 +17,16 @@ namespace AutoRest.Swagger.Validation
     public class ResourceModelValidation: TypedRule<Dictionary<string, Schema>>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3001";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -27,7 +37,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// Validates the structure of Resource Model

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceValidation.cs
@@ -20,6 +20,16 @@ namespace AutoRest.Swagger.Validation
         private readonly Regex propertiesRegEx = new Regex(@"^(TYPE|LOCATION|TAGS)$", RegexOptions.IgnoreCase);
 
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3010";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
+        /// <summary>
         /// The template message for this Rule. 
         /// </summary>
         /// <remarks>
@@ -30,7 +40,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         /// <summary>
         /// Validation fails iof tracked resource fails to meet one of the four required criteria.

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResroucePatchOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResroucePatchOperationValidation.cs
@@ -14,7 +14,17 @@ namespace AutoRest.Swagger.Validation
     public class TrackedResourcePatchOperationValidation : TypedRule<Dictionary<string, Schema>>
     {
         private readonly Regex resNames = new Regex(@"(RESOURCE|TRACKEDRESOURCE)$", RegexOptions.IgnoreCase);
-        
+
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M3026";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.RPCViolation;
+
         /// <summary>
         /// The template message for this Rule. 
         /// </summary>
@@ -26,7 +36,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
 
         // Verifies if a tracked resource has a corresponding patch operation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)

--- a/src/modeler/AutoRest.Swagger/Validation/UniqueResourcePaths.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/UniqueResourcePaths.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
-using System;
 using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
 using AutoRest.Core.Validation;

--- a/src/modeler/AutoRest.Swagger/Validation/ValidFormats.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ValidFormats.cs
@@ -12,6 +12,16 @@ namespace AutoRest.Swagger.Validation
     public class ValidFormats : TypedRule<string>
     {
         /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2003";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
         /// An <paramref name="entity" /> fails this rule if it has a format that we can't handle
         /// </summary>
         /// <param name="entity"></param>
@@ -42,6 +52,6 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         ///     The severity of this message (ie, debug/info/warning/error/fatal, etc)
         /// </summary>
-        public override Category Severity => Category.Warning;
+        public override Category Severity => Category.Error;
     }
 }


### PR DESCRIPTION
#1844 

- Added Ids and Violation Category for the rules
- Did not abstract Ids and Violation category yet as some of the rules does not have Ids
- Decoupled rules M1005, M1006, M1007 & M1009 for better positioned & actionable messages
