### PR TITLE
[NodeJs] Get module info by reading package.json and add

### DIFF
--- a/Samples/azure-storage/Azure.NodeJS/storageManagementClient.js
+++ b/Samples/azure-storage/Azure.NodeJS/storageManagementClient.js
@@ -66,6 +66,8 @@ function StorageManagementClient(credentials, subscriptionId, baseUri, options) 
   this.credentials = credentials;
   this.subscriptionId = subscriptionId;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.apiVersion !== null && options.apiVersion !== undefined) {
     this.apiVersion = options.apiVersion;
   }

--- a/Samples/petstore/NodeJS/swaggerPetstore.js
+++ b/Samples/petstore/NodeJS/swaggerPetstore.js
@@ -41,6 +41,8 @@ function SwaggerPetstore(baseUri, options) {
     this.baseUri = 'http://petstore.swagger.io/v2';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.models = models;
   msRest.addSerializationMixin(this);
 }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/azureCompositeModel.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureCompositeModelClient/azureCompositeModel.js
@@ -66,6 +66,8 @@ function AzureCompositeModel(credentials, baseUri, options) {
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/autoRestParameterGroupingTestService.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/autoRestParameterGroupingTestService.js
@@ -64,6 +64,8 @@ function AutoRestParameterGroupingTestService(credentials, baseUri, options) {
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureReport/autoRestReportServiceForAzure.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureReport/autoRestReportServiceForAzure.js
@@ -64,6 +64,8 @@ function AutoRestReportServiceForAzure(credentials, baseUri, options) {
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureResource/autoRestResourceFlatteningTestService.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureResource/autoRestResourceFlatteningTestService.js
@@ -64,6 +64,8 @@ function AutoRestResourceFlatteningTestService(credentials, baseUri, options) {
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autoRestAzureSpecialParametersTestClient.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autoRestAzureSpecialParametersTestClient.js
@@ -73,6 +73,8 @@ function AutoRestAzureSpecialParametersTestClient(credentials, subscriptionId, b
   this.credentials = credentials;
   this.subscriptionId = subscriptionId;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.apiVersion !== null && options.apiVersion !== undefined) {
     this.apiVersion = options.apiVersion;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/autoRestParameterizedHostTestClient.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/autoRestParameterizedHostTestClient.js
@@ -62,6 +62,8 @@ function AutoRestParameterizedHostTestClient(credentials, options) {
   this.baseUri = 'http://{accountName}{host}';
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.host !== null && options.host !== undefined) {
     this.host = options.host;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/Head/autoRestHeadTestService.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/Head/autoRestHeadTestService.js
@@ -64,6 +64,8 @@ function AutoRestHeadTestService(credentials, baseUri, options) {
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/autoRestHeadExceptionTestService.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/autoRestHeadExceptionTestService.js
@@ -64,6 +64,8 @@ function AutoRestHeadExceptionTestService(credentials, baseUri, options) {
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/Lro/autoRestLongRunningOperationTestService.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/Lro/autoRestLongRunningOperationTestService.js
@@ -64,6 +64,8 @@ function AutoRestLongRunningOperationTestService(credentials, baseUri, options) 
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/Paging/autoRestPagingTestService.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/Paging/autoRestPagingTestService.js
@@ -64,6 +64,8 @@ function AutoRestPagingTestService(credentials, baseUri, options) {
   }
   this.credentials = credentials;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.acceptLanguage !== null && options.acceptLanguage !== undefined) {
     this.acceptLanguage = options.acceptLanguage;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storageManagementClient.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storageManagementClient.js
@@ -73,6 +73,8 @@ function StorageManagementClient(credentials, subscriptionId, baseUri, options) 
   this.credentials = credentials;
   this.subscriptionId = subscriptionId;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.apiVersion !== null && options.apiVersion !== undefined) {
     this.apiVersion = options.apiVersion;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftAzureTestUrl.js
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftAzureTestUrl.js
@@ -73,6 +73,8 @@ function MicrosoftAzureTestUrl(credentials, subscriptionId, baseUri, options) {
   this.credentials = credentials;
   this.subscriptionId = subscriptionId;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.apiVersion !== null && options.apiVersion !== undefined) {
     this.apiVersion = options.apiVersion;
   }

--- a/src/generator/AutoRest.NodeJS.Azure.Tests/package.json
+++ b/src/generator/AutoRest.NodeJS.Azure.Tests/package.json
@@ -18,8 +18,8 @@
     }
   ],
   "dependencies": {
-    "ms-rest": "1.15.2",
-    "ms-rest-azure": "1.15.2",
+    "ms-rest": "^1.15.7",
+    "ms-rest-azure": "^1.15.7",
     "jshint": "2.8.0",
     "moment":  "^2.14.1",
     "xunit-file": "0.0.5",

--- a/src/generator/AutoRest.NodeJS.Azure/CodeGeneratorJsa.cs
+++ b/src/generator/AutoRest.NodeJS.Azure/CodeGeneratorJsa.cs
@@ -19,7 +19,7 @@ namespace AutoRest.NodeJS.Azure
 {
     public class CodeGeneratorJsa : NodeJS.CodeGeneratorJs
     {
-        private const string ClientRuntimePackage = "ms-rest-azure version 1.15.0";
+        private const string ClientRuntimePackage = "ms-rest-azure version 1.15.6";
 
         public override string UsageInstructions => string.Format(CultureInfo.InvariantCulture,
             Resources.UsageInformation, ClientRuntimePackage);

--- a/src/generator/AutoRest.NodeJS.Azure/Templates/AzureServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.NodeJS.Azure/Templates/AzureServiceClientTemplate.cshtml
@@ -101,6 +101,8 @@ else
 @:  this.@(param.Name) = @(param.Name);
 }
   @EmptyLine
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   @foreach (var property in optionalParameters)
   { 
   @:if(options.@(property.Name) !== null && options.@(property.Name) !== undefined) { 

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyArray/autoRestSwaggerBATArrayService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyArray/autoRestSwaggerBATArrayService.js
@@ -48,6 +48,8 @@ function AutoRestSwaggerBATArrayService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.arrayModel = new operations.ArrayModel(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyBoolean/autoRestBoolTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyBoolean/autoRestBoolTestService.js
@@ -48,6 +48,8 @@ function AutoRestBoolTestService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.bool = new operations.Bool(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyByte/autoRestSwaggerBATByteService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyByte/autoRestSwaggerBATByteService.js
@@ -48,6 +48,8 @@ function AutoRestSwaggerBATByteService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.byteModel = new operations.ByteModel(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyComplex/autoRestComplexTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyComplex/autoRestComplexTestService.js
@@ -49,6 +49,8 @@ function AutoRestComplexTestService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.basicOperations = new operations.BasicOperations(this);
   this.primitive = new operations.Primitive(this);
   this.arrayModel = new operations.ArrayModel(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDate/autoRestDateTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDate/autoRestDateTestService.js
@@ -48,6 +48,8 @@ function AutoRestDateTestService(baseUri, options) {
     this.baseUri = 'https://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.dateModel = new operations.DateModel(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDateTime/autoRestDateTimeTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDateTime/autoRestDateTimeTestService.js
@@ -48,6 +48,8 @@ function AutoRestDateTimeTestService(baseUri, options) {
     this.baseUri = 'https://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.datetime = new operations.Datetime(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/autoRestRFC1123DateTimeTestService.js
@@ -48,6 +48,8 @@ function AutoRestRFC1123DateTimeTestService(baseUri, options) {
     this.baseUri = 'https://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.datetimerfc1123 = new operations.Datetimerfc1123(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDictionary/autoRestSwaggerBATdictionaryService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDictionary/autoRestSwaggerBATdictionaryService.js
@@ -48,6 +48,8 @@ function AutoRestSwaggerBATdictionaryService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.dictionary = new operations.Dictionary(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDuration/autoRestDurationTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyDuration/autoRestDurationTestService.js
@@ -48,6 +48,8 @@ function AutoRestDurationTestService(baseUri, options) {
     this.baseUri = 'https://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.duration = new operations.Duration(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyFile/autoRestSwaggerBATFileService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyFile/autoRestSwaggerBATFileService.js
@@ -48,6 +48,8 @@ function AutoRestSwaggerBATFileService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.files = new operations.Files(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyFormData/autoRestSwaggerBATFormDataService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyFormData/autoRestSwaggerBATFormDataService.js
@@ -48,6 +48,8 @@ function AutoRestSwaggerBATFormDataService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.formdata = new operations.Formdata(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyInteger/autoRestIntegerTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyInteger/autoRestIntegerTestService.js
@@ -48,6 +48,8 @@ function AutoRestIntegerTestService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.intModel = new operations.IntModel(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyNumber/autoRestNumberTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyNumber/autoRestNumberTestService.js
@@ -48,6 +48,8 @@ function AutoRestNumberTestService(baseUri, options) {
     this.baseUri = 'https://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.number = new operations.Number(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyString/autoRestSwaggerBATService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/BodyString/autoRestSwaggerBATService.js
@@ -48,6 +48,8 @@ function AutoRestSwaggerBATService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.string = new operations.String(this);
   this.enumModel = new operations.EnumModel(this);
   this.models = models;

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/ComplexModelClient/complexModelClient.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/ComplexModelClient/complexModelClient.js
@@ -50,6 +50,8 @@ function ComplexModelClient(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.models = models;
   msRest.addSerializationMixin(this);
 }

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/compositeBoolInt.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/CompositeBoolIntClient/compositeBoolInt.js
@@ -48,6 +48,8 @@ function CompositeBoolInt(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.bool = new operations.Bool(this);
   this.intModel = new operations.IntModel(this);
   this.models = models;

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/CustomBaseUri/autoRestParameterizedHostTestClient.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/CustomBaseUri/autoRestParameterizedHostTestClient.js
@@ -46,6 +46,8 @@ function AutoRestParameterizedHostTestClient(options) {
   AutoRestParameterizedHostTestClient['super_'].call(this, null, options);
   this.baseUri = 'http://{accountName}{host}';
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.host !== null && options.host !== undefined) {
     this.host = options.host;
   }

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autoRestParameterizedCustomHostTestClient.js
@@ -52,6 +52,8 @@ function AutoRestParameterizedCustomHostTestClient(subscriptionId, options) {
   this.baseUri = '{vault}{secret}{dnsSuffix}';
   this.subscriptionId = subscriptionId;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.dnsSuffix !== null && options.dnsSuffix !== undefined) {
     this.dnsSuffix = options.dnsSuffix;
   }

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Header/autoRestSwaggerBATHeaderService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Header/autoRestSwaggerBATHeaderService.js
@@ -48,6 +48,8 @@ function AutoRestSwaggerBATHeaderService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.header = new operations.Header(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Http/autoRestHttpInfrastructureTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Http/autoRestHttpInfrastructureTestService.js
@@ -48,6 +48,8 @@ function AutoRestHttpInfrastructureTestService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.httpFailure = new operations.HttpFailure(this);
   this.httpSuccess = new operations.HttpSuccess(this);
   this.httpRedirects = new operations.HttpRedirects(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/ModelFlattening/autoRestResourceFlatteningTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/ModelFlattening/autoRestResourceFlatteningTestService.js
@@ -48,6 +48,8 @@ function AutoRestResourceFlatteningTestService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.models = models;
   msRest.addSerializationMixin(this);
 }

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/ParameterFlattening/autoRestParameterFlattening.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/ParameterFlattening/autoRestParameterFlattening.js
@@ -48,6 +48,8 @@ function AutoRestParameterFlattening(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.availabilitySets = new operations.AvailabilitySets(this);
   this.models = models;
   msRest.addSerializationMixin(this);

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Report/autoRestReportService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Report/autoRestReportService.js
@@ -48,6 +48,8 @@ function AutoRestReportService(baseUri, options) {
     this.baseUri = 'http://localhost';
   }
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.models = models;
   msRest.addSerializationMixin(this);
 }

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/RequiredOptional/autoRestRequiredOptionalTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/RequiredOptional/autoRestRequiredOptionalTestService.js
@@ -62,6 +62,8 @@ function AutoRestRequiredOptionalTestService(requiredGlobalPath, requiredGlobalQ
   this.requiredGlobalPath = requiredGlobalPath;
   this.requiredGlobalQuery = requiredGlobalQuery;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.optionalGlobalQuery !== null && options.optionalGlobalQuery !== undefined) {
     this.optionalGlobalQuery = options.optionalGlobalQuery;
   }

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Url/autoRestUrlTestService.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Url/autoRestUrlTestService.js
@@ -56,6 +56,8 @@ function AutoRestUrlTestService(globalStringPath, baseUri, options) {
   }
   this.globalStringPath = globalStringPath;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   if(options.globalStringQuery !== null && options.globalStringQuery !== undefined) {
     this.globalStringQuery = options.globalStringQuery;
   }

--- a/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Validation/autoRestValidationTest.js
+++ b/src/generator/AutoRest.NodeJS.Tests/Expected/AcceptanceTests/Validation/autoRestValidationTest.js
@@ -60,6 +60,8 @@ function AutoRestValidationTest(subscriptionId, apiVersion, baseUri, options) {
   this.subscriptionId = subscriptionId;
   this.apiVersion = apiVersion;
 
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   this.models = models;
   msRest.addSerializationMixin(this);
 }

--- a/src/generator/AutoRest.NodeJS.Tests/package.json
+++ b/src/generator/AutoRest.NodeJS.Tests/package.json
@@ -21,7 +21,7 @@
     "@types/mocha": "^2.2.39",
     "@types/node": "^7.0.5",
     "@types/should": "^8.1.30",
-    "ms-rest": "1.15.2",
+    "ms-rest": "^1.15.7",
     "jshint": "2.8.0",
     "xunit-file": "0.0.5",
     "mocha": "2.2.5",

--- a/src/generator/AutoRest.NodeJS/CodeGeneratorJs.cs
+++ b/src/generator/AutoRest.NodeJS/CodeGeneratorJs.cs
@@ -19,7 +19,7 @@ namespace AutoRest.NodeJS
 {
     public class CodeGeneratorJs : CodeGenerator
     {
-        private const string ClientRuntimePackage = "ms-rest version 1.15.0";
+        private const string ClientRuntimePackage = "ms-rest version 1.15.6";
 
 
         public override string ImplementationFileExtension => ".js";

--- a/src/generator/AutoRest.NodeJS/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.NodeJS/Templates/ServiceClientTemplate.cshtml
@@ -107,6 +107,8 @@ else
 @:  this.@(param.Name) = @(param.Name);
 }
   @EmptyLine
+  var packageInfo = this.getPackageJsonInfo(__dirname);
+  this.addUserAgentInfo(util.format('%s/%s', packageInfo.name, packageInfo.version));
   @foreach (var property in optionalParameters)
   { 
   @:if(options.@(property.Name) !== null && options.@(property.Name) !== undefined) { 


### PR DESCRIPTION
package name and version to user agent header for all auto rest
generated node packages.

This is part of work for https://github.com/Azure/azure-sdk-for-node/issues/2076. 
This change relies on runtime updates by PR https://github.com/Azure/azure-sdk-for-node/pull/2084 to fetch info from package.json.