### PR TITLE
Fixed validation rules

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -89,7 +89,7 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Top level property names should not be repeated inside the properties bag. Properties [{0}] conflict with ARM top level properties. Please rename these..
+        ///   Looks up a localized string similar to Top level property names should not be repeated inside the properties bag for ARM resource &quot;{0}&quot;. Properties [{1}] conflict with ARM top level properties. Please rename these..
         /// </summary>
         public static string ArmPropertiesBagValidationMessage {
             get {
@@ -204,7 +204,7 @@ namespace AutoRest.Core.Properties {
                 return ResourceManager.GetString("ConfigurationKnownPlugins", resourceCulture);
             }
         }
-               
+        
         /// <summary>
         ///   Looks up a localized string similar to &apos;Delete&apos; operation cannot have parameters in the request body..
         /// </summary>

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -376,6 +376,6 @@ Modelers:
     <value>Tracked resource '{0}' must have patch operation that at least supports the update of tags.</value>
   </data>
   <data name="ArmPropertiesBagValidationMessage" xml:space="preserve">
-    <value>Top level property names should not be repeated inside the properties bag. Properties [{0}] conflict with ARM top level properties. Please rename these.</value>
+    <value>Top level property names should not be repeated inside the properties bag for ARM resource "{0}". Properties [{1}] conflict with ARM top level properties. Please rename these.</value>
   </data>
 </root>

--- a/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
@@ -93,7 +93,7 @@ namespace AutoRest.Swagger.Model.Utilities
 
         public static IEnumerable<KeyValuePair<string, Schema>> GetArmResources(ServiceDefinition serviceDefinition)
         {
-            return serviceDefinition.Definitions.Where(defPair=>defPair.Value.Extensions?.ContainsKey("x-ms-azure-resource")==true && (bool?)defPair.Value.Extensions?["x-ms-azure-resource"] == true);
+            return serviceDefinition.Definitions.Where(defPair=> !defPair.Key.EqualsIgnoreCase("Resource") && defPair.Value.Extensions?.ContainsKey("x-ms-azure-resource")==true && (bool?)defPair.Value.Extensions["x-ms-azure-resource"] == true);
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
@@ -93,7 +93,7 @@ namespace AutoRest.Swagger.Model.Utilities
 
         public static IEnumerable<KeyValuePair<string, Schema>> GetArmResources(ServiceDefinition serviceDefinition)
         {
-            return serviceDefinition.Definitions.Where(defPair=> !defPair.Key.EqualsIgnoreCase("Resource") && defPair.Value.Extensions?.ContainsKey("x-ms-azure-resource")==true && (bool?)defPair.Value.Extensions["x-ms-azure-resource"] == true);
+            return serviceDefinition.Definitions.Where(defPair=> defPair.Value.Extensions?.ContainsKey("x-ms-azure-resource")==true && (bool?)defPair.Value.Extensions["x-ms-azure-resource"] == true);
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/ArmResourcePropertiesBag.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ArmResourcePropertiesBag.cs
@@ -46,18 +46,17 @@ namespace AutoRest.Swagger.Validation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
             var armDefsPairs = ValidationUtilities.GetArmResources((ServiceDefinition)context.Root);
-            var armDefs = armDefsPairs.Select(defPair => defPair.Value);
             var armDefsKeys = armDefsPairs.Select(defPair => defPair.Key);
             // Also get all models that directly reference an allOf on these arm models
-            var derivedArmDefs = definitions.Values.Where(def => def.AllOf?.Any(defAllOfRef => armDefsKeys.Contains(defAllOfRef.Reference?.StripDefinitionPath()))==true);
-            var modelsToCheck = armDefs.Concat(derivedArmDefs);
+            var derivedArms = definitions.Where(def => def.Value?.AllOf?.Any(defAllOfRef => armDefsKeys.Contains(defAllOfRef.Reference?.StripDefinitionPath()))==true);
+            var modelsToCheck = armDefsPairs.Concat(derivedArms);
             
-            foreach (var modelDef in modelsToCheck)
+            foreach (var modelDefPair in modelsToCheck)
             {
-                var repeatedProps = modelDef.Properties.Keys.Intersect(ArmPropertiesBag);
+                var repeatedProps = modelDefPair.Value.Properties.Keys.Intersect(ArmPropertiesBag);
                 if (repeatedProps.Any())
                 {
-                    yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, string.Join(", ", repeatedProps));
+                    yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, modelDefPair.Key.StripDefinitionPath(), string.Join(", ", repeatedProps));
                 }
             }
         }

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
@@ -49,14 +49,12 @@ namespace AutoRest.Swagger.Validation
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
-                    foreach (var getOp in getOperations)
+                    // check for 200 status response models since they correspond to a successful get operation
+                    if (!getOperations.Any(op => op.Responses.ContainsKey("200") && (op.Responses["200"]?.Schema?.Reference?.StripDefinitionPath()) == definition.Key))
                     {
-                        if (getOp.Responses.ContainsKey("200") && getOp.Responses["200"]?.Schema?.Reference?.StripDefinitionPath() == definition.Key)
-                        {
-                            // if no GET operation returns current tracked resource as a response, 
-                            // the tracked resource does not have a corresponding get operation
-                            yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
-                        }
+                        // if no GET operation returns current tracked resource as a response, 
+                        // the tracked resource does not have a corresponding get operation
+                        yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
                     }
                 }
             }

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceGetOperationValidation.cs
@@ -49,12 +49,14 @@ namespace AutoRest.Swagger.Validation
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
-                    // check for 200 status response models since they correspond to a successful get operation
-                    if (!getOperations.Any(op => (op.Responses["200"]?.Schema?.Reference?.StripDefinitionPath()) == definition.Key))
+                    foreach (var getOp in getOperations)
                     {
-                        // if no GET operation returns current tracked resource as a response, 
-                        // the tracked resource does not have a corresponding get operation
-                        yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
+                        if (getOp.Responses.ContainsKey("200") && getOp.Responses["200"]?.Schema?.Reference?.StripDefinitionPath() == definition.Key)
+                        {
+                            // if no GET operation returns current tracked resource as a response, 
+                            // the tracked resource does not have a corresponding get operation
+                            yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
+                        }
                     }
                 }
             }

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
@@ -48,12 +48,11 @@ namespace AutoRest.Swagger.Validation
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
-                    foreach (var patchOp in patchOperations)
+                    if(!patchOperations.Any(op => op.Responses.ContainsKey("200") && (op.Responses["200"]?.Schema?.Reference?.StripDefinitionPath()) == definition.Key))
                     {
-                        if (patchOp.Responses.ContainsKey("200") && patchOp.Responses["200"]?.Schema?.Reference?.StripDefinitionPath() == definition.Key)
-                        {
-                            yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
-                        }
+                        // if no patch operation returns current tracked resource as a response, 
+                        // the tracked resource does not have a corresponding patch operation
+                        yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
                     }
                 }
             }

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourcePatchOperationValidation.cs
@@ -48,11 +48,12 @@ namespace AutoRest.Swagger.Validation
             {
                 if (respDefinitions.Contains(definition.Key) && ValidationUtilities.IsTrackedResource(definition.Value, definitions))
                 {
-                    if(!patchOperations.Any(op => (op.Responses["200"]?.Schema?.Reference?.StripDefinitionPath()) == definition.Key))
+                    foreach (var patchOp in patchOperations)
                     {
-                        // if no patch operation returns current tracked resource as a response, 
-                        // the tracked resource does not have a corresponding patch operation
-                        yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
+                        if (patchOp.Responses.ContainsKey("200") && patchOp.Responses["200"]?.Schema?.Reference?.StripDefinitionPath() == definition.Key)
+                        {
+                            yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, definition.Key.StripDefinitionPath());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Minor fixes to rules
- Improved message for ArmPropertiesBagValidationMessage
- Filtered ArmResource "Resource" since it is a top level resource from applying the validation rule
- Adding check for keys in responses map 

@olydis PTAL