### PR TITLE
Removing default empty constructors, added tests

### DIFF
--- a/Samples/azure-storage/Azure.CSharp/Models/CheckNameAvailabilityResult.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/CheckNameAvailabilityResult.cs
@@ -9,11 +9,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class CheckNameAvailabilityResult
     {
-        /// <summary>
-        /// Initializes a new instance of the CheckNameAvailabilityResult
-        /// class.
-        /// </summary>
-        public CheckNameAvailabilityResult() { }
 
         /// <summary>
         /// Initializes a new instance of the CheckNameAvailabilityResult

--- a/Samples/azure-storage/Azure.CSharp/Models/CustomDomain.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/CustomDomain.cs
@@ -11,10 +11,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class CustomDomain
     {
-        /// <summary>
-        /// Initializes a new instance of the CustomDomain class.
-        /// </summary>
-        public CustomDomain() { }
 
         /// <summary>
         /// Initializes a new instance of the CustomDomain class.

--- a/Samples/azure-storage/Azure.CSharp/Models/Endpoints.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/Endpoints.cs
@@ -10,10 +10,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class Endpoints
     {
-        /// <summary>
-        /// Initializes a new instance of the Endpoints class.
-        /// </summary>
-        public Endpoints() { }
 
         /// <summary>
         /// Initializes a new instance of the Endpoints class.

--- a/Samples/azure-storage/Azure.CSharp/Models/Resource.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/Resource.cs
@@ -10,10 +10,6 @@ namespace Petstore.Models
 
     public partial class Resource : IResource
     {
-        /// <summary>
-        /// Initializes a new instance of the Resource class.
-        /// </summary>
-        public Resource() { }
 
         /// <summary>
         /// Initializes a new instance of the Resource class.

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccount.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccount.cs
@@ -11,10 +11,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class StorageAccount : Resource
     {
-        /// <summary>
-        /// Initializes a new instance of the StorageAccount class.
-        /// </summary>
-        public StorageAccount() { }
 
         /// <summary>
         /// Initializes a new instance of the StorageAccount class.

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCheckNameAvailabilityParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCheckNameAvailabilityParameters.cs
@@ -7,11 +7,6 @@ namespace Petstore.Models
 
     public partial class StorageAccountCheckNameAvailabilityParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// StorageAccountCheckNameAvailabilityParameters class.
-        /// </summary>
-        public StorageAccountCheckNameAvailabilityParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCreateParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountCreateParameters.cs
@@ -13,11 +13,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class StorageAccountCreateParameters : IResource
     {
-        /// <summary>
-        /// Initializes a new instance of the StorageAccountCreateParameters
-        /// class.
-        /// </summary>
-        public StorageAccountCreateParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the StorageAccountCreateParameters

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountKeys.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountKeys.cs
@@ -9,10 +9,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class StorageAccountKeys
     {
-        /// <summary>
-        /// Initializes a new instance of the StorageAccountKeys class.
-        /// </summary>
-        public StorageAccountKeys() { }
 
         /// <summary>
         /// Initializes a new instance of the StorageAccountKeys class.

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountProperties.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountProperties.cs
@@ -6,10 +6,6 @@ namespace Petstore.Models
 
     public partial class StorageAccountProperties
     {
-        /// <summary>
-        /// Initializes a new instance of the StorageAccountProperties class.
-        /// </summary>
-        public StorageAccountProperties() { }
 
         /// <summary>
         /// Initializes a new instance of the StorageAccountProperties class.

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountPropertiesCreateParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountPropertiesCreateParameters.cs
@@ -6,11 +6,6 @@ namespace Petstore.Models
 
     public partial class StorageAccountPropertiesCreateParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// StorageAccountPropertiesCreateParameters class.
-        /// </summary>
-        public StorageAccountPropertiesCreateParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountPropertiesUpdateParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountPropertiesUpdateParameters.cs
@@ -6,11 +6,6 @@ namespace Petstore.Models
 
     public partial class StorageAccountPropertiesUpdateParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// StorageAccountPropertiesUpdateParameters class.
-        /// </summary>
-        public StorageAccountPropertiesUpdateParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountRegenerateKeyParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountRegenerateKeyParameters.cs
@@ -7,11 +7,6 @@ namespace Petstore.Models
 
     public partial class StorageAccountRegenerateKeyParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// StorageAccountRegenerateKeyParameters class.
-        /// </summary>
-        public StorageAccountRegenerateKeyParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/Samples/azure-storage/Azure.CSharp/Models/StorageAccountUpdateParameters.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/StorageAccountUpdateParameters.cs
@@ -13,11 +13,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class StorageAccountUpdateParameters : IResource
     {
-        /// <summary>
-        /// Initializes a new instance of the StorageAccountUpdateParameters
-        /// class.
-        /// </summary>
-        public StorageAccountUpdateParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the StorageAccountUpdateParameters

--- a/Samples/azure-storage/Azure.CSharp/Models/Usage.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/Usage.cs
@@ -10,10 +10,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class Usage
     {
-        /// <summary>
-        /// Initializes a new instance of the Usage class.
-        /// </summary>
-        public Usage() { }
 
         /// <summary>
         /// Initializes a new instance of the Usage class.

--- a/Samples/azure-storage/Azure.CSharp/Models/UsageName.cs
+++ b/Samples/azure-storage/Azure.CSharp/Models/UsageName.cs
@@ -9,10 +9,6 @@ namespace Petstore.Models
     /// </summary>
     public partial class UsageName
     {
-        /// <summary>
-        /// Initializes a new instance of the UsageName class.
-        /// </summary>
-        public UsageName() { }
 
         /// <summary>
         /// Initializes a new instance of the UsageName class.

--- a/Samples/petstore/CSharp/Models/Category.cs
+++ b/Samples/petstore/CSharp/Models/Category.cs
@@ -8,10 +8,6 @@ namespace Petstore.Models
 
     public partial class Category
     {
-        /// <summary>
-        /// Initializes a new instance of the Category class.
-        /// </summary>
-        public Category() { }
 
         /// <summary>
         /// Initializes a new instance of the Category class.

--- a/Samples/petstore/CSharp/Models/Order.cs
+++ b/Samples/petstore/CSharp/Models/Order.cs
@@ -8,10 +8,6 @@ namespace Petstore.Models
 
     public partial class Order
     {
-        /// <summary>
-        /// Initializes a new instance of the Order class.
-        /// </summary>
-        public Order() { }
 
         /// <summary>
         /// Initializes a new instance of the Order class.

--- a/Samples/petstore/CSharp/Models/Pet.cs
+++ b/Samples/petstore/CSharp/Models/Pet.cs
@@ -17,10 +17,6 @@ namespace Petstore.Models
     /// </remarks>
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/Samples/petstore/CSharp/Models/Tag.cs
+++ b/Samples/petstore/CSharp/Models/Tag.cs
@@ -8,10 +8,6 @@ namespace Petstore.Models
 
     public partial class Tag
     {
-        /// <summary>
-        /// Initializes a new instance of the Tag class.
-        /// </summary>
-        public Tag() { }
 
         /// <summary>
         /// Initializes a new instance of the Tag class.

--- a/Samples/petstore/CSharp/Models/User.cs
+++ b/Samples/petstore/CSharp/Models/User.cs
@@ -8,10 +8,6 @@ namespace Petstore.Models
 
     public partial class User
     {
-        /// <summary>
-        /// Initializes a new instance of the User class.
-        /// </summary>
-        public User() { }
 
         /// <summary>
         /// Initializes a new instance of the User class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureBodyDuration/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureBodyDuration/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationAllSync.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationNoSync.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ArrayWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ArrayWrapperInner.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class ArrayWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the ArrayWrapperInner class.
-        /// </summary>
-        public ArrayWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the ArrayWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/BasicInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/BasicInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class BasicInner
     {
-        /// <summary>
-        /// Initializes a new instance of the BasicInner class.
-        /// </summary>
-        public BasicInner() { }
 
         /// <summary>
         /// Initializes a new instance of the BasicInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/BooleanWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/BooleanWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class BooleanWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the BooleanWrapperInner class.
-        /// </summary>
-        public BooleanWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the BooleanWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ByteWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ByteWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class ByteWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the ByteWrapperInner class.
-        /// </summary>
-        public ByteWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the ByteWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cat.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cat.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Cat : Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Cat class.
-        /// </summary>
-        public Cat() { }
 
         /// <summary>
         /// Initializes a new instance of the Cat class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArrayInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArrayInner.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogArrayInner
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogArrayInner class.
-        /// </summary>
-        public CatalogArrayInner() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogArrayInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArrayOfDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArrayOfDictionary.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogArrayOfDictionary
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogArrayOfDictionary class.
-        /// </summary>
-        public CatalogArrayOfDictionary() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogArrayOfDictionary class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionaryInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionaryInner.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogDictionaryInner
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogDictionaryInner class.
-        /// </summary>
-        public CatalogDictionaryInner() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogDictionaryInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionaryOfArray.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionaryOfArray.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogDictionaryOfArray
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogDictionaryOfArray class.
-        /// </summary>
-        public CatalogDictionaryOfArray() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogDictionaryOfArray class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cookiecuttershark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cookiecuttershark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("cookiecuttershark")]
     public partial class Cookiecuttershark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Cookiecuttershark class.
-        /// </summary>
-        public Cookiecuttershark() { }
 
         /// <summary>
         /// Initializes a new instance of the Cookiecuttershark class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DateWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DateWrapperInner.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DateWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the DateWrapperInner class.
-        /// </summary>
-        public DateWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the DateWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DatetimeWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DatetimeWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DatetimeWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the DatetimeWrapperInner class.
-        /// </summary>
-        public DatetimeWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the DatetimeWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Datetimerfc1123WrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Datetimerfc1123WrapperInner.cs
@@ -16,11 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Datetimerfc1123WrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the Datetimerfc1123WrapperInner
-        /// class.
-        /// </summary>
-        public Datetimerfc1123WrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the Datetimerfc1123WrapperInner

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DictionaryWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DictionaryWrapperInner.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DictionaryWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the DictionaryWrapperInner class.
-        /// </summary>
-        public DictionaryWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the DictionaryWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Dog.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Dog.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Dog : Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Dog class.
-        /// </summary>
-        public Dog() { }
 
         /// <summary>
         /// Initializes a new instance of the Dog class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DoubleWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DoubleWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DoubleWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the DoubleWrapperInner class.
-        /// </summary>
-        public DoubleWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the DoubleWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DurationWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DurationWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DurationWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the DurationWrapperInner class.
-        /// </summary>
-        public DurationWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the DurationWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/FishInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/FishInner.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("Fish")]
     public partial class FishInner
     {
-        /// <summary>
-        /// Initializes a new instance of the FishInner class.
-        /// </summary>
-        public FishInner() { }
 
         /// <summary>
         /// Initializes a new instance of the FishInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/FloatWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/FloatWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class FloatWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the FloatWrapperInner class.
-        /// </summary>
-        public FloatWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the FloatWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Goblinshark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Goblinshark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("goblin")]
     public partial class Goblinshark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Goblinshark class.
-        /// </summary>
-        public Goblinshark() { }
 
         /// <summary>
         /// Initializes a new instance of the Goblinshark class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/IntWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/IntWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class IntWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the IntWrapperInner class.
-        /// </summary>
-        public IntWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the IntWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/LongWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/LongWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class LongWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the LongWrapperInner class.
-        /// </summary>
-        public LongWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the LongWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Pet.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ProductInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ProductInner.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     /// </summary>
     public partial class ProductInner
     {
-        /// <summary>
-        /// Initializes a new instance of the ProductInner class.
-        /// </summary>
-        public ProductInner() { }
 
         /// <summary>
         /// Initializes a new instance of the ProductInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ReadonlyObjInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ReadonlyObjInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class ReadonlyObjInner
     {
-        /// <summary>
-        /// Initializes a new instance of the ReadonlyObjInner class.
-        /// </summary>
-        public ReadonlyObjInner() { }
 
         /// <summary>
         /// Initializes a new instance of the ReadonlyObjInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Salmon.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Salmon.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("salmon")]
     public partial class Salmon : FishInner
     {
-        /// <summary>
-        /// Initializes a new instance of the Salmon class.
-        /// </summary>
-        public Salmon() { }
 
         /// <summary>
         /// Initializes a new instance of the Salmon class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Sawshark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Sawshark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("sawshark")]
     public partial class Sawshark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Sawshark class.
-        /// </summary>
-        public Sawshark() { }
 
         /// <summary>
         /// Initializes a new instance of the Sawshark class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Shark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Shark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("shark")]
     public partial class Shark : FishInner
     {
-        /// <summary>
-        /// Initializes a new instance of the Shark class.
-        /// </summary>
-        public Shark() { }
 
         /// <summary>
         /// Initializes a new instance of the Shark class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/SiameseInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/SiameseInner.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class SiameseInner : Cat
     {
-        /// <summary>
-        /// Initializes a new instance of the SiameseInner class.
-        /// </summary>
-        public SiameseInner() { }
 
         /// <summary>
         /// Initializes a new instance of the SiameseInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/StringWrapperInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/StringWrapperInner.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class StringWrapperInner
     {
-        /// <summary>
-        /// Initializes a new instance of the StringWrapperInner class.
-        /// </summary>
-        public StringWrapperInner() { }
 
         /// <summary>
         /// Initializes a new instance of the StringWrapperInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/FirstParameterGroupInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/FirstParameterGroupInner.cs
@@ -20,10 +20,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class FirstParameterGroupInner
     {
-        /// <summary>
-        /// Initializes a new instance of the FirstParameterGroupInner class.
-        /// </summary>
-        public FirstParameterGroupInner() { }
 
         /// <summary>
         /// Initializes a new instance of the FirstParameterGroupInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostMultiParamGroupsSecondParamGroupInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostMultiParamGroupsSecondParamGroupInner.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class ParameterGroupingPostMultiParamGroupsSecondParamGroupInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// ParameterGroupingPostMultiParamGroupsSecondParamGroupInner class.
-        /// </summary>
-        public ParameterGroupingPostMultiParamGroupsSecondParamGroupInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostOptionalParametersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostOptionalParametersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class ParameterGroupingPostOptionalParametersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// ParameterGroupingPostOptionalParametersInner class.
-        /// </summary>
-        public ParameterGroupingPostOptionalParametersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostRequiredParametersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostRequiredParametersInner.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class ParameterGroupingPostRequiredParametersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// ParameterGroupingPostRequiredParametersInner class.
-        /// </summary>
-        public ParameterGroupingPostRequiredParametersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureReport/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureReport/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/FlattenedProductInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/FlattenedProductInner.cs
@@ -21,10 +21,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
     [JsonTransformation]
     public partial class FlattenedProductInner : Microsoft.Rest.Azure.Resource
     {
-        /// <summary>
-        /// Initializes a new instance of the FlattenedProductInner class.
-        /// </summary>
-        public FlattenedProductInner() { }
 
         /// <summary>
         /// Initializes a new instance of the FlattenedProductInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/ResourceCollectionInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/ResourceCollectionInner.cs
@@ -17,10 +17,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
 
     public partial class ResourceCollectionInner
     {
-        /// <summary>
-        /// Initializes a new instance of the ResourceCollectionInner class.
-        /// </summary>
-        public ResourceCollectionInner() { }
 
         /// <summary>
         /// Initializes a new instance of the ResourceCollectionInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/ResourceInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureResource/Models/ResourceInner.cs
@@ -21,10 +21,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
     /// </summary>
     public partial class ResourceInner
     {
-        /// <summary>
-        /// Initializes a new instance of the ResourceInner class.
-        /// </summary>
-        public ResourceInner() { }
 
         /// <summary>
         /// Initializes a new instance of the ResourceInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeadHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeadHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdHeadHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdHeadHeadersInner class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdHeadHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdHeadersInner class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdParamGroupingHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdParamGroupingHeadersInner class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdParamGroupingHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingParametersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingParametersInner.cs
@@ -20,11 +20,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdParamGroupingParametersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdParamGroupingParametersInner class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdParamGroupingParametersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/OdataFilterInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/AzureSpecials/Models/OdataFilterInner.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
 
     public partial class OdataFilterInner
     {
-        /// <summary>
-        /// Initializes a new instance of the OdataFilterInner class.
-        /// </summary>
-        public OdataFilterInner() { }
 
         /// <summary>
         /// Initializes a new instance of the OdataFilterInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/CustomBaseUri/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/CustomBaseUri/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDelete202Retry200HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDelete202Retry200HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysDelete202Retry200HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysDelete202Retry200HeadersInner class.
-        /// </summary>
-        public LRORetrysDelete202Retry200HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner class.
-        /// </summary>
-        public LRORetrysDeleteAsyncRelativeRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner.cs
@@ -19,12 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner
-        /// class.
-        /// </summary>
-        public LRORetrysDeleteProvisioning202Accepted200SucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPost202Retry200HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPost202Retry200HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysPost202Retry200HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysPost202Retry200HeadersInner class.
-        /// </summary>
-        public LRORetrysPost202Retry200HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPostAsyncRelativeRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPostAsyncRelativeRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysPostAsyncRelativeRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysPostAsyncRelativeRetrySucceededHeadersInner class.
-        /// </summary>
-        public LRORetrysPostAsyncRelativeRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPutAsyncRelativeRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPutAsyncRelativeRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysPutAsyncRelativeRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysPutAsyncRelativeRetrySucceededHeadersInner class.
-        /// </summary>
-        public LRORetrysPutAsyncRelativeRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202NonRetry400HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202NonRetry400HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDelete202NonRetry400HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDelete202NonRetry400HeadersInner class.
-        /// </summary>
-        public LROSADsDelete202NonRetry400HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202RetryInvalidHeaderHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202RetryInvalidHeaderHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDelete202RetryInvalidHeaderHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDelete202RetryInvalidHeaderHeadersInner class.
-        /// </summary>
-        public LROSADsDelete202RetryInvalidHeaderHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetry400HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetry400HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetry400HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetry400HeadersInner class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetry400HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner.cs
@@ -19,12 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner
-        /// class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetryNoStatusHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteNonRetry400HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteNonRetry400HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteNonRetry400HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteNonRetry400HeadersInner class.
-        /// </summary>
-        public LROSADsDeleteNonRetry400HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NoLocationHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NoLocationHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPost202NoLocationHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPost202NoLocationHeadersInner class.
-        /// </summary>
-        public LROSADsPost202NoLocationHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NonRetry400HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NonRetry400HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPost202NonRetry400HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPost202NonRetry400HeadersInner class.
-        /// </summary>
-        public LROSADsPost202NonRetry400HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202RetryInvalidHeaderHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202RetryInvalidHeaderHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPost202RetryInvalidHeaderHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPost202RetryInvalidHeaderHeadersInner class.
-        /// </summary>
-        public LROSADsPost202RetryInvalidHeaderHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetry400HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetry400HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetry400HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetry400HeadersInner class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetry400HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetryInvalidHeaderHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetryNoPayloadHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostNonRetry400HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostNonRetry400HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostNonRetry400HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostNonRetry400HeadersInner class.
-        /// </summary>
-        public LROSADsPostNonRetry400HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetry400HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetry400HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetry400HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetry400HeadersInner class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetry400HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryInvalidHeaderHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryNoStatusHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryNoStatusHeadersInner class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryNoStatusHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryNoStatusPayloadHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPost202Retry200HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPost202Retry200HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsCustomHeaderPost202Retry200HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsCustomHeaderPost202Retry200HeadersInner class.
-        /// </summary>
-        public LROsCustomHeaderPost202Retry200HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPostAsyncRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPostAsyncRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsCustomHeaderPostAsyncRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsCustomHeaderPostAsyncRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsCustomHeaderPostAsyncRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPutAsyncRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPutAsyncRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsCustomHeaderPutAsyncRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsCustomHeaderPutAsyncRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsCustomHeaderPutAsyncRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202NoRetry204HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202NoRetry204HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDelete202NoRetry204HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDelete202NoRetry204HeadersInner class.
-        /// </summary>
-        public LROsDelete202NoRetry204HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202Retry200HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202Retry200HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDelete202Retry200HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsDelete202Retry200HeadersInner
-        /// class.
-        /// </summary>
-        public LROsDelete202Retry200HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsDelete202Retry200HeadersInner

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoHeaderInRetryHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoHeaderInRetryHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncNoHeaderInRetryHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncNoHeaderInRetryHeadersInner class.
-        /// </summary>
-        public LROsDeleteAsyncNoHeaderInRetryHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncNoRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncNoRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsDeleteAsyncNoRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetryFailedHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetryFailedHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncRetryFailedHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncRetryFailedHeadersInner class.
-        /// </summary>
-        public LROsDeleteAsyncRetryFailedHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsDeleteAsyncRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrycanceledHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrycanceledHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncRetrycanceledHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncRetrycanceledHeadersInner class.
-        /// </summary>
-        public LROsDeleteAsyncRetrycanceledHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteNoHeaderInRetryHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteNoHeaderInRetryHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteNoHeaderInRetryHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteNoHeaderInRetryHeadersInner class.
-        /// </summary>
-        public LROsDeleteNoHeaderInRetryHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Accepted200SucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Accepted200SucceededHeadersInner.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteProvisioning202Accepted200SucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteProvisioning202Accepted200SucceededHeadersInner class.
-        /// </summary>
-        public LROsDeleteProvisioning202Accepted200SucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202DeletingFailed200HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202DeletingFailed200HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteProvisioning202DeletingFailed200HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteProvisioning202DeletingFailed200HeadersInner class.
-        /// </summary>
-        public LROsDeleteProvisioning202DeletingFailed200HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Deletingcanceled200HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Deletingcanceled200HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteProvisioning202Deletingcanceled200HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteProvisioning202Deletingcanceled200HeadersInner class.
-        /// </summary>
-        public LROsDeleteProvisioning202Deletingcanceled200HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202NoRetry204HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202NoRetry204HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPost202NoRetry204HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPost202NoRetry204HeadersInner
-        /// class.
-        /// </summary>
-        public LROsPost202NoRetry204HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPost202NoRetry204HeadersInner

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202Retry200HeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202Retry200HeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPost202Retry200HeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPost202Retry200HeadersInner
-        /// class.
-        /// </summary>
-        public LROsPost202Retry200HeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPost202Retry200HeadersInner

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncNoRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncNoRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncNoRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncNoRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsPostAsyncNoRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetryFailedHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetryFailedHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncRetryFailedHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncRetryFailedHeadersInner class.
-        /// </summary>
-        public LROsPostAsyncRetryFailedHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsPostAsyncRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrycanceledHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrycanceledHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncRetrycanceledHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncRetrycanceledHeadersInner class.
-        /// </summary>
-        public LROsPostAsyncRetrycanceledHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoHeaderInRetryHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoHeaderInRetryHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncNoHeaderInRetryHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncNoHeaderInRetryHeadersInner class.
-        /// </summary>
-        public LROsPutAsyncNoHeaderInRetryHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncNoRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncNoRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsPutAsyncNoRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrycanceledHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrycanceledHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncNoRetrycanceledHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncNoRetrycanceledHeadersInner class.
-        /// </summary>
-        public LROsPutAsyncNoRetrycanceledHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetryFailedHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetryFailedHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncRetryFailedHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncRetryFailedHeadersInner class.
-        /// </summary>
-        public LROsPutAsyncRetryFailedHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetrySucceededHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetrySucceededHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncRetrySucceededHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncRetrySucceededHeadersInner class.
-        /// </summary>
-        public LROsPutAsyncRetrySucceededHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutNoHeaderInRetryHeadersInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutNoHeaderInRetryHeadersInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutNoHeaderInRetryHeadersInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutNoHeaderInRetryHeadersInner class.
-        /// </summary>
-        public LROsPutNoHeaderInRetryHeadersInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/OperationResult.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/OperationResult.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class OperationResult
     {
-        /// <summary>
-        /// Initializes a new instance of the OperationResult class.
-        /// </summary>
-        public OperationResult() { }
 
         /// <summary>
         /// Initializes a new instance of the OperationResult class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/OperationResultError.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/OperationResultError.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class OperationResultError
     {
-        /// <summary>
-        /// Initializes a new instance of the OperationResultError class.
-        /// </summary>
-        public OperationResultError() { }
 
         /// <summary>
         /// Initializes a new instance of the OperationResultError class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/ProductInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/ProductInner.cs
@@ -21,10 +21,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     [JsonTransformation]
     public partial class ProductInner : Microsoft.Rest.Azure.Resource
     {
-        /// <summary>
-        /// Initializes a new instance of the ProductInner class.
-        /// </summary>
-        public ProductInner() { }
 
         /// <summary>
         /// Initializes a new instance of the ProductInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/SkuInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/SkuInner.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class SkuInner
     {
-        /// <summary>
-        /// Initializes a new instance of the SkuInner class.
-        /// </summary>
-        public SkuInner() { }
 
         /// <summary>
         /// Initializes a new instance of the SkuInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/SubProductInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Lro/Models/SubProductInner.cs
@@ -19,10 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     [JsonTransformation]
     public partial class SubProductInner : Microsoft.Rest.Azure.SubResource
     {
-        /// <summary>
-        /// Initializes a new instance of the SubProductInner class.
-        /// </summary>
-        public SubProductInner() { }
 
         /// <summary>
         /// Initializes a new instance of the SubProductInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/CustomParameterGroupInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/CustomParameterGroupInner.cs
@@ -21,10 +21,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class CustomParameterGroupInner
     {
-        /// <summary>
-        /// Initializes a new instance of the CustomParameterGroupInner class.
-        /// </summary>
-        public CustomParameterGroupInner() { }
 
         /// <summary>
         /// Initializes a new instance of the CustomParameterGroupInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/OperationResult.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/OperationResult.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
 
     public partial class OperationResult
     {
-        /// <summary>
-        /// Initializes a new instance of the OperationResult class.
-        /// </summary>
-        public OperationResult() { }
 
         /// <summary>
         /// Initializes a new instance of the OperationResult class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesOptionsInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesOptionsInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetMultiplePagesOptionsInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// PagingGetMultiplePagesOptionsInner class.
-        /// </summary>
-        public PagingGetMultiplePagesOptionsInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetNextOptionsInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetNextOptionsInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetMultiplePagesWithOffsetNextOptionsInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// PagingGetMultiplePagesWithOffsetNextOptionsInner class.
-        /// </summary>
-        public PagingGetMultiplePagesWithOffsetNextOptionsInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetOptionsInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetOptionsInner.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetMultiplePagesWithOffsetOptionsInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// PagingGetMultiplePagesWithOffsetOptionsInner class.
-        /// </summary>
-        public PagingGetMultiplePagesWithOffsetOptionsInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetOdataMultiplePagesOptionsInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetOdataMultiplePagesOptionsInner.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetOdataMultiplePagesOptionsInner
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// PagingGetOdataMultiplePagesOptionsInner class.
-        /// </summary>
-        public PagingGetOdataMultiplePagesOptionsInner() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/Product.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
 
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/ProductProperties.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/Paging/Models/ProductProperties.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
 
     public partial class ProductProperties
     {
-        /// <summary>
-        /// Initializes a new instance of the ProductProperties class.
-        /// </summary>
-        public ProductProperties() { }
 
         /// <summary>
         /// Initializes a new instance of the ProductProperties class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/SampleResourceGroupInner.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Fluent.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/SampleResourceGroupInner.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion.Models
 
     public partial class SampleResourceGroupInner
     {
-        /// <summary>
-        /// Initializes a new instance of the SampleResourceGroupInner class.
-        /// </summary>
-        public SampleResourceGroupInner() { }
 
         /// <summary>
         /// Initializes a new instance of the SampleResourceGroupInner class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureBodyDuration.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationAllSync/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationAllSync.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureBodyDurationNoSync/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureBodyDurationNoSync.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ArrayWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ArrayWrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class ArrayWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ArrayWrapper class.
-        /// </summary>
-        public ArrayWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ArrayWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Basic.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Basic.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Basic
     {
-        /// <summary>
-        /// Initializes a new instance of the Basic class.
-        /// </summary>
-        public Basic() { }
 
         /// <summary>
         /// Initializes a new instance of the Basic class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/BooleanWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/BooleanWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class BooleanWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the BooleanWrapper class.
-        /// </summary>
-        public BooleanWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the BooleanWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ByteWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ByteWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class ByteWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ByteWrapper class.
-        /// </summary>
-        public ByteWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ByteWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cat.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cat.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Cat : Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Cat class.
-        /// </summary>
-        public Cat() { }
 
         /// <summary>
         /// Initializes a new instance of the Cat class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArray.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArray.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogArray
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogArray class.
-        /// </summary>
-        public CatalogArray() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogArray class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArrayOfDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogArrayOfDictionary.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogArrayOfDictionary
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogArrayOfDictionary class.
-        /// </summary>
-        public CatalogArrayOfDictionary() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogArrayOfDictionary class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionary.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogDictionary
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogDictionary class.
-        /// </summary>
-        public CatalogDictionary() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogDictionary class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionaryOfArray.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/CatalogDictionaryOfArray.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class CatalogDictionaryOfArray
     {
-        /// <summary>
-        /// Initializes a new instance of the CatalogDictionaryOfArray class.
-        /// </summary>
-        public CatalogDictionaryOfArray() { }
 
         /// <summary>
         /// Initializes a new instance of the CatalogDictionaryOfArray class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cookiecuttershark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Cookiecuttershark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("cookiecuttershark")]
     public partial class Cookiecuttershark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Cookiecuttershark class.
-        /// </summary>
-        public Cookiecuttershark() { }
 
         /// <summary>
         /// Initializes a new instance of the Cookiecuttershark class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DateWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DateWrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DateWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DateWrapper class.
-        /// </summary>
-        public DateWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DateWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DatetimeWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DatetimeWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DatetimeWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DatetimeWrapper class.
-        /// </summary>
-        public DatetimeWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DatetimeWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Datetimerfc1123Wrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Datetimerfc1123Wrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Datetimerfc1123Wrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the Datetimerfc1123Wrapper class.
-        /// </summary>
-        public Datetimerfc1123Wrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the Datetimerfc1123Wrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DictionaryWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DictionaryWrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DictionaryWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DictionaryWrapper class.
-        /// </summary>
-        public DictionaryWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DictionaryWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Dog.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Dog.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Dog : Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Dog class.
-        /// </summary>
-        public Dog() { }
 
         /// <summary>
         /// Initializes a new instance of the Dog class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DoubleWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DoubleWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DoubleWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DoubleWrapper class.
-        /// </summary>
-        public DoubleWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DoubleWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DurationWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/DurationWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class DurationWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DurationWrapper class.
-        /// </summary>
-        public DurationWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DurationWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Fish.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Fish.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Fish
     {
-        /// <summary>
-        /// Initializes a new instance of the Fish class.
-        /// </summary>
-        public Fish() { }
 
         /// <summary>
         /// Initializes a new instance of the Fish class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/FloatWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/FloatWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class FloatWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the FloatWrapper class.
-        /// </summary>
-        public FloatWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the FloatWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Goblinshark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Goblinshark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("goblin")]
     public partial class Goblinshark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Goblinshark class.
-        /// </summary>
-        public Goblinshark() { }
 
         /// <summary>
         /// Initializes a new instance of the Goblinshark class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/IntWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/IntWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class IntWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the IntWrapper class.
-        /// </summary>
-        public IntWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the IntWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/LongWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/LongWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class LongWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the LongWrapper class.
-        /// </summary>
-        public LongWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the LongWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Pet.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Product.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     /// </summary>
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ReadonlyObj.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/ReadonlyObj.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class ReadonlyObj
     {
-        /// <summary>
-        /// Initializes a new instance of the ReadonlyObj class.
-        /// </summary>
-        public ReadonlyObj() { }
 
         /// <summary>
         /// Initializes a new instance of the ReadonlyObj class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Salmon.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Salmon.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("salmon")]
     public partial class Salmon : Fish
     {
-        /// <summary>
-        /// Initializes a new instance of the Salmon class.
-        /// </summary>
-        public Salmon() { }
 
         /// <summary>
         /// Initializes a new instance of the Salmon class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Sawshark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Sawshark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("sawshark")]
     public partial class Sawshark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Sawshark class.
-        /// </summary>
-        public Sawshark() { }
 
         /// <summary>
         /// Initializes a new instance of the Sawshark class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Shark.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Shark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
     [Newtonsoft.Json.JsonObject("shark")]
     public partial class Shark : Fish
     {
-        /// <summary>
-        /// Initializes a new instance of the Shark class.
-        /// </summary>
-        public Shark() { }
 
         /// <summary>
         /// Initializes a new instance of the Shark class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Siamese.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/Siamese.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class Siamese : Cat
     {
-        /// <summary>
-        /// Initializes a new instance of the Siamese class.
-        /// </summary>
-        public Siamese() { }
 
         /// <summary>
         /// Initializes a new instance of the Siamese class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/StringWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/Models/StringWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsAzureCompositeModelClient.Models
 
     public partial class StringWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the StringWrapper class.
-        /// </summary>
-        public StringWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the StringWrapper class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/FirstParameterGroup.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/FirstParameterGroup.cs
@@ -20,10 +20,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class FirstParameterGroup
     {
-        /// <summary>
-        /// Initializes a new instance of the FirstParameterGroup class.
-        /// </summary>
-        public FirstParameterGroup() { }
 
         /// <summary>
         /// Initializes a new instance of the FirstParameterGroup class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostMultiParamGroupsSecondParamGroup.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostMultiParamGroupsSecondParamGroup.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class ParameterGroupingPostMultiParamGroupsSecondParamGroup
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// ParameterGroupingPostMultiParamGroupsSecondParamGroup class.
-        /// </summary>
-        public ParameterGroupingPostMultiParamGroupsSecondParamGroup() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostOptionalParameters.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostOptionalParameters.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class ParameterGroupingPostOptionalParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// ParameterGroupingPostOptionalParameters class.
-        /// </summary>
-        public ParameterGroupingPostOptionalParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostRequiredParameters.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/Models/ParameterGroupingPostRequiredParameters.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureParameterGrouping.Models
     /// </summary>
     public partial class ParameterGroupingPostRequiredParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// ParameterGroupingPostRequiredParameters class.
-        /// </summary>
-        public ParameterGroupingPostRequiredParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureReport/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureReport/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureReport.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/FlattenedProduct.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/FlattenedProduct.cs
@@ -20,10 +20,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
     [JsonTransformation]
     public partial class FlattenedProduct : Resource
     {
-        /// <summary>
-        /// Initializes a new instance of the FlattenedProduct class.
-        /// </summary>
-        public FlattenedProduct() { }
 
         /// <summary>
         /// Initializes a new instance of the FlattenedProduct class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/Resource.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/Resource.cs
@@ -23,10 +23,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
     /// </summary>
     public partial class Resource : IResource
     {
-        /// <summary>
-        /// Initializes a new instance of the Resource class.
-        /// </summary>
-        public Resource() { }
 
         /// <summary>
         /// Initializes a new instance of the Resource class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/ResourceCollection.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureResource/Models/ResourceCollection.cs
@@ -17,10 +17,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureResource.Models
 
     public partial class ResourceCollection
     {
-        /// <summary>
-        /// Initializes a new instance of the ResourceCollection class.
-        /// </summary>
-        public ResourceCollection() { }
 
         /// <summary>
         /// Initializes a new instance of the ResourceCollection class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeadHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeadHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdHeadHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdHeadHeaders class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdHeadHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderCustomNamedRequestIdHeaders
-        /// class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderCustomNamedRequestIdHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdParamGroupingHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdParamGroupingHeaders class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdParamGroupingHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingParameters.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/HeaderCustomNamedRequestIdParamGroupingParameters.cs
@@ -20,11 +20,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
     /// </summary>
     public partial class HeaderCustomNamedRequestIdParamGroupingParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderCustomNamedRequestIdParamGroupingParameters class.
-        /// </summary>
-        public HeaderCustomNamedRequestIdParamGroupingParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/OdataFilter.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/Models/OdataFilter.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsAzureSpecials.Models
 
     public partial class OdataFilter
     {
-        /// <summary>
-        /// Initializes a new instance of the OdataFilter class.
-        /// </summary>
-        public OdataFilter() { }
 
         /// <summary>
         /// Initializes a new instance of the OdataFilter class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsCustomBaseUri.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDelete202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDelete202Retry200Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysDelete202Retry200Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LRORetrysDelete202Retry200Headers
-        /// class.
-        /// </summary>
-        public LRORetrysDelete202Retry200Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LRORetrysDelete202Retry200Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteAsyncRelativeRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysDeleteAsyncRelativeRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysDeleteAsyncRelativeRetrySucceededHeaders class.
-        /// </summary>
-        public LRORetrysDeleteAsyncRelativeRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysDeleteProvisioning202Accepted200SucceededHeaders.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysDeleteProvisioning202Accepted200SucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysDeleteProvisioning202Accepted200SucceededHeaders class.
-        /// </summary>
-        public LRORetrysDeleteProvisioning202Accepted200SucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPost202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPost202Retry200Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysPost202Retry200Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LRORetrysPost202Retry200Headers
-        /// class.
-        /// </summary>
-        public LRORetrysPost202Retry200Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LRORetrysPost202Retry200Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPostAsyncRelativeRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysPostAsyncRelativeRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysPostAsyncRelativeRetrySucceededHeaders class.
-        /// </summary>
-        public LRORetrysPostAsyncRelativeRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LRORetrysPutAsyncRelativeRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LRORetrysPutAsyncRelativeRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LRORetrysPutAsyncRelativeRetrySucceededHeaders class.
-        /// </summary>
-        public LRORetrysPutAsyncRelativeRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202NonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202NonRetry400Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDelete202NonRetry400Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDelete202NonRetry400Headers class.
-        /// </summary>
-        public LROSADsDelete202NonRetry400Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202RetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDelete202RetryInvalidHeaderHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDelete202RetryInvalidHeaderHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDelete202RetryInvalidHeaderHeaders class.
-        /// </summary>
-        public LROSADsDelete202RetryInvalidHeaderHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetry400Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetry400Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetry400Headers class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetry400Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetryInvalidHeaderHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetryInvalidJsonPollingHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryNoStatusHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteAsyncRelativeRetryNoStatusHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteAsyncRelativeRetryNoStatusHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsDeleteAsyncRelativeRetryNoStatusHeaders class.
-        /// </summary>
-        public LROSADsDeleteAsyncRelativeRetryNoStatusHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteNonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsDeleteNonRetry400Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsDeleteNonRetry400Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LROSADsDeleteNonRetry400Headers
-        /// class.
-        /// </summary>
-        public LROSADsDeleteNonRetry400Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LROSADsDeleteNonRetry400Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NoLocationHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NoLocationHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPost202NoLocationHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROSADsPost202NoLocationHeaders
-        /// class.
-        /// </summary>
-        public LROSADsPost202NoLocationHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROSADsPost202NoLocationHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202NonRetry400Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPost202NonRetry400Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LROSADsPost202NonRetry400Headers
-        /// class.
-        /// </summary>
-        public LROSADsPost202NonRetry400Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LROSADsPost202NonRetry400Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202RetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPost202RetryInvalidHeaderHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPost202RetryInvalidHeaderHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPost202RetryInvalidHeaderHeaders class.
-        /// </summary>
-        public LROSADsPost202RetryInvalidHeaderHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetry400Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetry400Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetry400Headers class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetry400Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetryInvalidHeaderHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetryInvalidJsonPollingHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryNoPayloadHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostAsyncRelativeRetryNoPayloadHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostAsyncRelativeRetryNoPayloadHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPostAsyncRelativeRetryNoPayloadHeaders class.
-        /// </summary>
-        public LROSADsPostAsyncRelativeRetryNoPayloadHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostNonRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPostNonRetry400Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPostNonRetry400Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LROSADsPostNonRetry400Headers
-        /// class.
-        /// </summary>
-        public LROSADsPostNonRetry400Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LROSADsPostNonRetry400Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetry400Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetry400Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetry400Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetry400Headers class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetry400Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryInvalidHeaderHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryInvalidJsonPollingHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryNoStatusHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryNoStatusHeaders class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryNoStatusHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders class.
-        /// </summary>
-        public LROSADsPutAsyncRelativeRetryNoStatusPayloadHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPost202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPost202Retry200Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsCustomHeaderPost202Retry200Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsCustomHeaderPost202Retry200Headers class.
-        /// </summary>
-        public LROsCustomHeaderPost202Retry200Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPostAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPostAsyncRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsCustomHeaderPostAsyncRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsCustomHeaderPostAsyncRetrySucceededHeaders class.
-        /// </summary>
-        public LROsCustomHeaderPostAsyncRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPutAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsCustomHeaderPutAsyncRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsCustomHeaderPutAsyncRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsCustomHeaderPutAsyncRetrySucceededHeaders class.
-        /// </summary>
-        public LROsCustomHeaderPutAsyncRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202NoRetry204Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202NoRetry204Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDelete202NoRetry204Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsDelete202NoRetry204Headers
-        /// class.
-        /// </summary>
-        public LROsDelete202NoRetry204Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsDelete202NoRetry204Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDelete202Retry200Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDelete202Retry200Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsDelete202Retry200Headers
-        /// class.
-        /// </summary>
-        public LROsDelete202Retry200Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsDelete202Retry200Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoHeaderInRetryHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoHeaderInRetryHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncNoHeaderInRetryHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncNoHeaderInRetryHeaders class.
-        /// </summary>
-        public LROsDeleteAsyncNoHeaderInRetryHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncNoRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncNoRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncNoRetrySucceededHeaders class.
-        /// </summary>
-        public LROsDeleteAsyncNoRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetryFailedHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetryFailedHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncRetryFailedHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsDeleteAsyncRetryFailedHeaders
-        /// class.
-        /// </summary>
-        public LROsDeleteAsyncRetryFailedHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsDeleteAsyncRetryFailedHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncRetrySucceededHeaders class.
-        /// </summary>
-        public LROsDeleteAsyncRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrycanceledHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteAsyncRetrycanceledHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteAsyncRetrycanceledHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteAsyncRetrycanceledHeaders class.
-        /// </summary>
-        public LROsDeleteAsyncRetrycanceledHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteNoHeaderInRetryHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteNoHeaderInRetryHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteNoHeaderInRetryHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsDeleteNoHeaderInRetryHeaders
-        /// class.
-        /// </summary>
-        public LROsDeleteNoHeaderInRetryHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsDeleteNoHeaderInRetryHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Accepted200SucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Accepted200SucceededHeaders.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteProvisioning202Accepted200SucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteProvisioning202Accepted200SucceededHeaders class.
-        /// </summary>
-        public LROsDeleteProvisioning202Accepted200SucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202DeletingFailed200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202DeletingFailed200Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteProvisioning202DeletingFailed200Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteProvisioning202DeletingFailed200Headers class.
-        /// </summary>
-        public LROsDeleteProvisioning202DeletingFailed200Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Deletingcanceled200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsDeleteProvisioning202Deletingcanceled200Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsDeleteProvisioning202Deletingcanceled200Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsDeleteProvisioning202Deletingcanceled200Headers class.
-        /// </summary>
-        public LROsDeleteProvisioning202Deletingcanceled200Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202NoRetry204Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202NoRetry204Headers.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPost202NoRetry204Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPost202NoRetry204Headers
-        /// class.
-        /// </summary>
-        public LROsPost202NoRetry204Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPost202NoRetry204Headers

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202Retry200Headers.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPost202Retry200Headers.cs
@@ -18,10 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPost202Retry200Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPost202Retry200Headers class.
-        /// </summary>
-        public LROsPost202Retry200Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPost202Retry200Headers class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncNoRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncNoRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncNoRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncNoRetrySucceededHeaders class.
-        /// </summary>
-        public LROsPostAsyncNoRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetryFailedHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetryFailedHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncRetryFailedHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPostAsyncRetryFailedHeaders
-        /// class.
-        /// </summary>
-        public LROsPostAsyncRetryFailedHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPostAsyncRetryFailedHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPostAsyncRetrySucceededHeaders class.
-        /// </summary>
-        public LROsPostAsyncRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrycanceledHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPostAsyncRetrycanceledHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPostAsyncRetrycanceledHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPostAsyncRetrycanceledHeaders
-        /// class.
-        /// </summary>
-        public LROsPostAsyncRetrycanceledHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPostAsyncRetrycanceledHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoHeaderInRetryHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoHeaderInRetryHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncNoHeaderInRetryHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncNoHeaderInRetryHeaders class.
-        /// </summary>
-        public LROsPutAsyncNoHeaderInRetryHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncNoRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncNoRetrySucceededHeaders class.
-        /// </summary>
-        public LROsPutAsyncNoRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrycanceledHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncNoRetrycanceledHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncNoRetrycanceledHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// LROsPutAsyncNoRetrycanceledHeaders class.
-        /// </summary>
-        public LROsPutAsyncNoRetrycanceledHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetryFailedHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetryFailedHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncRetryFailedHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPutAsyncRetryFailedHeaders
-        /// class.
-        /// </summary>
-        public LROsPutAsyncRetryFailedHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPutAsyncRetryFailedHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetrySucceededHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutAsyncRetrySucceededHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutAsyncRetrySucceededHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPutAsyncRetrySucceededHeaders
-        /// class.
-        /// </summary>
-        public LROsPutAsyncRetrySucceededHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPutAsyncRetrySucceededHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutNoHeaderInRetryHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/LROsPutNoHeaderInRetryHeaders.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     /// </summary>
     public partial class LROsPutNoHeaderInRetryHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LROsPutNoHeaderInRetryHeaders
-        /// class.
-        /// </summary>
-        public LROsPutNoHeaderInRetryHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LROsPutNoHeaderInRetryHeaders

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/OperationResult.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/OperationResult.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class OperationResult
     {
-        /// <summary>
-        /// Initializes a new instance of the OperationResult class.
-        /// </summary>
-        public OperationResult() { }
 
         /// <summary>
         /// Initializes a new instance of the OperationResult class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/OperationResultError.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/OperationResultError.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class OperationResultError
     {
-        /// <summary>
-        /// Initializes a new instance of the OperationResultError class.
-        /// </summary>
-        public OperationResultError() { }
 
         /// <summary>
         /// Initializes a new instance of the OperationResultError class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/Product.cs
@@ -20,10 +20,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     [JsonTransformation]
     public partial class Product : Resource
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/Resource.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/Resource.cs
@@ -19,10 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class Resource : IResource
     {
-        /// <summary>
-        /// Initializes a new instance of the Resource class.
-        /// </summary>
-        public Resource() { }
 
         /// <summary>
         /// Initializes a new instance of the Resource class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/Sku.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/Sku.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class Sku
     {
-        /// <summary>
-        /// Initializes a new instance of the Sku class.
-        /// </summary>
-        public Sku() { }
 
         /// <summary>
         /// Initializes a new instance of the Sku class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/SubProduct.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/SubProduct.cs
@@ -18,10 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
     [JsonTransformation]
     public partial class SubProduct : SubResource
     {
-        /// <summary>
-        /// Initializes a new instance of the SubProduct class.
-        /// </summary>
-        public SubProduct() { }
 
         /// <summary>
         /// Initializes a new instance of the SubProduct class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/SubResource.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Lro/Models/SubResource.cs
@@ -17,10 +17,6 @@ namespace Fixtures.Azure.AcceptanceTestsLro.Models
 
     public partial class SubResource : IResource
     {
-        /// <summary>
-        /// Initializes a new instance of the SubResource class.
-        /// </summary>
-        public SubResource() { }
 
         /// <summary>
         /// Initializes a new instance of the SubResource class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/CustomParameterGroup.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/CustomParameterGroup.cs
@@ -21,10 +21,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class CustomParameterGroup
     {
-        /// <summary>
-        /// Initializes a new instance of the CustomParameterGroup class.
-        /// </summary>
-        public CustomParameterGroup() { }
 
         /// <summary>
         /// Initializes a new instance of the CustomParameterGroup class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/OperationResult.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/OperationResult.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
 
     public partial class OperationResult
     {
-        /// <summary>
-        /// Initializes a new instance of the OperationResult class.
-        /// </summary>
-        public OperationResult() { }
 
         /// <summary>
         /// Initializes a new instance of the OperationResult class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesOptions.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetMultiplePagesOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the PagingGetMultiplePagesOptions
-        /// class.
-        /// </summary>
-        public PagingGetMultiplePagesOptions() { }
 
         /// <summary>
         /// Initializes a new instance of the PagingGetMultiplePagesOptions

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetNextOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetNextOptions.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetMultiplePagesWithOffsetNextOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// PagingGetMultiplePagesWithOffsetNextOptions class.
-        /// </summary>
-        public PagingGetMultiplePagesWithOffsetNextOptions() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetMultiplePagesWithOffsetOptions.cs
@@ -19,11 +19,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetMultiplePagesWithOffsetOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// PagingGetMultiplePagesWithOffsetOptions class.
-        /// </summary>
-        public PagingGetMultiplePagesWithOffsetOptions() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetOdataMultiplePagesOptions.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/PagingGetOdataMultiplePagesOptions.cs
@@ -18,11 +18,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
     /// </summary>
     public partial class PagingGetOdataMultiplePagesOptions
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// PagingGetOdataMultiplePagesOptions class.
-        /// </summary>
-        public PagingGetOdataMultiplePagesOptions() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/Product.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
 
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/ProductProperties.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/Paging/Models/ProductProperties.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsPaging.Models
 
     public partial class ProductProperties
     {
-        /// <summary>
-        /// Initializes a new instance of the ProductProperties class.
-        /// </summary>
-        public ProductProperties() { }
 
         /// <summary>
         /// Initializes a new instance of the ProductProperties class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/Error.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/SampleResourceGroup.cs
+++ b/src/generator/AutoRest.CSharp.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/Models/SampleResourceGroup.cs
@@ -15,10 +15,6 @@ namespace Fixtures.Azure.AcceptanceTestsSubscriptionIdApiVersion.Models
 
     public partial class SampleResourceGroup
     {
-        /// <summary>
-        /// Initializes a new instance of the SampleResourceGroup class.
-        /// </summary>
-        public SampleResourceGroup() { }
 
         /// <summary>
         /// Initializes a new instance of the SampleResourceGroup class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyArray.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyArray/Models/Product.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyArray.Models
 
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyBoolean/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyBoolean/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyBoolean.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyByte/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyByte/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyByte.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/ArrayWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/ArrayWrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class ArrayWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ArrayWrapper class.
-        /// </summary>
-        public ArrayWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ArrayWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Basic.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Basic.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Basic
     {
-        /// <summary>
-        /// Initializes a new instance of the Basic class.
-        /// </summary>
-        public Basic() { }
 
         /// <summary>
         /// Initializes a new instance of the Basic class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/BooleanWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/BooleanWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class BooleanWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the BooleanWrapper class.
-        /// </summary>
-        public BooleanWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the BooleanWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/ByteWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/ByteWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class ByteWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ByteWrapper class.
-        /// </summary>
-        public ByteWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ByteWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Cat.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Cat.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Cat : Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Cat class.
-        /// </summary>
-        public Cat() { }
 
         /// <summary>
         /// Initializes a new instance of the Cat class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Cookiecuttershark.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Cookiecuttershark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
     [Newtonsoft.Json.JsonObject("cookiecuttershark")]
     public partial class Cookiecuttershark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Cookiecuttershark class.
-        /// </summary>
-        public Cookiecuttershark() { }
 
         /// <summary>
         /// Initializes a new instance of the Cookiecuttershark class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DateWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DateWrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class DateWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DateWrapper class.
-        /// </summary>
-        public DateWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DateWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DatetimeWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DatetimeWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class DatetimeWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DatetimeWrapper class.
-        /// </summary>
-        public DatetimeWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DatetimeWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Datetimerfc1123Wrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Datetimerfc1123Wrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Datetimerfc1123Wrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the Datetimerfc1123Wrapper class.
-        /// </summary>
-        public Datetimerfc1123Wrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the Datetimerfc1123Wrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DictionaryWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DictionaryWrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class DictionaryWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DictionaryWrapper class.
-        /// </summary>
-        public DictionaryWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DictionaryWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Dog.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Dog.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Dog : Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Dog class.
-        /// </summary>
-        public Dog() { }
 
         /// <summary>
         /// Initializes a new instance of the Dog class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DoubleWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DoubleWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class DoubleWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DoubleWrapper class.
-        /// </summary>
-        public DoubleWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DoubleWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DurationWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/DurationWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class DurationWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the DurationWrapper class.
-        /// </summary>
-        public DurationWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the DurationWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Fish.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Fish.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Fish
     {
-        /// <summary>
-        /// Initializes a new instance of the Fish class.
-        /// </summary>
-        public Fish() { }
 
         /// <summary>
         /// Initializes a new instance of the Fish class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/FloatWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/FloatWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class FloatWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the FloatWrapper class.
-        /// </summary>
-        public FloatWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the FloatWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Goblinshark.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Goblinshark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
     [Newtonsoft.Json.JsonObject("goblin")]
     public partial class Goblinshark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Goblinshark class.
-        /// </summary>
-        public Goblinshark() { }
 
         /// <summary>
         /// Initializes a new instance of the Goblinshark class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/IntWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/IntWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class IntWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the IntWrapper class.
-        /// </summary>
-        public IntWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the IntWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/LongWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/LongWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class LongWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the LongWrapper class.
-        /// </summary>
-        public LongWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the LongWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Pet.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/ReadonlyObj.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/ReadonlyObj.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class ReadonlyObj
     {
-        /// <summary>
-        /// Initializes a new instance of the ReadonlyObj class.
-        /// </summary>
-        public ReadonlyObj() { }
 
         /// <summary>
         /// Initializes a new instance of the ReadonlyObj class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Salmon.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Salmon.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
     [Newtonsoft.Json.JsonObject("salmon")]
     public partial class Salmon : Fish
     {
-        /// <summary>
-        /// Initializes a new instance of the Salmon class.
-        /// </summary>
-        public Salmon() { }
 
         /// <summary>
         /// Initializes a new instance of the Salmon class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Sawshark.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Sawshark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
     [Newtonsoft.Json.JsonObject("sawshark")]
     public partial class Sawshark : Shark
     {
-        /// <summary>
-        /// Initializes a new instance of the Sawshark class.
-        /// </summary>
-        public Sawshark() { }
 
         /// <summary>
         /// Initializes a new instance of the Sawshark class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Shark.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Shark.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
     [Newtonsoft.Json.JsonObject("shark")]
     public partial class Shark : Fish
     {
-        /// <summary>
-        /// Initializes a new instance of the Shark class.
-        /// </summary>
-        public Shark() { }
 
         /// <summary>
         /// Initializes a new instance of the Shark class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Siamese.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/Siamese.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class Siamese : Cat
     {
-        /// <summary>
-        /// Initializes a new instance of the Siamese class.
-        /// </summary>
-        public Siamese() { }
 
         /// <summary>
         /// Initializes a new instance of the Siamese class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/StringWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyComplex/Models/StringWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyComplex.Models
 
     public partial class StringWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the StringWrapper class.
-        /// </summary>
-        public StringWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the StringWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDate/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDate/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyDate.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDateTime/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDateTime/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyDateTime.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyDateTimeRfc1123.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyDictionary.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Models/Widget.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDictionary/Models/Widget.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyDictionary.Models
 
     public partial class Widget
     {
-        /// <summary>
-        /// Initializes a new instance of the Widget class.
-        /// </summary>
-        public Widget() { }
 
         /// <summary>
         /// Initializes a new instance of the Widget class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDuration/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyDuration/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyDuration.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyFile/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyFile/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyFile.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyFormData/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyFormData/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyFormData.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyInteger/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyInteger/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyInteger.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyNumber/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyNumber/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyNumber.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyString/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyString/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyString.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyString/Models/RefColorConstant.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/BodyString/Models/RefColorConstant.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsBodyString.Models
 
     public partial class RefColorConstant
     {
-        /// <summary>
-        /// Initializes a new instance of the RefColorConstant class.
-        /// </summary>
-        public RefColorConstant() { }
 
         /// <summary>
         /// Initializes a new instance of the RefColorConstant class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsCompositeBoolIntClient.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/CustomBaseUri/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/CustomBaseUri/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsCustomBaseUri.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsCustomBaseUriMoreOptions.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseBoolHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseBoolHeaders.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseBoolHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseBoolHeaders class.
-        /// </summary>
-        public HeaderResponseBoolHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseBoolHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseByteHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseByteHeaders.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseByteHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseByteHeaders class.
-        /// </summary>
-        public HeaderResponseByteHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseByteHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDateHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDateHeaders.cs
@@ -19,10 +19,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseDateHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseDateHeaders class.
-        /// </summary>
-        public HeaderResponseDateHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseDateHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDatetimeHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDatetimeHeaders.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseDatetimeHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseDatetimeHeaders
-        /// class.
-        /// </summary>
-        public HeaderResponseDatetimeHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseDatetimeHeaders

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDatetimeRfc1123Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDatetimeRfc1123Headers.cs
@@ -19,11 +19,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseDatetimeRfc1123Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the
-        /// HeaderResponseDatetimeRfc1123Headers class.
-        /// </summary>
-        public HeaderResponseDatetimeRfc1123Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDoubleHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDoubleHeaders.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseDoubleHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseDoubleHeaders
-        /// class.
-        /// </summary>
-        public HeaderResponseDoubleHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseDoubleHeaders

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDurationHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseDurationHeaders.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseDurationHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseDurationHeaders
-        /// class.
-        /// </summary>
-        public HeaderResponseDurationHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseDurationHeaders

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseEnumHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseEnumHeaders.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseEnumHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseEnumHeaders class.
-        /// </summary>
-        public HeaderResponseEnumHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseEnumHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseExistingKeyHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseExistingKeyHeaders.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseExistingKeyHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseExistingKeyHeaders
-        /// class.
-        /// </summary>
-        public HeaderResponseExistingKeyHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseExistingKeyHeaders

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseFloatHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseFloatHeaders.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseFloatHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseFloatHeaders class.
-        /// </summary>
-        public HeaderResponseFloatHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseFloatHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseIntegerHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseIntegerHeaders.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseIntegerHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseIntegerHeaders
-        /// class.
-        /// </summary>
-        public HeaderResponseIntegerHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseIntegerHeaders

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseLongHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseLongHeaders.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseLongHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseLongHeaders class.
-        /// </summary>
-        public HeaderResponseLongHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseLongHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseProtectedKeyHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseProtectedKeyHeaders.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseProtectedKeyHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseProtectedKeyHeaders
-        /// class.
-        /// </summary>
-        public HeaderResponseProtectedKeyHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseProtectedKeyHeaders

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseStringHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Header/Models/HeaderResponseStringHeaders.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHeader.Models
     /// </summary>
     public partial class HeaderResponseStringHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the HeaderResponseStringHeaders
-        /// class.
-        /// </summary>
-        public HeaderResponseStringHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the HeaderResponseStringHeaders

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/A.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/A.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
 
     public partial class A
     {
-        /// <summary>
-        /// Initializes a new instance of the A class.
-        /// </summary>
-        public A() { }
 
         /// <summary>
         /// Initializes a new instance of the A class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/B.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/B.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
 
     public partial class B : A
     {
-        /// <summary>
-        /// Initializes a new instance of the B class.
-        /// </summary>
-        public B() { }
 
         /// <summary>
         /// Initializes a new instance of the B class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/C.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/C.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
 
     public partial class C
     {
-        /// <summary>
-        /// Initializes a new instance of the C class.
-        /// </summary>
-        public C() { }
 
         /// <summary>
         /// Initializes a new instance of the C class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/D.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/D.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
 
     public partial class D
     {
-        /// <summary>
-        /// Initializes a new instance of the D class.
-        /// </summary>
-        public D() { }
 
         /// <summary>
         /// Initializes a new instance of the D class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsDelete307Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsDelete307Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsDelete307Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsDelete307Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsDelete307Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsDelete307Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet300Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet300Headers.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsGet300Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsGet300Headers class.
-        /// </summary>
-        public HttpRedirectsGet300Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsGet300Headers class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet301Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet301Headers.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsGet301Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsGet301Headers class.
-        /// </summary>
-        public HttpRedirectsGet301Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsGet301Headers class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet302Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet302Headers.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsGet302Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsGet302Headers class.
-        /// </summary>
-        public HttpRedirectsGet302Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsGet302Headers class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet307Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsGet307Headers.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsGet307Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsGet307Headers class.
-        /// </summary>
-        public HttpRedirectsGet307Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsGet307Headers class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead300Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead300Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsHead300Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsHead300Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsHead300Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsHead300Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead301Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead301Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsHead301Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsHead301Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsHead301Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsHead301Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead302Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead302Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsHead302Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsHead302Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsHead302Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsHead302Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead307Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsHead307Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsHead307Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsHead307Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsHead307Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsHead307Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPatch302Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPatch302Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsPatch302Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsPatch302Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsPatch302Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsPatch302Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPatch307Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPatch307Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsPatch307Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsPatch307Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsPatch307Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsPatch307Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPost303Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPost303Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsPost303Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsPost303Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsPost303Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsPost303Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPost307Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPost307Headers.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsPost307Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsPost307Headers
-        /// class.
-        /// </summary>
-        public HttpRedirectsPost307Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsPost307Headers

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPut301Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPut301Headers.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsPut301Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsPut301Headers class.
-        /// </summary>
-        public HttpRedirectsPut301Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsPut301Headers class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPut307Headers.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Http/Models/HttpRedirectsPut307Headers.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsHttp.Models
     /// </summary>
     public partial class HttpRedirectsPut307Headers
     {
-        /// <summary>
-        /// Initializes a new instance of the HttpRedirectsPut307Headers class.
-        /// </summary>
-        public HttpRedirectsPut307Headers() { }
 
         /// <summary>
         /// Initializes a new instance of the HttpRedirectsPut307Headers class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/BaseProduct.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/BaseProduct.cs
@@ -18,10 +18,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
     /// </summary>
     public partial class BaseProduct
     {
-        /// <summary>
-        /// Initializes a new instance of the BaseProduct class.
-        /// </summary>
-        public BaseProduct() { }
 
         /// <summary>
         /// Initializes a new instance of the BaseProduct class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenParameterGroup.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenParameterGroup.cs
@@ -20,10 +20,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
     [JsonTransformation]
     public partial class FlattenParameterGroup
     {
-        /// <summary>
-        /// Initializes a new instance of the FlattenParameterGroup class.
-        /// </summary>
-        public FlattenParameterGroup() { }
 
         /// <summary>
         /// Initializes a new instance of the FlattenParameterGroup class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenedProduct.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/FlattenedProduct.cs
@@ -23,10 +23,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
     [JsonTransformation]
     public partial class FlattenedProduct : Resource
     {
-        /// <summary>
-        /// Initializes a new instance of the FlattenedProduct class.
-        /// </summary>
-        public FlattenedProduct() { }
 
         /// <summary>
         /// Initializes a new instance of the FlattenedProduct class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/GenericUrl.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/GenericUrl.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
     /// </summary>
     public partial class GenericUrl
     {
-        /// <summary>
-        /// Initializes a new instance of the GenericUrl class.
-        /// </summary>
-        public GenericUrl() { }
 
         /// <summary>
         /// Initializes a new instance of the GenericUrl class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/Resource.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/Resource.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
 
     public partial class Resource
     {
-        /// <summary>
-        /// Initializes a new instance of the Resource class.
-        /// </summary>
-        public Resource() { }
 
         /// <summary>
         /// Initializes a new instance of the Resource class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/ResourceCollection.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/ResourceCollection.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
 
     public partial class ResourceCollection
     {
-        /// <summary>
-        /// Initializes a new instance of the ResourceCollection class.
-        /// </summary>
-        public ResourceCollection() { }
 
         /// <summary>
         /// Initializes a new instance of the ResourceCollection class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/SimpleProduct.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ModelFlattening/Models/SimpleProduct.cs
@@ -20,10 +20,6 @@ namespace Fixtures.AcceptanceTestsModelFlattening.Models
     [JsonTransformation]
     public partial class SimpleProduct : BaseProduct
     {
-        /// <summary>
-        /// Initializes a new instance of the SimpleProduct class.
-        /// </summary>
-        public SimpleProduct() { }
 
         /// <summary>
         /// Initializes a new instance of the SimpleProduct class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ParameterFlattening/Models/AvailabilitySetUpdateParameters.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/ParameterFlattening/Models/AvailabilitySetUpdateParameters.cs
@@ -17,11 +17,6 @@ namespace Fixtures.AcceptanceTestsParameterFlattening.Models
 
     public partial class AvailabilitySetUpdateParameters
     {
-        /// <summary>
-        /// Initializes a new instance of the AvailabilitySetUpdateParameters
-        /// class.
-        /// </summary>
-        public AvailabilitySetUpdateParameters() { }
 
         /// <summary>
         /// Initializes a new instance of the AvailabilitySetUpdateParameters

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Report/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Report/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsReport.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ArrayOptionalWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ArrayOptionalWrapper.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class ArrayOptionalWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ArrayOptionalWrapper class.
-        /// </summary>
-        public ArrayOptionalWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ArrayOptionalWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ArrayWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ArrayWrapper.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class ArrayWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ArrayWrapper class.
-        /// </summary>
-        public ArrayWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ArrayWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ClassOptionalWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ClassOptionalWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class ClassOptionalWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ClassOptionalWrapper class.
-        /// </summary>
-        public ClassOptionalWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ClassOptionalWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ClassWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/ClassWrapper.cs
@@ -15,10 +15,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class ClassWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the ClassWrapper class.
-        /// </summary>
-        public ClassWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the ClassWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/IntOptionalWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/IntOptionalWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class IntOptionalWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the IntOptionalWrapper class.
-        /// </summary>
-        public IntOptionalWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the IntOptionalWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/IntWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/IntWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class IntWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the IntWrapper class.
-        /// </summary>
-        public IntWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the IntWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/Product.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/StringOptionalWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/StringOptionalWrapper.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class StringOptionalWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the StringOptionalWrapper class.
-        /// </summary>
-        public StringOptionalWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the StringOptionalWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/StringWrapper.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/RequiredOptional/Models/StringWrapper.cs
@@ -15,10 +15,6 @@ namespace Fixtures.AcceptanceTestsRequiredOptional.Models
 
     public partial class StringWrapper
     {
-        /// <summary>
-        /// Initializes a new instance of the StringWrapper class.
-        /// </summary>
-        public StringWrapper() { }
 
         /// <summary>
         /// Initializes a new instance of the StringWrapper class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Url/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsUrl.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsUrlMultiCollectionFormat.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Validation/Models/ChildProduct.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Validation/Models/ChildProduct.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsValidation.Models
     /// </summary>
     public partial class ChildProduct
     {
-        /// <summary>
-        /// Initializes a new instance of the ChildProduct class.
-        /// </summary>
-        public ChildProduct() { }
 
         /// <summary>
         /// Initializes a new instance of the ChildProduct class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Validation/Models/ConstantProduct.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Validation/Models/ConstantProduct.cs
@@ -17,10 +17,6 @@ namespace Fixtures.AcceptanceTestsValidation.Models
     /// </summary>
     public partial class ConstantProduct
     {
-        /// <summary>
-        /// Initializes a new instance of the ConstantProduct class.
-        /// </summary>
-        public ConstantProduct() { }
 
         /// <summary>
         /// Static constructor for ConstantProduct class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Validation/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/AcceptanceTests/Validation/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AcceptanceTestsValidation.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/Feature.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/Feature.cs
@@ -14,10 +14,6 @@ namespace Fixtures.AdditionalProperties.Models
 
     public partial class Feature
     {
-        /// <summary>
-        /// Initializes a new instance of the Feature class.
-        /// </summary>
-        public Feature() { }
 
         /// <summary>
         /// Initializes a new instance of the Feature class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/Pet.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AdditionalProperties.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithStringDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithStringDictionary.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AdditionalProperties.Models
 
     public partial class WithStringDictionary
     {
-        /// <summary>
-        /// Initializes a new instance of the WithStringDictionary class.
-        /// </summary>
-        public WithStringDictionary() { }
 
         /// <summary>
         /// Initializes a new instance of the WithStringDictionary class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithTypedDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithTypedDictionary.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AdditionalProperties.Models
 
     public partial class WithTypedDictionary
     {
-        /// <summary>
-        /// Initializes a new instance of the WithTypedDictionary class.
-        /// </summary>
-        public WithTypedDictionary() { }
 
         /// <summary>
         /// Initializes a new instance of the WithTypedDictionary class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithUntypedDictionary.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Additional.Properties/Models/WithUntypedDictionary.cs
@@ -16,10 +16,6 @@ namespace Fixtures.AdditionalProperties.Models
 
     public partial class WithUntypedDictionary
     {
-        /// <summary>
-        /// Initializes a new instance of the WithUntypedDictionary class.
-        /// </summary>
-        public WithUntypedDictionary() { }
 
         /// <summary>
         /// Initializes a new instance of the WithUntypedDictionary class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.DateTimeOffset.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/DateTimeOffset/Models/Product.cs
@@ -18,10 +18,6 @@ namespace Fixtures.DateTimeOffset.Models
 
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Animal.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Animal.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class Animal
     {
-        /// <summary>
-        /// Initializes a new instance of the Animal class.
-        /// </summary>
-        public Animal() { }
 
         /// <summary>
         /// Initializes a new instance of the Animal class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/BaseCat.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/BaseCat.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class BaseCat : Animal
     {
-        /// <summary>
-        /// Initializes a new instance of the BaseCat class.
-        /// </summary>
-        public BaseCat() { }
 
         /// <summary>
         /// Initializes a new instance of the BaseCat class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/BurmeseCat.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/BurmeseCat.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class BurmeseCat : SiameseCat
     {
-        /// <summary>
-        /// Initializes a new instance of the BurmeseCat class.
-        /// </summary>
-        public BurmeseCat() { }
 
         /// <summary>
         /// Initializes a new instance of the BurmeseCat class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Doggy.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Doggy.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class Doggy : Animal
     {
-        /// <summary>
-        /// Initializes a new instance of the Doggy class.
-        /// </summary>
-        public Doggy() { }
 
         /// <summary>
         /// Initializes a new instance of the Doggy class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Error2.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Error2.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class Error2
     {
-        /// <summary>
-        /// Initializes a new instance of the Error2 class.
-        /// </summary>
-        public Error2() { }
 
         /// <summary>
         /// Initializes a new instance of the Error2 class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/HimalayanCat.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/HimalayanCat.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class HimalayanCat : SiameseCat
     {
-        /// <summary>
-        /// Initializes a new instance of the HimalayanCat class.
-        /// </summary>
-        public HimalayanCat() { }
 
         /// <summary>
         /// Initializes a new instance of the HimalayanCat class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Horsey.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/Horsey.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class Horsey : Animal
     {
-        /// <summary>
-        /// Initializes a new instance of the Horsey class.
-        /// </summary>
-        public Horsey() { }
 
         /// <summary>
         /// Initializes a new instance of the Horsey class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/PersianCat.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/PersianCat.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class PersianCat : BaseCat
     {
-        /// <summary>
-        /// Initializes a new instance of the PersianCat class.
-        /// </summary>
-        public PersianCat() { }
 
         /// <summary>
         /// Initializes a new instance of the PersianCat class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/SiameseCat.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Polymorphic/Models/SiameseCat.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPolymorphic.Models
 
     public partial class SiameseCat : BaseCat
     {
-        /// <summary>
-        /// Initializes a new instance of the SiameseCat class.
-        /// </summary>
-        public SiameseCat() { }
 
         /// <summary>
         /// Initializes a new instance of the SiameseCat class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Primitives/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Primitives/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorPrimitives.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Primitives/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Primitives/Models/Product.cs
@@ -18,10 +18,6 @@ namespace Fixtures.MirrorPrimitives.Models
 
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/Models/Error.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/Models/Error.cs
@@ -14,10 +14,6 @@ namespace Fixtures.MirrorRecursiveTypes.Models
 
     public partial class Error
     {
-        /// <summary>
-        /// Initializes a new instance of the Error class.
-        /// </summary>
-        public Error() { }
 
         /// <summary>
         /// Initializes a new instance of the Error class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/Models/Product.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.RecursiveTypes/Models/Product.cs
@@ -16,10 +16,6 @@ namespace Fixtures.MirrorRecursiveTypes.Models
 
     public partial class Product
     {
-        /// <summary>
-        /// Initializes a new instance of the Product class.
-        /// </summary>
-        public Product() { }
 
         /// <summary>
         /// Initializes a new instance of the Product class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/Models/ErrorModel.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/Models/ErrorModel.cs
@@ -15,10 +15,6 @@ namespace Fixtures.MirrorSequences.Models
 
     public partial class ErrorModel
     {
-        /// <summary>
-        /// Initializes a new instance of the ErrorModel class.
-        /// </summary>
-        public ErrorModel() { }
 
         /// <summary>
         /// Initializes a new instance of the ErrorModel class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/Models/Pet.cs
@@ -17,10 +17,6 @@ namespace Fixtures.MirrorSequences.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/Models/PetStyle.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/Mirror.Sequences/Models/PetStyle.cs
@@ -15,10 +15,6 @@ namespace Fixtures.MirrorSequences.Models
 
     public partial class PetStyle
     {
-        /// <summary>
-        /// Initializes a new instance of the PetStyle class.
-        /// </summary>
-        public PetStyle() { }
 
         /// <summary>
         /// Initializes a new instance of the PetStyle class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/ApiResponse.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/ApiResponse.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2.Models
 
     public partial class ApiResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the ApiResponse class.
-        /// </summary>
-        public ApiResponse() { }
 
         /// <summary>
         /// Initializes a new instance of the ApiResponse class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Category.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Category.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2.Models
 
     public partial class Category
     {
-        /// <summary>
-        /// Initializes a new instance of the Category class.
-        /// </summary>
-        public Category() { }
 
         /// <summary>
         /// Initializes a new instance of the Category class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/LoginUserHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/LoginUserHeaders.cs
@@ -19,10 +19,6 @@ namespace Fixtures.PetstoreV2.Models
     /// </summary>
     public partial class LoginUserHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LoginUserHeaders class.
-        /// </summary>
-        public LoginUserHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LoginUserHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Order.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Order.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2.Models
 
     public partial class Order
     {
-        /// <summary>
-        /// Initializes a new instance of the Order class.
-        /// </summary>
-        public Order() { }
 
         /// <summary>
         /// Initializes a new instance of the Order class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Pet.cs
@@ -19,10 +19,6 @@ namespace Fixtures.PetstoreV2.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Tag.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/Tag.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2.Models
 
     public partial class Tag
     {
-        /// <summary>
-        /// Initializes a new instance of the Tag class.
-        /// </summary>
-        public Tag() { }
 
         /// <summary>
         /// Initializes a new instance of the Tag class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/User.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2/Models/User.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2.Models
 
     public partial class User
     {
-        /// <summary>
-        /// Initializes a new instance of the User class.
-        /// </summary>
-        public User() { }
 
         /// <summary>
         /// Initializes a new instance of the User class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/ApiResponse.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/ApiResponse.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2AllSync.Models
 
     public partial class ApiResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the ApiResponse class.
-        /// </summary>
-        public ApiResponse() { }
 
         /// <summary>
         /// Initializes a new instance of the ApiResponse class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Category.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Category.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2AllSync.Models
 
     public partial class Category
     {
-        /// <summary>
-        /// Initializes a new instance of the Category class.
-        /// </summary>
-        public Category() { }
 
         /// <summary>
         /// Initializes a new instance of the Category class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/LoginUserHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/LoginUserHeaders.cs
@@ -19,10 +19,6 @@ namespace Fixtures.PetstoreV2AllSync.Models
     /// </summary>
     public partial class LoginUserHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LoginUserHeaders class.
-        /// </summary>
-        public LoginUserHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LoginUserHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Order.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Order.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2AllSync.Models
 
     public partial class Order
     {
-        /// <summary>
-        /// Initializes a new instance of the Order class.
-        /// </summary>
-        public Order() { }
 
         /// <summary>
         /// Initializes a new instance of the Order class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Pet.cs
@@ -19,10 +19,6 @@ namespace Fixtures.PetstoreV2AllSync.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Tag.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/Tag.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2AllSync.Models
 
     public partial class Tag
     {
-        /// <summary>
-        /// Initializes a new instance of the Tag class.
-        /// </summary>
-        public Tag() { }
 
         /// <summary>
         /// Initializes a new instance of the Tag class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/User.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2AllSync/Models/User.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2AllSync.Models
 
     public partial class User
     {
-        /// <summary>
-        /// Initializes a new instance of the User class.
-        /// </summary>
-        public User() { }
 
         /// <summary>
         /// Initializes a new instance of the User class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/ApiResponse.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/ApiResponse.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2NoSync.Models
 
     public partial class ApiResponse
     {
-        /// <summary>
-        /// Initializes a new instance of the ApiResponse class.
-        /// </summary>
-        public ApiResponse() { }
 
         /// <summary>
         /// Initializes a new instance of the ApiResponse class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Category.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Category.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2NoSync.Models
 
     public partial class Category
     {
-        /// <summary>
-        /// Initializes a new instance of the Category class.
-        /// </summary>
-        public Category() { }
 
         /// <summary>
         /// Initializes a new instance of the Category class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/LoginUserHeaders.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/LoginUserHeaders.cs
@@ -19,10 +19,6 @@ namespace Fixtures.PetstoreV2NoSync.Models
     /// </summary>
     public partial class LoginUserHeaders
     {
-        /// <summary>
-        /// Initializes a new instance of the LoginUserHeaders class.
-        /// </summary>
-        public LoginUserHeaders() { }
 
         /// <summary>
         /// Initializes a new instance of the LoginUserHeaders class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Order.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Order.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2NoSync.Models
 
     public partial class Order
     {
-        /// <summary>
-        /// Initializes a new instance of the Order class.
-        /// </summary>
-        public Order() { }
 
         /// <summary>
         /// Initializes a new instance of the Order class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Pet.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Pet.cs
@@ -19,10 +19,6 @@ namespace Fixtures.PetstoreV2NoSync.Models
 
     public partial class Pet
     {
-        /// <summary>
-        /// Initializes a new instance of the Pet class.
-        /// </summary>
-        public Pet() { }
 
         /// <summary>
         /// Initializes a new instance of the Pet class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Tag.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/Tag.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2NoSync.Models
 
     public partial class Tag
     {
-        /// <summary>
-        /// Initializes a new instance of the Tag class.
-        /// </summary>
-        public Tag() { }
 
         /// <summary>
         /// Initializes a new instance of the Tag class.

--- a/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/User.cs
+++ b/src/generator/AutoRest.CSharp.Tests/Expected/PetstoreV2NoSync/Models/User.cs
@@ -16,10 +16,6 @@ namespace Fixtures.PetstoreV2NoSync.Models
 
     public partial class User
     {
-        /// <summary>
-        /// Initializes a new instance of the User class.
-        /// </summary>
-        public User() { }
 
         /// <summary>
         /// Initializes a new instance of the User class.

--- a/src/generator/AutoRest.CSharp.Unit.Tests/Bug781.cs
+++ b/src/generator/AutoRest.CSharp.Unit.Tests/Bug781.cs
@@ -1,0 +1,65 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Xunit;
+using Xunit.Abstractions;
+using System.Reflection;
+
+namespace AutoRest.CSharp.Unit.Tests
+{
+    public class Bug781 : BugTest
+    {
+
+        /// <summary>
+        ///     https://github.com/Azure/autorest/issues/781
+        ///     Autorest does not generate empty default constructor
+        /// </summary>
+        [Fact]
+        public async Task EnsureNoEmptyCtorsGenerated()
+        {
+            // simplified test pattern for unit testing aspects of code generation
+            using (var fileSystem = GenerateCodeForTestFromSpec())
+            {
+                // check for the expected class.
+                Assert.True(fileSystem.FileExists(@"Models\ReqObject.cs"));
+
+                var result = await Compile(fileSystem);
+
+                // filter the warnings
+                var warnings = result.Messages.Where(
+                    each => each.Severity == DiagnosticSeverity.Warning
+                            && !SuppressWarnings.Contains(each.Id)).ToArray();
+
+                // filter the errors
+                var errors = result.Messages.Where(each => each.Severity == DiagnosticSeverity.Error).ToArray();
+
+                Write(warnings, fileSystem);
+                Write(errors, fileSystem);
+
+                // Don't proceed unless we have zero Warnings.
+                Assert.Empty(warnings);
+
+                // Don't proceed unless we have zero Errors.
+                Assert.Empty(errors);
+
+                // Should also succeed.
+                Assert.True(result.Succeeded);
+
+
+                // try to load the assembly
+                var asm = LoadAssembly(result.Output);
+                Assert.NotNull(asm);
+
+                // verify that we have the class we expected
+                var reqObject = asm.ExportedTypes.FirstOrDefault(each => each.FullName == "Test.Models.ReqObject");
+                
+                // verify there is no ctor that does not take any args
+                Assert.True(reqObject.GetConstructors().All(ctor => ctor.GetParameters().Any()));
+            }
+        }
+
+    }
+}

--- a/src/generator/AutoRest.CSharp.Unit.Tests/Resource/Bug781/Bug781.yaml
+++ b/src/generator/AutoRest.CSharp.Unit.Tests/Resource/Bug781/Bug781.yaml
@@ -1,0 +1,30 @@
+﻿---
+swagger: '2.0'
+info:
+  version: 1.0.0
+  title: Simple API
+paths:
+  "/operation":
+    put:
+      operationId: deprecated_operation
+      parameters:
+      - name: reqObj
+        in: body
+        required: true
+        schema:
+          "$ref": "#/definitions/ReqObject"
+      responses:
+        '200':
+          description: OK
+definitions:
+  ReqObject:
+    properties:
+      Message:
+        type: string
+        description: This is a response.
+        default: helloserver
+      prop1:
+        type: number
+        description: This is a response.
+    required:
+    - Message

--- a/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
@@ -48,7 +48,7 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
         /// <summary>
         @WrapComment("/// ", ("Initializes a new instance of the " + Model.Name + " class.").EscapeXmlComment())
         ///
-        </summary>
+        /// </summary>
 
         public @(Model.Name)()
         {

--- a/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
@@ -47,7 +47,6 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
 <text>
         /// <summary>
         @WrapComment("/// ", ("Initializes a new instance of the " + Model.Name + " class.").EscapeXmlComment())
-        ///
         /// </summary>
 
         public @(Model.Name)()

--- a/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
@@ -42,12 +42,14 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
 
     public partial class @Model.Name@(Model.BaseModelType != null ? " : " + Model.BaseModelType.Name : "")
     {
-        /// <summary>
-        @WrapComment("/// ", ("Initializes a new instance of the " + Model.Name + " class.").EscapeXmlComment())
-        /// </summary>
         @if (Model.Properties.Any(p => p.ModelType is CompositeType && ((CompositeType)p.ModelType).ContainsConstantProperties))
         {
 <text>
+        /// <summary>
+        @WrapComment("/// ", ("Initializes a new instance of the " + Model.Name + " class.").EscapeXmlComment())
+        ///
+        </summary>
+
         public @(Model.Name)()
         {
             @foreach(var property in Model.ComposedProperties.Where(p => p.ModelType is CompositeType
@@ -59,10 +61,6 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
             }
         }
 </text>
-        }
-        else
-        {
-        @:public @(Model.Name)() { }
         }
 
         @EmptyLine


### PR DESCRIPTION
This is a partial fix for bug https://github.com/Azure/autorest/issues/781
- Removing default constructor and leaving it up to service teams to implement it which is possible since class declarations are partial
- This is to mitigate cases where default values need to be set on models themselves, there are inherent problems to doing this within the default empty constructor itself since these model default values can cause serious conflicts during PATCH operations
- Added a test case that ensures that we do not auto generate an empty default constructor for a given model

@fearthecowboy @olydis PTAL
