### PR TITLE
skip val. by def., react. ARS tests, fix #1828 & #1829, legacy --help

### DIFF
--- a/gulpfile.iced
+++ b/gulpfile.iced
@@ -32,7 +32,6 @@ Import
   tests:() ->
     source 'src/**/*[Tt]ests.csproj'
       .pipe except /AutoRest.Tests/ig #not used yet.
-      .pipe except /AutoRest.AzureResourceSchema.Tests/ig
       #.pipe except /AutoRest.Swagger.Tests/ig
     
   # assemblies that we sign

--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -106,6 +106,13 @@ async function currentMain(autorestArgs: string[]): Promise<void> {
 async function main() {
   try {
     const autorestArgs = process.argv.slice(2);
+
+    // temporary: --help displays legacy AutoRest's -Help message
+    if (autorestArgs.indexOf("--help") !== -1) {
+      await legacyMain(["-Help"]);
+      return;
+    }
+
     if (isLegacy(autorestArgs)) {
       await legacyMain(autorestArgs);
     } else {

--- a/src/autorest-core/interop/autorest-dotnet.ts
+++ b/src/autorest-core/interop/autorest-dotnet.ts
@@ -9,7 +9,7 @@ import { homedir } from "os";
 import * as path from "path";
 
 function AutoRestDllPath() {
-  let result = path.join(__dirname, "../../AutoRest.dll");
+  let result = path.join(__dirname, "../../../AutoRest.dll");
 
   // try relative path to __dirname
   if (fs.existsSync(result)) {

--- a/src/core/AutoRest.Core/AutoRestController.cs
+++ b/src/core/AutoRest.Core/AutoRestController.cs
@@ -45,11 +45,6 @@ namespace AutoRest.Core
             CodeModel codeModel = null;
             
             var modeler = ExtensionsLoader.GetModeler();
-            var plugin = ExtensionsLoader.GetPlugin();
-            if (!(plugin is NoOpPlugin))
-            {
-                Settings.Instance.SkipValidation = true;
-            }
 
             try
             {
@@ -77,6 +72,8 @@ namespace AutoRest.Core
             {
                 return; // no code gen in Json validation mode
             }
+
+            var plugin = ExtensionsLoader.GetPlugin();
             
             Console.ResetColor();
             Console.WriteLine(plugin.CodeGenerator.UsageInstructions);

--- a/src/core/AutoRest.Core/AutoRestController.cs
+++ b/src/core/AutoRest.Core/AutoRestController.cs
@@ -45,6 +45,11 @@ namespace AutoRest.Core
             CodeModel codeModel = null;
             
             var modeler = ExtensionsLoader.GetModeler();
+            var plugin = ExtensionsLoader.GetPlugin();
+            if (!(plugin is NoOpPlugin))
+            {
+                Settings.Instance.SkipValidation = true;
+            }
 
             try
             {
@@ -72,8 +77,6 @@ namespace AutoRest.Core
             {
                 return; // no code gen in Json validation mode
             }
-
-            var plugin = ExtensionsLoader.GetPlugin();
             
             Console.ResetColor();
             Console.WriteLine(plugin.CodeGenerator.UsageInstructions);

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -474,14 +474,6 @@ Licensed under the MIT License. See License.txt in the project root for license 
                     throw new CodeGenerationException(string.Format(Resources.ParameterValueIsMissing, property.Name));
                 }
             }
-
-            if (CustomSettings != null)
-            {
-                foreach (var unmatchedSetting in CustomSettings.Keys)
-                {
-                    Logger.Instance.Log(Category.Warning, Resources.ParameterIsNotValid, unmatchedSetting);
-                }
-            }
         }
     }
 }

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -238,13 +238,6 @@ Licensed under the MIT License. See License.txt in the project root for license 
         public bool AddCredentials { get; set; }
 
         /// <summary>
-        /// If set to true, behave in a way consistent with earlier builds of AutoRest..
-        /// </summary>
-        [SettingsInfo("If true, skips the ARM specific Swagger validation step.")]
-        [SettingsAlias("skipvalidation")]
-        public bool SkipValidation { get; set; }
-
-        /// <summary>
         /// If set, will cause generated code to be output to a single file. Not supported by all code generators.
         /// </summary>
         [SettingsInfo(

--- a/src/generator/AutoRest.AzureResourceSchema.Tests/AzureResourceSchemaAcceptanceTests.cs
+++ b/src/generator/AutoRest.AzureResourceSchema.Tests/AzureResourceSchemaAcceptanceTests.cs
@@ -55,7 +55,7 @@ namespace AutoRest.AzureResourceSchema.Tests
         [Fact]
         public static void CommitmentPlans_2016_05_01_preview()
         {
-            RunSwaggerTest("CommitmentPlans", "2016-05-01-preview", "commitmentplans.json");
+            RunSwaggerTest("CommitmentPlans", "2016-05-01-preview", "commitmentPlans.json");
         }
 
         [Fact]

--- a/src/generator/AutoRest.AzureResourceSchema.Tests/AzureResourceSchemaAcceptanceTests.cs
+++ b/src/generator/AutoRest.AzureResourceSchema.Tests/AzureResourceSchemaAcceptanceTests.cs
@@ -291,7 +291,8 @@ namespace AutoRest.AzureResourceSchema.Tests
         {
             SwaggerSpecHelper.RunTests(
                 Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", resourceType, apiVersion, swaggerFileName),
-                Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Expected", resourceType, apiVersion),plugin:"AzureResourceSchema");
+                Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Expected", resourceType, apiVersion),
+                plugin: "AzureResourceSchema");
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -47,6 +47,7 @@ namespace AutoRest.Swagger.Tests
             {
                 new Settings
                 {
+                    CodeGenerator = "None",
                     Namespace = "Test",
                     Input = input
                 };

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerSpecHelper.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerSpecHelper.cs
@@ -59,7 +59,7 @@ namespace AutoRest.Swagger.Tests
                 : settings.Namespace;
             settings.DisableSimplifier = true;
 
-            AutoRest.Core.AutoRestController.Generate();
+            AutoRestController.Generate();
             Assert.NotEmpty(settings.FileSystemOutput.VirtualStore);
 
             var actualFiles = settings.FileSystemOutput.GetFiles("", "*.*", SearchOption.AllDirectories).OrderBy(f => f).ToArray();

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerSpecHelper.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerSpecHelper.cs
@@ -60,7 +60,6 @@ namespace AutoRest.Swagger.Tests
             settings.DisableSimplifier = true;
 
             AutoRestController.Generate();
-            Assert.NotEmpty(settings.FileSystemOutput.VirtualStore);
 
             var actualFiles = settings.FileSystemOutput.GetFiles("", "*.*", SearchOption.AllDirectories).OrderBy(f => f).ToArray();
             var expectedFiles = Directory.Exists(resultFolder) ? Directory.GetFiles(resultFolder, "*.*", SearchOption.AllDirectories).OrderBy(f => f).ToArray() : new string[0];

--- a/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
@@ -16,6 +16,7 @@ using AutoRest.Swagger.Properties;
 using ParameterLocation = AutoRest.Swagger.Model.ParameterLocation;
 using AutoRest.Core.Validation;
 using static AutoRest.Core.Utilities.DependencyInjection;
+using AutoRest.Core.Extensibility;
 
 namespace AutoRest.Swagger
 {
@@ -84,6 +85,18 @@ namespace AutoRest.Swagger
                 {
                     Logger.Instance.Log(validationEx);
                 }
+            }
+            try
+            {
+                if (ExtensionsLoader.GetPlugin() is NoOpPlugin)
+                {
+                    return New<CodeModel>();
+                }
+            }
+            catch
+            {
+                // no problem: the above is just a shortcut for validation-only runs 
+                // (the modeler takes time and may throw exceptions, so bypassing it improves validation experience)
             }
 
             Logger.Instance.Log(Category.Info, Resources.GeneratingClient);

--- a/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
+++ b/src/modeler/AutoRest.Swagger/SwaggerModeler.cs
@@ -16,7 +16,6 @@ using AutoRest.Swagger.Properties;
 using ParameterLocation = AutoRest.Swagger.Model.ParameterLocation;
 using AutoRest.Core.Validation;
 using static AutoRest.Core.Utilities.DependencyInjection;
-using AutoRest.Core.Extensibility;
 
 namespace AutoRest.Swagger
 {
@@ -77,7 +76,7 @@ namespace AutoRest.Swagger
         public CodeModel Build(ServiceDefinition serviceDefinition)
         {
             ServiceDefinition = serviceDefinition;
-            if (!Settings.SkipValidation)
+            if (Settings.Instance.CodeGenerator.EqualsIgnoreCase("None"))
             {
                 // Look for semantic errors and warnings in the document.
                 var validator = new RecursiveObjectValidator(PropertyNameResolver.JsonName);
@@ -85,18 +84,7 @@ namespace AutoRest.Swagger
                 {
                     Logger.Instance.Log(validationEx);
                 }
-            }
-            try
-            {
-                if (ExtensionsLoader.GetPlugin() is NoOpPlugin)
-                {
-                    return New<CodeModel>();
-                }
-            }
-            catch
-            {
-                // no problem: the above is just a shortcut for validation-only runs 
-                // (the modeler takes time and may throw exceptions, so bypassing it improves validation experience)
+                return New<CodeModel>();
             }
 
             Logger.Instance.Log(Category.Info, Resources.GeneratingClient);


### PR DESCRIPTION
- skip validation unless `-CodeGenerator=None` (makes `-SkipValidation` unnecessary)
- fixed and reactivated ARS tests in gulp
- fixed #1828 and #1829 (nonsense validation of `CustomSettings`)
- make `--help` also print the legacy help (=> don't call "new" autorest core)