### PR TITLE
[Python] ApiVersion in Operation group for Swagger modeler

### DIFF
--- a/Samples/azure-storage/Azure.Python/storagemanagementclient/operations/storage_accounts_operations.py
+++ b/Samples/azure-storage/Azure.Python/storagemanagementclient/operations/storage_accounts_operations.py
@@ -17,6 +17,7 @@ class StorageAccountsOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An objec model deserializer.
+    :ivar api_version: Client Api Version. Constant value: "2015-06-15".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -24,6 +25,7 @@ class StorageAccountsOperations(object):
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
+        self.api_version = "2015-06-15"
 
         self.config = config
 
@@ -57,7 +59,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -133,7 +135,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -224,7 +226,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -283,7 +285,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -363,7 +365,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -429,7 +431,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -488,7 +490,7 @@ class StorageAccountsOperations(object):
 
                 # Construct parameters
                 query_parameters = {}
-                query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+                query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
             else:
                 url = next_link
@@ -557,7 +559,7 @@ class StorageAccountsOperations(object):
 
                 # Construct parameters
                 query_parameters = {}
-                query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+                query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
             else:
                 url = next_link
@@ -632,7 +634,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}

--- a/Samples/azure-storage/Azure.Python/storagemanagementclient/operations/usage_operations.py
+++ b/Samples/azure-storage/Azure.Python/storagemanagementclient/operations/usage_operations.py
@@ -16,6 +16,7 @@ class UsageOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An objec model deserializer.
+    :ivar api_version: Client Api Version. Constant value: "2015-06-15".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -23,6 +24,7 @@ class UsageOperations(object):
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
+        self.api_version = "2015-06-15"
 
         self.config = config
 
@@ -51,7 +53,7 @@ class UsageOperations(object):
 
                 # Construct parameters
                 query_parameters = {}
-                query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+                query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
             else:
                 url = next_link

--- a/Samples/azure-storage/Azure.Python/storagemanagementclient/storage_management_client.py
+++ b/Samples/azure-storage/Azure.Python/storagemanagementclient/storage_management_client.py
@@ -23,13 +23,11 @@ class StorageManagementClientConfiguration(AzureConfiguration):
      identify Microsoft Azure subscription. The subscription ID forms part of
      the URI for every service call.
     :type subscription_id: str
-    :param api_version: Client Api Version.
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-06-15', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -37,8 +35,6 @@ class StorageManagementClientConfiguration(AzureConfiguration):
             raise ValueError("Parameter 'subscription_id' must not be None.")
         if not isinstance(subscription_id, str):
             raise TypeError("Parameter 'subscription_id' must be str.")
-        if api_version is not None and not isinstance(api_version, str):
-            raise TypeError("Optional parameter 'api_version' must be str.")
         if not base_url:
             base_url = 'https://management.azure.com'
 
@@ -49,7 +45,6 @@ class StorageManagementClientConfiguration(AzureConfiguration):
 
         self.credentials = credentials
         self.subscription_id = subscription_id
-        self.api_version = api_version
 
 
 class StorageManagementClient(object):
@@ -70,18 +65,17 @@ class StorageManagementClient(object):
      identify Microsoft Azure subscription. The subscription ID forms part of
      the URI for every service call.
     :type subscription_id: str
