### PR TITLE
Refining/Fixing exisitng validation rules

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -674,7 +674,7 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Tracked resource {0} must have a get operation..
+        ///   Looks up a localized string similar to Tracked resource &apos;{0}&apos; must have a get operation..
         /// </summary>
         public static string TrackedResourceGetOperationMissing {
             get {
@@ -693,6 +693,15 @@ namespace AutoRest.Core.Properties {
         public static string TrackedResourceIsNotValid {
             get {
                 return ResourceManager.GetString("TrackedResourceIsNotValid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Tracked resource &apos;{0}&apos; must have patch operation that at least supports the update of tags..
+        /// </summary>
+        public static string TrackedResourcePatchOperationMissing {
+            get {
+                return ResourceManager.GetString("TrackedResourcePatchOperationMissing", resourceCulture);
             }
         }
         

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -361,7 +361,7 @@ Modelers:
     <value>Top level properties should be one of name, type, id, location, properties, tags, plan, sku, etag, managedBy, identity. Extra properties found: "{0}".</value>
   </data>
   <data name="TrackedResourceGetOperationMissing" xml:space="preserve">
-    <value>Tracked resource {0} must have a get operation.</value>
+    <value>Tracked resource '{0}' must have a get operation.</value>
   </data>
   <data name="DeleteOperationNameNotValid" xml:space="preserve">
     <value>'DELETE' operation must use method name 'Delete'.</value>
@@ -374,5 +374,8 @@ Modelers:
   </data>
   <data name="CollectionObjectPropertiesNamingMessage" xml:space="preserve">
     <value>Collection object {0} returned by list operation {1} has no property named 'value'.</value>
+  </data>
+  <data name="TrackedResourcePatchOperationMissing" xml:space="preserve">
+    <value>Tracked resource '{0}' must have patch operation that at least supports the update of tags.</value>
   </data>
 </root>

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/tracked-resource-get-valid-operation.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/tracked-resource-get-valid-operation.json
@@ -33,7 +33,7 @@
           "200": {
             "description": "the resource",
             "schema": {
-              "$ref": "#/definitions/Resource"
+              "$ref": "#/definitions/TempResource"
             }
           }
         }
@@ -58,7 +58,7 @@
           "200": {
             "description": "the resource patched",
             "schema": {
-              "$ref": "#/definitions/Resource"
+              "$ref": "#/definitions/TempResource"
             }
           }
         }
@@ -122,6 +122,19 @@
         "location"
       ],
       "x-ms-azure-resource": true
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        }
+      }
     },
     "OperationsListResult": {
       "description": "List of operations",

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/tracked-resource-patch-valid-operation.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/tracked-resource-patch-valid-operation.json
@@ -33,7 +33,7 @@
           "200": {
             "description": "the resource",
             "schema": {
-              "$ref": "#/definitions/Resource"
+              "$ref": "#/definitions/TempResource"
             }
           }
         }
@@ -58,7 +58,7 @@
           "200": {
             "description": "the resource patched",
             "schema": {
-              "$ref": "#/definitions/Resource"
+              "$ref": "#/definitions/TempResource"
             }
           }
         }
@@ -122,6 +122,19 @@
         "location"
       ],
       "x-ms-azure-resource": true
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        }
+      }
     },
     "OperationsListResult": {
       "description": "List of operations",

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/tracked-resource-get-operation.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/tracked-resource-get-operation.json
@@ -26,7 +26,7 @@
           "200": {
             "description": "the resource",
             "schema": {
-              "$ref": "#/definitions/Resource"
+              "$ref": "#/definitions/TempResource"
             }
           }
         }
@@ -90,6 +90,19 @@
         "location"
       ],
       "x-ms-azure-resource": true
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        }
+      }
     },
     "OperationsListResult": {
       "description": "List of operations",

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/tracked-resource-patch-operation.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/tracked-resource-patch-operation.json
@@ -26,7 +26,7 @@
           "200": {
             "description": "the resource",
             "schema": {
-              "$ref": "#/definitions/Resource"
+              "$ref": "#/definitions/TempResource"
             }
           }
         }
@@ -90,6 +90,19 @@
         "location"
       ],
       "x-ms-azure-resource": true
+    },
+    "TempResource": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/Resource"
+        }
+      ],
+      "description": "temporary resource",
+      "properties": {
+        "prop0": {
+          "type": "string"
+        }
+      }
     },
     "OperationsListResult": {
       "description": "List of operations",

--- a/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
@@ -86,7 +86,7 @@ namespace AutoRest.Swagger.Model.Utilities
                                         pathPair => pathPair.Value.Select(
                                             pathObj => pathObj.Value.Responses?.ContainsKey("200") == true ? pathObj.Value.Responses["200"]?.Schema?.Reference?.StripDefinitionPath() : string.Empty)));
 
