### PR TITLE
Refine build

### DIFF
--- a/gulpfile.iced
+++ b/gulpfile.iced
@@ -13,6 +13,7 @@ Tasks "dotnet",  # compiling dotnet
 
 # Settings
 Import
+  initialized: false
   solution: "#{basefolder}/AutoRest.sln"
   packages: "#{basefolder}/packages"
   release_name: if argv.nightly then "#{version}-#{today}-2300-nightly"              else if argv.preview then "#{version}-#{now}-preview"              else "#{version}"
@@ -112,7 +113,11 @@ task 'autorest', 'Runs AutoRest', (done)->
   else  
     Fail "You must run #{ info 'gulp build'}' first"
 
+
+
 task 'init', "" ,(done)->
+  return done() if initialized
+  global.initialized = true
   # is the main node_modules out of date?
   doit = true if (newer "#{basefolder}/package.json",  "#{basefolder}/node_modules") or (! test '-d', "#{basefolder}/src/autorest/node_modules/autorest-core") or (! test '-d', "#{basefolder}/src/vscode-autorest/server/node_modules/autorest")
 

--- a/gulpfile.iced
+++ b/gulpfile.iced
@@ -52,7 +52,14 @@ Import
     source ["src/autorest-core", "src/autorest" ,"src/vscode-autorest/server","src/vscode-autorest"]
 
   npminstalls: ()->
-    source ["src/autorest-core", "src/autorest" ,"src/vscode-autorest/server","src/vscode-autorest", "src/generator/AutoRest.NodeJS.Tests","src/generator/AutoRest.NodeJS.Azure.Tests" ,"src/dev/TestServer/server"]
+    source ["src/autorest-core", 
+      "src/autorest" 
+      "src/vscode-autorest/server"
+      "src/vscode-autorest"
+      "src/generator/AutoRest.NodeJS.Tests"
+      "src/generator/AutoRest.NodeJS.Azure.Tests" 
+      "src/dev/TestServer/server"
+    ]
 
   typescriptProjects: () -> 
     typescriptProjectFolders()
@@ -67,7 +74,7 @@ Import
   generatedFiles: () -> 
     typescriptProjectFolders()
       .pipe foreach (each,next,more)=>
-        source(["#{each.path}/**/*.js","#{each.path}/**/*.d.ts" ,"#{each.path}/**/*.js.map", "!#{each.path}/node_modules/**","!#{each.path}/server/node_modules/**"])
+        source(["#{each.path}/**/*.js","#{each.path}/**/*.d.ts" ,"#{each.path}/**/*.js.map", "!**/node_modules/**"])
           .on 'end', -> 
             next null
           .pipe foreach (e,n)->
@@ -85,6 +92,11 @@ Import
             e.base = each.base
             more.push e
             n null
+
+
+task "list","",->
+  generatedFiles()
+    .pipe showFiles()
 
 task 'install-binaries', '', (done)->
   mkdir "-p", "#{os.homedir()}/.autorest/plugins/autorest/#{version}-#{now}-private"

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "through2": "^2.0.3",
     "typescript": "^2.1.5",
     "vinyl-paths": "^2.1.0",