-    :param api_version: Client Api Version.
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-06-15', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
-        self.config = StorageManagementClientConfiguration(credentials, subscription_id, api_version, base_url)
+        self.config = StorageManagementClientConfiguration(credentials, subscription_id, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '2015-06-15'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/Samples/petstore/Python/swaggerpetstore/swagger_petstore.py
+++ b/Samples/petstore/Python/swaggerpetstore/swagger_petstore.py
@@ -45,6 +45,7 @@ class SwaggerPetstore(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
@@ -66,6 +66,7 @@ class AutoRestDurationTestService(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/autorestparametergroupingtestservice/auto_rest_parameter_grouping_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/autorestparametergroupingtestservice/auto_rest_parameter_grouping_test_service.py
@@ -66,6 +66,7 @@ class AutoRestParameterGroupingTestService(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureReport/autorestreportserviceforazure/auto_rest_report_service_for_azure.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureReport/autorestreportserviceforazure/auto_rest_report_service_for_azure.py
@@ -64,6 +64,7 @@ class AutoRestReportServiceForAzure(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureResource/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureResource/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
@@ -64,6 +64,7 @@ class AutoRestResourceFlatteningTestService(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/auto_rest_azure_special_parameters_test_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/auto_rest_azure_special_parameters_test_client.py
@@ -35,14 +35,11 @@ class AutoRestAzureSpecialParametersTestClientConfiguration(AzureConfiguration):
     :param subscription_id: The subscription id, which appears in the path,
      always modeled in credentials. The value is always '1234-5678-9012-3456'
     :type subscription_id: str
-    :param api_version: The api version, which appears in the query, the value
-     is always '2015-07-01-preview'
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-07-01-preview', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -50,8 +47,6 @@ class AutoRestAzureSpecialParametersTestClientConfiguration(AzureConfiguration):
             raise ValueError("Parameter 'subscription_id' must not be None.")
         if not isinstance(subscription_id, str):
             raise TypeError("Parameter 'subscription_id' must be str.")
-        if api_version is not None and not isinstance(api_version, str):
-            raise TypeError("Optional parameter 'api_version' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
@@ -62,7 +57,6 @@ class AutoRestAzureSpecialParametersTestClientConfiguration(AzureConfiguration):
 
         self.credentials = credentials
         self.subscription_id = subscription_id
-        self.api_version = api_version
 
 
 class AutoRestAzureSpecialParametersTestClient(object):
@@ -94,19 +88,17 @@ class AutoRestAzureSpecialParametersTestClient(object):
     :param subscription_id: The subscription id, which appears in the path,
      always modeled in credentials. The value is always '1234-5678-9012-3456'
     :type subscription_id: str
-    :param api_version: The api version, which appears in the query, the value
-     is always '2015-07-01-preview'
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-07-01-preview', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
-        self.config = AutoRestAzureSpecialParametersTestClientConfiguration(credentials, subscription_id, api_version, base_url)
+        self.config = AutoRestAzureSpecialParametersTestClientConfiguration(credentials, subscription_id, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '2015-07-01-preview'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/operations/api_version_default_operations.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/operations/api_version_default_operations.py
@@ -22,6 +22,7 @@ class ApiVersionDefaultOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An objec model deserializer.
+    :ivar api_version: The api version, which appears in the query, the value is always '2015-07-01-preview'. Constant value: "2015-07-01-preview".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -29,6 +30,7 @@ class ApiVersionDefaultOperations(object):
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
+        self.api_version = "2015-07-01-preview"
 
         self.config = config
 
@@ -52,7 +54,7 @@ class ApiVersionDefaultOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -95,7 +97,7 @@ class ApiVersionDefaultOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -138,7 +140,7 @@ class ApiVersionDefaultOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -181,7 +183,7 @@ class ApiVersionDefaultOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/operations/subscription_in_credentials_operations.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/autorestazurespecialparameterstestclient/operations/subscription_in_credentials_operations.py
@@ -22,6 +22,7 @@ class SubscriptionInCredentialsOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An objec model deserializer.
+    :ivar api_version: The api version, which appears in the query, the value is always '2015-07-01-preview'. Constant value: "2015-07-01-preview".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -29,6 +30,7 @@ class SubscriptionInCredentialsOperations(object):
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
+        self.api_version = "2015-07-01-preview"
 
         self.config = config
 
@@ -152,7 +154,7 @@ class SubscriptionInCredentialsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
@@ -74,6 +74,7 @@ class AutoRestParameterizedHostTestClient(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/autorestheadtestservice/auto_rest_head_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/autorestheadtestservice/auto_rest_head_test_service.py
@@ -65,6 +65,7 @@ class AutoRestHeadTestService(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/autorestheadexceptiontestservice/auto_rest_head_exception_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/autorestheadexceptiontestservice/auto_rest_head_exception_test_service.py
@@ -65,6 +65,7 @@ class AutoRestHeadExceptionTestService(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/autorestlongrunningoperationtestservice/auto_rest_long_running_operation_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/autorestlongrunningoperationtestservice/auto_rest_long_running_operation_test_service.py
@@ -75,6 +75,7 @@ class AutoRestLongRunningOperationTestService(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/autorestpagingtestservice/auto_rest_paging_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/autorestpagingtestservice/auto_rest_paging_test_service.py
@@ -66,6 +66,7 @@ class AutoRestPagingTestService(object):
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/operations/storage_accounts_operations.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/operations/storage_accounts_operations.py
@@ -24,6 +24,7 @@ class StorageAccountsOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An objec model deserializer.
+    :ivar api_version: Client Api Version. Constant value: "2015-05-01-preview".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -31,6 +32,7 @@ class StorageAccountsOperations(object):
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
+        self.api_version = "2015-05-01-preview"
 
         self.config = config
 
@@ -64,7 +66,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -140,7 +142,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -231,7 +233,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -291,7 +293,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -369,7 +371,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -436,7 +438,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}
@@ -495,7 +497,7 @@ class StorageAccountsOperations(object):
 
                 # Construct parameters
                 query_parameters = {}
-                query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+                query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
             else:
                 url = next_link
@@ -564,7 +566,7 @@ class StorageAccountsOperations(object):
 
                 # Construct parameters
                 query_parameters = {}
-                query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+                query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
             else:
                 url = next_link
@@ -640,7 +642,7 @@ class StorageAccountsOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/operations/usage_operations.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/operations/usage_operations.py
@@ -23,6 +23,7 @@ class UsageOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An objec model deserializer.
+    :ivar api_version: Client Api Version. Constant value: "2015-05-01-preview".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -30,6 +31,7 @@ class UsageOperations(object):
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
+        self.api_version = "2015-05-01-preview"
 
         self.config = config
 
@@ -58,7 +60,7 @@ class UsageOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/storage_management_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/storagemanagementclient/storage_management_client.py
@@ -30,13 +30,11 @@ class StorageManagementClientConfiguration(AzureConfiguration):
      identify Microsoft Azure subscription. The subscription ID forms part of
      the URI for every service call.
     :type subscription_id: str
-    :param api_version: Client Api Version.
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-05-01-preview', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -44,8 +42,6 @@ class StorageManagementClientConfiguration(AzureConfiguration):
             raise ValueError("Parameter 'subscription_id' must not be None.")
         if not isinstance(subscription_id, str):
             raise TypeError("Parameter 'subscription_id' must be str.")
-        if api_version is not None and not isinstance(api_version, str):
-            raise TypeError("Optional parameter 'api_version' must be str.")
         if not base_url:
             base_url = 'https://management.azure.com'
 
@@ -56,7 +52,6 @@ class StorageManagementClientConfiguration(AzureConfiguration):
 
         self.credentials = credentials
         self.subscription_id = subscription_id
-        self.api_version = api_version
 
 
 class StorageManagementClient(object):
@@ -77,18 +72,17 @@ class StorageManagementClient(object):
      identify Microsoft Azure subscription. The subscription ID forms part of
      the URI for every service call.
     :type subscription_id: str
-    :param api_version: Client Api Version.
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2015-05-01-preview', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
-        self.config = StorageManagementClientConfiguration(credentials, subscription_id, api_version, base_url)
+        self.config = StorageManagementClientConfiguration(credentials, subscription_id, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '2015-05-01-preview'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftazuretesturl/microsoft_azure_test_url.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftazuretesturl/microsoft_azure_test_url.py
@@ -27,13 +27,11 @@ class MicrosoftAzureTestUrlConfiguration(AzureConfiguration):
      object<msrestazure.azure_active_directory>`
     :param subscription_id: Subscription Id.
     :type subscription_id: str
-    :param api_version: API Version with value '2014-04-01-preview'.
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2014-04-01-preview', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
         if credentials is None:
             raise ValueError("Parameter 'credentials' must not be None.")
@@ -41,8 +39,6 @@ class MicrosoftAzureTestUrlConfiguration(AzureConfiguration):
             raise ValueError("Parameter 'subscription_id' must not be None.")
         if not isinstance(subscription_id, str):
             raise TypeError("Parameter 'subscription_id' must be str.")
-        if api_version is not None and not isinstance(api_version, str):
-            raise TypeError("Optional parameter 'api_version' must be str.")
         if not base_url:
             base_url = 'https://management.azure.com/'
 
@@ -53,7 +49,6 @@ class MicrosoftAzureTestUrlConfiguration(AzureConfiguration):
 
         self.credentials = credentials
         self.subscription_id = subscription_id
-        self.api_version = api_version
 
 
 class MicrosoftAzureTestUrl(object):
@@ -70,18 +65,17 @@ class MicrosoftAzureTestUrl(object):
      object<msrestazure.azure_active_directory>`
     :param subscription_id: Subscription Id.
     :type subscription_id: str
-    :param api_version: API Version with value '2014-04-01-preview'.
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, credentials, subscription_id, api_version='2014-04-01-preview', base_url=None):
+            self, credentials, subscription_id, base_url=None):
 
-        self.config = MicrosoftAzureTestUrlConfiguration(credentials, subscription_id, api_version, base_url)
+        self.config = MicrosoftAzureTestUrlConfiguration(credentials, subscription_id, base_url)
         self._client = ServiceClient(self.config.credentials, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '2014-04-01-preview'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftazuretesturl/operations/group_operations.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/microsoftazuretesturl/operations/group_operations.py
@@ -22,6 +22,7 @@ class GroupOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An objec model deserializer.
+    :ivar api_version: API Version with value '2014-04-01-preview'. Constant value: "2014-04-01-preview".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -29,6 +30,7 @@ class GroupOperations(object):
         self._client = client
         self._serialize = serializer
         self._deserialize = deserializer
+        self.api_version = "2014-04-01-preview"
 
         self.config = config
 
@@ -61,7 +63,7 @@ class GroupOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}

--- a/src/generator/AutoRest.Python.Azure/Templates/AzureServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Python.Azure/Templates/AzureServiceClientTemplate.cshtml
@@ -142,6 +142,10 @@ else
 {
         @:client_models = {}
 }
+@if (Model.ApiVersion != null)
+{
+        @:self.api_version = '@(Model.ApiVersion)'
+}
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 @EmptyLine

--- a/src/generator/AutoRest.Python.Azure/TransformerPya.cs
+++ b/src/generator/AutoRest.Python.Azure/TransformerPya.cs
@@ -249,6 +249,7 @@ namespace AutoRest.Python.Azure
             codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "long_running_operation_retry_timeout"));
             codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "generate_client_request_id"));
             codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "accept_language"));
+            codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "api_version"));
 
             if (acceptLanguage != null) // && acceptLanguage.DefaultValue != "en-US"
             {

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyArray/autorestswaggerbatarrayservice/auto_rest_swagger_bat_array_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyArray/autorestswaggerbatarrayservice/auto_rest_swagger_bat_array_service.py
@@ -54,6 +54,7 @@ class AutoRestSwaggerBATArrayService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyBoolean/autorestbooltestservice/auto_rest_bool_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyBoolean/autorestbooltestservice/auto_rest_bool_test_service.py
@@ -54,6 +54,7 @@ class AutoRestBoolTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyByte/autorestswaggerbatbyteservice/auto_rest_swagger_bat_byte_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyByte/autorestswaggerbatbyteservice/auto_rest_swagger_bat_byte_service.py
@@ -54,6 +54,7 @@ class AutoRestSwaggerBATByteService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/autorestcomplextestservice/auto_rest_complex_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/autorestcomplextestservice/auto_rest_complex_test_service.py
@@ -79,6 +79,7 @@ class AutoRestComplexTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '2016-02-29'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/autorestcomplextestservice/operations/basic_operations.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/autorestcomplextestservice/operations/basic_operations.py
@@ -21,6 +21,7 @@ class BasicOperations(object):
     :param config: Configuration of service client.
     :param serializer: An object model serializer.
     :param deserializer: An object model deserializer.
+    :ivar api_version: API ID. Constant value: "2016-02-29".
     """
 
     def __init__(self, client, config, serializer, deserializer):
@@ -30,6 +31,7 @@ class BasicOperations(object):
         self._deserialize = deserializer
 
         self.config = config
+        self.api_version = "2016-02-29"
 
     def get_valid(
             self, custom_headers=None, raw=False, **operation_config):
@@ -100,7 +102,7 @@ class BasicOperations(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['api-version'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str')
+        query_parameters['api-version'] = self._serialize.query("self.api_version", self.api_version, 'str')
 
         # Construct headers
         header_parameters = {}

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDate/autorestdatetestservice/auto_rest_date_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDate/autorestdatetestservice/auto_rest_date_test_service.py
@@ -54,6 +54,7 @@ class AutoRestDateTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTime/autorestdatetimetestservice/auto_rest_date_time_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTime/autorestdatetimetestservice/auto_rest_date_time_test_service.py
@@ -54,6 +54,7 @@ class AutoRestDateTimeTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/autorestrfc1123datetimetestservice/auto_rest_rfc1123_date_time_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/autorestrfc1123datetimetestservice/auto_rest_rfc1123_date_time_test_service.py
@@ -54,6 +54,7 @@ class AutoRestRFC1123DateTimeTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDictionary/autorestswaggerbatdictionaryservice/auto_rest_swagger_ba_tdictionary_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDictionary/autorestswaggerbatdictionaryservice/auto_rest_swagger_ba_tdictionary_service.py
@@ -54,6 +54,7 @@ class AutoRestSwaggerBATdictionaryService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDuration/autorestdurationtestservice/auto_rest_duration_test_service.py
@@ -54,6 +54,7 @@ class AutoRestDurationTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFile/autorestswaggerbatfileservice/auto_rest_swagger_bat_file_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFile/autorestswaggerbatfileservice/auto_rest_swagger_bat_file_service.py
@@ -54,6 +54,7 @@ class AutoRestSwaggerBATFileService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFormData/autorestswaggerbatformdataservice/auto_rest_swagger_bat_form_data_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFormData/autorestswaggerbatformdataservice/auto_rest_swagger_bat_form_data_service.py
@@ -54,6 +54,7 @@ class AutoRestSwaggerBATFormDataService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyInteger/autorestintegertestservice/auto_rest_integer_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyInteger/autorestintegertestservice/auto_rest_integer_test_service.py
@@ -54,6 +54,7 @@ class AutoRestIntegerTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyNumber/autorestnumbertestservice/auto_rest_number_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyNumber/autorestnumbertestservice/auto_rest_number_test_service.py
@@ -54,6 +54,7 @@ class AutoRestNumberTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyString/autorestswaggerbatservice/auto_rest_swagger_bat_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyString/autorestswaggerbatservice/auto_rest_swagger_bat_service.py
@@ -57,6 +57,7 @@ class AutoRestSwaggerBATService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUri/autorestparameterizedhosttestclient/auto_rest_parameterized_host_test_client.py
@@ -63,6 +63,7 @@ class AutoRestParameterizedHostTestClient(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autorestparameterizedcustomhosttestclient/auto_rest_parameterized_custom_host_test_client.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/autorestparameterizedcustomhosttestclient/auto_rest_parameterized_custom_host_test_client.py
@@ -72,6 +72,7 @@ class AutoRestParameterizedCustomHostTestClient(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Header/autorestswaggerbatheaderservice/auto_rest_swagger_bat_header_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Header/autorestswaggerbatheaderservice/auto_rest_swagger_bat_header_service.py
@@ -54,6 +54,7 @@ class AutoRestSwaggerBATHeaderService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Http/autoresthttpinfrastructuretestservice/auto_rest_http_infrastructure_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Http/autoresthttpinfrastructuretestservice/auto_rest_http_infrastructure_test_service.py
@@ -73,6 +73,7 @@ class AutoRestHttpInfrastructureTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ModelFlattening/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ModelFlattening/autorestresourceflatteningtestservice/auto_rest_resource_flattening_test_service.py
@@ -51,6 +51,7 @@ class AutoRestResourceFlatteningTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ParameterFlattening/autorestparameterflattening/auto_rest_parameter_flattening.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ParameterFlattening/autorestparameterflattening/auto_rest_parameter_flattening.py
@@ -55,6 +55,7 @@ class AutoRestParameterFlattening(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Report/autorestreportservice/auto_rest_report_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Report/autorestreportservice/auto_rest_report_service.py
@@ -51,6 +51,7 @@ class AutoRestReportService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/RequiredOptional/autorestrequiredoptionaltestservice/auto_rest_required_optional_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/RequiredOptional/autorestrequiredoptionaltestservice/auto_rest_required_optional_test_service.py
@@ -81,6 +81,7 @@ class AutoRestRequiredOptionalTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Url/autoresturltestservice/auto_rest_url_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Url/autoresturltestservice/auto_rest_url_test_service.py
@@ -79,6 +79,7 @@ class AutoRestUrlTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/autoresturlmutlicollectionformattestservice/auto_rest_url_mutli_collection_format_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/autoresturlmutlicollectionformattestservice/auto_rest_url_mutli_collection_format_test_service.py
@@ -54,6 +54,7 @@ class AutoRestUrlMutliCollectionFormatTestService(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Validation/autorestvalidationtest/auto_rest_validation_test.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Validation/autorestvalidationtest/auto_rest_validation_test.py
@@ -71,6 +71,7 @@ class AutoRestValidationTest(object):
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
+        self.api_version = '1.0.0'
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 

--- a/src/generator/AutoRest.Python/Model/ParameterPy.cs
+++ b/src/generator/AutoRest.Python/Model/ParameterPy.cs
@@ -18,6 +18,13 @@ namespace AutoRest.Python.Model
             {
                 if (!value.StartsWith("self."))
                 {
+                    // api_version is always at the first level, operation group or client
+                    // if it's a client property (could be a method property)
+                    if (value == "api_version" && IsClientProperty && IsConstant)
+                    {
+                        return $"self.{value}";
+                    }
+
                     if (IsClientProperty)
                     {
                         return $"self.config.{value}";

--- a/src/generator/AutoRest.Python/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Python/Templates/ServiceClientTemplate.cshtml
@@ -132,6 +132,10 @@ else
 {
         @:client_models = {}
 }
+@if (Model.ApiVersion != null)
+{
+        @:self.api_version = '@(Model.ApiVersion)'
+}
         self._serialize = Serializer(client_models)
         self._deserialize = Deserializer(client_models)
 @EmptyLine


### PR DESCRIPTION
Currently, ApiVersion is not generated the same way with Swagger and CompositeSwagger modelers in Python:
- In Composite: api_version is constant at the operation group level. Not mentioned in the client at all.
- In Swagger: api_version is parameter of the client. Operation groups use the value in the client.

This PR makes the behavior consistent by pushing api_version in the operation group level, even in Swagger modeler. ApiVersion is no more at all a parameter in the client.
Several advantages:
- This simplify user code, since now they are sure that "api_version" is always available as an attribute in the operation group instance
- This simplify the client constructor, for a parameter that 99.99% of the time is not changed, because it will imply using a Swagger for an ApiVersion not planned for. Note that the attribute is not private, and can still be changed for advanced usage
- This has interesting side-effects on our Azure Stack prototype, since now the client is agnostic of ApiVersion.

All tests ok, didn't change any test code (just regenerated).

@fearthecowboy @olydis for review please, considering that it's my first real Autorest PR where I had to understand the `CodeModel`
@derekbekoe FYI will generate AZ prototype for Compute/Network/Resources after this merged
@annatisch FYI if you have time