-            respDefinitions = respDefinitions.Where(def => !string.IsNullOrEmpty(def)).Distinct();
+            respDefinitions = respDefinitions.Where(def => !string.IsNullOrWhiteSpace(def)).Distinct();
 
             return respDefinitions;
         }

--- a/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
@@ -73,5 +73,23 @@ namespace AutoRest.Swagger.Model.Utilities
         {
             return serviceDefinition.Paths.Values.Select(pathObj => pathObj.Where(pair=> pair.Key.ToLower().Equals(id.ToLower()))).SelectMany(pathPair => pathPair.Select(opPair => opPair.Value));
         }
+
+        public static IEnumerable<string> GetResponseModelDefinitions(ServiceDefinition serviceDefinition)
+        {
+            // for every path, check its response object and get its model definition
+            var respDefinitions = serviceDefinition.Paths.SelectMany(
+                                    pathPair => pathPair.Value.Select(
+                                        pathObj => pathObj.Value.Responses?.ContainsKey("200") == true ? pathObj.Value.Responses["200"]?.Schema?.Reference?.StripDefinitionPath() : string.Empty));
+
+            respDefinitions = respDefinitions.Concat(
+                                    serviceDefinition.CustomPaths.SelectMany(
+                                        pathPair => pathPair.Value.Select(
+                                            pathObj => pathObj.Value.Responses?.ContainsKey("200") == true ? pathObj.Value.Responses["200"]?.Schema?.Reference?.StripDefinitionPath() : string.Empty)));
+
+            respDefinitions = respDefinitions.Where(def => !string.IsNullOrEmpty(def)).Distinct();
+
+            return respDefinitions;
+        }
+
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
@@ -41,10 +41,10 @@ namespace AutoRest.Swagger.Validation
         // Verifies if a tracked resource has a corresponding get operation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
-            var servDef = (ServiceDefinition)context.Root;
-            IEnumerable<Operation> getOperations = ValidationUtilities.GetOperationsByRequestMethod("get", servDef);
+            var serviceDefinition = (ServiceDefinition)context.Root;
+            IEnumerable<Operation> getOperations = ValidationUtilities.GetOperationsByRequestMethod("get", serviceDefinition);
             // filter out the model definitions that are not being returned as a response
