### PR TITLE
Added Trace to the list of permissible HTTP Verbs in Swagger Validation

### DIFF
--- a/src/modeler/AutoRest.Swagger/Validation/HttpVerbValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/HttpVerbValidation.cs
@@ -16,7 +16,7 @@ namespace AutoRest.Swagger.Validation
     /// </summary>
     public class HttpVerbValidation : TypedRule<Dictionary<string, Operation>>
     {
-        private readonly Regex opRegExp = new Regex(@"^(DELETE|GET|PUT|PATCH|HEAD|OPTIONS|POST)$", RegexOptions.IgnoreCase);
+        private readonly Regex opRegExp = new Regex(@"^(DELETE|GET|PUT|PATCH|HEAD|OPTIONS|POST|TRACE)$", RegexOptions.IgnoreCase);
 
         /// <summary>
         /// Id of the Rule.


### PR DESCRIPTION
@amarzavery @salameer Please review

Added Trace to the list of permissible HTTP Verbs in Swagger Validation

Related to https://github.com/Azure/autorest/issues/1913 