+    "vinyl-fs": "^2.4.4",
     "yargs": "^6.6.0"
   },
   "dependencies": {

--- a/src/autorest/package.json
+++ b/src/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autorest",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "description": "The AutoRest tool generates client libraries for accessing RESTful web services. Input to AutoRest is a spec that describes the REST API using the Open API Initiative format.",
   "repository": {
     "type": "git",

--- a/src/autorest/utility/index.ts
+++ b/src/autorest/utility/index.ts
@@ -11,7 +11,7 @@ class ExecResult {
 export class Utility {
 
   public static get Id(): string {
-    return 'rr8nso45s5219n68375o8np69s55rrnorppor0op'.replace(/[a-zA-Z]/g, (c: any) => { return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26); })
+    return '3s8ono7s45qsqnn4p82179pp11r9so632q942o52'.replace(/[a-zA-Z]/g, (c: any) => { return String.fromCharCode((c <= 'Z' ? 90 : 122) >= (c = c.charCodeAt(0) + 13) ? c : c - 26); })
   }
 
   static async exec(cmdline: string, ): Promise<ExecResult> {

--- a/src/gulp_modules/common.iced
+++ b/src/gulp_modules/common.iced
@@ -193,13 +193,16 @@ module.exports =
         fn = (queue.shift())
         fn() 
 
-      if code 
-        echo error "#{options.cwd}"
-        echo error "#{cmdline}"
-        echo warning stderr
-        echo error stdout
+      if code            
+        echo error "Exec Failed #{quiet_info options.cwd} :: #{info cmdline}"  
+        if( stderr.length )
+          echo error "(stderr)"
+          echo marked  ">> #{error stderr}"
+        if( stdout.length ) 
+          echo warning "(stdout)" 
+          echo marked ">> #{ warning stdout}" 
 
-        Fail "Task failed, fast exit"
+        Fail "Execute Task failed, fast exit"
       callback(code,stdout,stderr)
 
 # build task for global build

--- a/src/gulp_modules/common.iced
+++ b/src/gulp_modules/common.iced
@@ -3,6 +3,7 @@ fs = require('fs')
 concurrency = 0 
 queue = []
 global.completed = []
+vfs = require('vinyl-fs');
 
 module.exports =
   # lets us just handle each item in a stream easily.
@@ -29,7 +30,9 @@ module.exports =
       done null
 
   source: (globs, options ) -> 
-    gulp.src( globs, options) 
+    options = options or { }
+    options.follow = true
+    vfs.src( globs, options) 
 
   destination: (globs, options ) -> 
     gulp.dest( globs, options) 

--- a/src/gulp_modules/dotnet.iced
+++ b/src/gulp_modules/dotnet.iced
@@ -67,7 +67,7 @@ task 'sign-assemblies','', (done) ->
 
     .on 'end', () =>
       # after the files are in the folder, we can call the signing utility
-      codesign "Microsoft Azure SDK (Perks)",
+      codesign "AutoRest",
         "Microsoft Azure .NET SDK"
         unsigned,
         signed,

--- a/src/gulp_modules/publishing.iced
+++ b/src/gulp_modules/publishing.iced
@@ -3,7 +3,7 @@ task 'build/dotnet/binaries','', (done) ->
     Fail "Build Failed #{ warning stdout } \n#{ error stderr }" if code 
     done();
 
-task 'zip-autorest', '', (done) ->
+task 'zip-autorest', '', () ->
   packagefiles()
     .pipe zip package_name
     .pipe destination packages
@@ -16,7 +16,7 @@ task 'install-node-files' ,'', (done)->
   
   if ! test '-d', "#{basefolder}/src/core/AutoRest/bin/#{configuration}/netcoreapp1.0/publish/node_modules/autorest-core"
     fs.symlinkSync "#{basefolder}/src/autorest-core", "#{basefolder}/src/core/AutoRest/bin/#{configuration}/netcoreapp1.0/publish/node_modules/autorest-core",'junction' 
-    
+  done();
   return null;
 
 task 'package','From scratch build, sign, and package autorest', (done) -> 

--- a/src/gulp_modules/typescript.iced
+++ b/src/gulp_modules/typescript.iced
@@ -3,7 +3,7 @@ task 'build', 'typescript', (done)->
   count = 4
   typescriptProjects()
     .pipe foreach (each,next) -> 
-      execute "#{basefolder}/node_modules/.bin/tsc --project #{folder each.path}",{retry:1} ,(code,stdout,stderr) ->
+      execute "#{basefolder}/node_modules/.bin/tsc --project #{folder each.path}",{retry:2} ,(code,stdout,stderr) ->
         echo stdout.replace("src/","#{basefolder}/src/".trim()) 
         count--
         if count is 0


### PR DESCRIPTION
- Ensure `init` task is not called more than once
- exclude all `node_modules` content from the clean script
- switch to using `vinyl-fs` for selecting files (supports following symlinks)
- updated github api key to use one that isn't getting throttled.
- changed retry count during typescript compile to `2` -- this should solve race-condition when compiling fresh.