-            var respDefinitions = servDef.Paths.Concat(servDef.CustomPaths).SelectMany(pathPair => pathPair.Value.Select(pathObj => pathObj.Value.Responses["200"]?.Schema?.Reference?.StripDefinitionPath())).Distinct();
+            var respDefinitions = ValidationUtilities.GetResponseModelDefinitions(serviceDefinition);
             foreach (KeyValuePair<string, Schema> definition in definitions)
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
@@ -49,7 +49,7 @@ namespace AutoRest.Swagger.Validation
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
-                    if (!getOperations.Any(op => (op.Responses["200"].Schema?.Reference?.StripDefinitionPath()) == definition.Key))
+                    if (!getOperations.Any(op => (op.Responses["200"]?.Schema?.Reference?.StripDefinitionPath()) == definition.Key))
                     {
                         // if no GET operation returns current tracked resource as a response, 
                         // the tracked resource does not have a corresponding get operation

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
@@ -41,7 +41,7 @@ namespace AutoRest.Swagger.Validation
         // Verifies if a tracked resource has a corresponding get operation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
-            var serviceDefinition = (ServiceDefinition)context.Root;
+            ServiceDefinition serviceDefinition = (ServiceDefinition)context.Root;
             IEnumerable<Operation> getOperations = ValidationUtilities.GetOperationsByRequestMethod("get", serviceDefinition);
             // filter out the model definitions that are not being returned as a response
             var respDefinitions = ValidationUtilities.GetResponseModelDefinitions(serviceDefinition);
@@ -49,6 +49,7 @@ namespace AutoRest.Swagger.Validation
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
+                    // check for 200 status response models since they correspond to a successful get operation
                     if (!getOperations.Any(op => (op.Responses["200"]?.Schema?.Reference?.StripDefinitionPath()) == definition.Key))
                     {
                         // if no GET operation returns current tracked resource as a response, 

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License. See License.txt in the project root for license information.
 
+using AutoRest.Core.Properties;
 using AutoRest.Core.Logging;
 using AutoRest.Core.Validation;
 using AutoRest.Swagger.Model.Utilities;
@@ -13,8 +14,6 @@ namespace AutoRest.Swagger.Validation
 {
     public class TrackedResourcePatchOperationValidation : TypedRule<Dictionary<string, Schema>>
     {
-        private readonly Regex resNames = new Regex(@"(RESOURCE|TRACKEDRESOURCE)$", RegexOptions.IgnoreCase);
-
         /// <summary>
         /// Id of the Rule.
         /// </summary>
@@ -31,7 +30,7 @@ namespace AutoRest.Swagger.Validation
         /// <remarks>
         /// This may contain placeholders '{0}' for parameterized messages.
         /// </remarks>
-        public override string MessageTemplate => "Tracked resource {0} must have patch operation that at least supports the update of tags.";
+        public override string MessageTemplate => Resources.TrackedResourcePatchOperationMissing;
 
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
@@ -41,10 +40,12 @@ namespace AutoRest.Swagger.Validation
         // Verifies if a tracked resource has a corresponding patch operation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
-            IEnumerable<Operation> patchOperations = ValidationUtilities.GetOperationsByRequestMethod("patch", (ServiceDefinition)context.Root);
+            var servDef = (ServiceDefinition)context.Root;
+            IEnumerable<Operation> patchOperations = ValidationUtilities.GetOperationsByRequestMethod("patch", servDef);
+            var respDefinitions = servDef.Paths.Concat(servDef.CustomPaths).SelectMany(pathPair => pathPair.Value.Select(pathObj => pathObj.Value.Responses["200"]?.Schema?.Reference?.StripDefinitionPath())).Distinct();
             foreach (KeyValuePair<string, Schema> definition in definitions)
             {
-                if (resNames.IsMatch(definition.Key) || ValidationUtilities.IsTrackedResource(definition.Value, definitions))
+                if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
                     if(!patchOperations.Any(op => (op.Responses["200"].Schema?.Reference?.StripDefinitionPath()) == definition.Key))
                     {

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
@@ -47,7 +47,7 @@ namespace AutoRest.Swagger.Validation
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
-                    if(!patchOperations.Any(op => (op.Responses["200"].Schema?.Reference?.StripDefinitionPath()) == definition.Key))
+                    if(!patchOperations.Any(op => (op.Responses["200"]?.Schema?.Reference?.StripDefinitionPath()) == definition.Key))
                     {
                         // if no patch operation returns current tracked resource as a response, 
                         // the tracked resource does not have a corresponding patch operation

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
@@ -6,6 +6,7 @@ using AutoRest.Core.Logging;
 using AutoRest.Core.Validation;
 using AutoRest.Swagger.Model.Utilities;
 using System.Collections.Generic;
+using AutoRest.Swagger;
 using AutoRest.Swagger.Model;
 using System.Text.RegularExpressions;
 using System.Linq;
@@ -40,9 +41,9 @@ namespace AutoRest.Swagger.Validation
         // Verifies if a tracked resource has a corresponding patch operation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
-            var servDef = (ServiceDefinition)context.Root;
-            IEnumerable<Operation> patchOperations = ValidationUtilities.GetOperationsByRequestMethod("patch", servDef);
-            var respDefinitions = servDef.Paths.Concat(servDef.CustomPaths).SelectMany(pathPair => pathPair.Value.Select(pathObj => pathObj.Value.Responses["200"]?.Schema?.Reference?.StripDefinitionPath())).Distinct();
+            var serviceDefinition = (ServiceDefinition)context.Root;
+            IEnumerable<Operation> patchOperations = ValidationUtilities.GetOperationsByRequestMethod("patch", serviceDefinition);
+            var respDefinitions = ValidationUtilities.GetResponseModelDefinitions(serviceDefinition);
             foreach (KeyValuePair<string, Schema> definition in definitions)
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
@@ -41,7 +41,7 @@ namespace AutoRest.Swagger.Validation
         // Verifies if a tracked resource has a corresponding patch operation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
-            var serviceDefinition = (ServiceDefinition)context.Root;
+            ServiceDefinition serviceDefinition = (ServiceDefinition)context.Root;
             IEnumerable<Operation> patchOperations = ValidationUtilities.GetOperationsByRequestMethod("patch", serviceDefinition);
             var respDefinitions = ValidationUtilities.GetResponseModelDefinitions(serviceDefinition);
             foreach (KeyValuePair<string, Schema> definition in definitions)


### PR DESCRIPTION
- Improved messaging for tracked resource get/patch operation validations
- Get/patch operation validation is not applied to the top level resource
- Get/patch operation validation is not applied to tracked resources which are not response models
@vishrutshah @amarzavery PTAL