### PR TITLE
Generating-a-client Inconsistent file name

### DIFF
--- a/docs/generating-a-client.md
+++ b/docs/generating-a-client.md
@@ -4,7 +4,7 @@ First,Download the Swagger.json example:
 
 | Platform | Command |
 |----|---|
-|PowerShell|`iwr https://raw.githubusercontent.com/Azure/autorest/master/Samples/petstore/petstore.json -o swagger.json`|
+|PowerShell|`iwr https://raw.githubusercontent.com/Azure/autorest/master/Samples/petstore/petstore.json -o petstore.json`|
 |Linux/OS X|`curl -O https://raw.githubusercontent.com/Azure/autorest/master/Samples/petstore/petstore.json`|
 
 Next, generate the client:

--- a/docs/generating-a-client.md
+++ b/docs/generating-a-client.md
@@ -1,6 +1,6 @@
 # <img align="center" src="./images/logo.png"> Sample : Generating a client using AutoRest
 
-First,Download the Swagger.json example:
+First, download the petstore.json example file:
 
 | Platform | Command |
 |----|---|


### PR DESCRIPTION
The PowerShell command saves the file locally with one name (swagger.json), but then the subsequent command is looking for a different file name (petstore.json)