### PR TITLE
Version template fix

### DIFF
--- a/Samples/petstore/Go/version.go
+++ b/Samples/petstore/Go/version.go
@@ -1,42 +1,13 @@
 package petstore
 
 
-import (
-    "bytes"
-    "fmt"
-    "strings"
-)
-
-const (
-    major = "0"
-    minor = "0"
-    patch = "0"
-    tag   = ""
-    userAgentFormat = "Azure-SDK-For-Go/%s arm-%s/%s"
-)
-// cached results of UserAgent and Version to prevent repeated operations.
-var (
-    userAgent string
-    version string
-)
 
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-    if userAgent == "" {
-        userAgent = fmt.Sprintf(userAgentFormat, Version(), "petstore", "1.0.0")
-    }
-    return userAgent
+    return "Azure-SDK-For-Go/0.0.0 arm-petstore/1.0.0"
 }
 
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-    if version == "" {
-        versionBuilder := bytes.NewBufferString(fmt.Sprintf("%s.%s.%s", major, minor, patch))
-        if tag != "" {
-            versionBuilder.WriteRune('-')
-            versionBuilder.WriteString(strings.TrimPrefix(tag, "-"))
-        }
-        version = string(versionBuilder.Bytes())
-    }
-    return version
+  return "0.0.0"
 }

--- a/src/generator/AutoRest.Go/CodeNamerGo.cs
+++ b/src/generator/AutoRest.Go/CodeNamerGo.cs
@@ -90,7 +90,6 @@ namespace AutoRest.Go
         public IReadOnlyDictionary<HttpStatusCode, string> StatusCodeToGoString;
 
 
-        private static readonly Regex semVerPattern = new Regex(@"^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<tag>\S+))?$", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of CodeNamerGo.
@@ -424,27 +423,6 @@ namespace AutoRest.Go
                 builder.Append(CommonInitialisms.Contains(s) ? s.ToUpper() : s);
             }
             return builder.ToString();
-        }
-
-        public static string[] SDKVersionFromPackageVersion(string v)
-        {
-            if (string.IsNullOrEmpty(v))
-            {
-                throw new ArgumentNullException("package version");
-            }
-
-            var ver = semVerPattern.Match(v);
-
-            if (ver.Success)
-            {
-                var tagVal = ver.Groups["tag"].Success ? ver.Groups["tag"].Value : "";
-                return new[] { ver.Groups["major"].Value, ver.Groups["minor"].Value, ver.Groups["patch"].Value, tagVal };
-                 
-            }
-            throw new ArgumentException(
-                paramName: nameof(v),
-                message: "Version strings should be either of the format \"<major>.<minor>.<patch>\" or \"<major>.<minor>.<patch>-<tag>\". Where major, minor, and patch are decimal numbers and tag does not include whitespace.");
-
         }
 
         public override string EscapeDefaultValue(string defaultValue, IModelType type)

--- a/src/generator/AutoRest.Go/CodeNamerGo.cs
+++ b/src/generator/AutoRest.Go/CodeNamerGo.cs
@@ -90,7 +90,7 @@ namespace AutoRest.Go
         public IReadOnlyDictionary<HttpStatusCode, string> StatusCodeToGoString;
 
 
-        private static readonly Regex semVerPattern = new Regex(@"^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<tag>\S+))?$", RegexOptions.Compiled);
+        private static readonly Regex semVerPattern = new Regex(@"^v?(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)(?:-(?<tag>\S+))?$", RegexOptions.Compiled);
 
         /// <summary>
         /// Initializes a new instance of CodeNamerGo.

--- a/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/VersionTemplate.cshtml
@@ -12,47 +12,15 @@ package @Model.Namespace
 @Header("// ")
 
 @EmptyLine
-import (
-    "bytes"
-    "fmt"
-    "strings"
-)
-@EmptyLine
-
-const (
-    major = "@(Model.Version[0])"
-    minor = "@(Model.Version[1])"
-    patch = "@(Model.Version[2])"
-    tag   = "@(Model.Version[3])"
-
-    userAgentFormat = "Azure-SDK-For-Go/%s arm-%s/%s"
-)
-
-// cached results of UserAgent and Version to prevent repeated operations.
-var (
-    userAgent string
-    version string
-)
 
 @EmptyLine
 // UserAgent returns the UserAgent string to use when sending http.Requests.
 func UserAgent() string {
-    if userAgent == "" {
-        userAgent = fmt.Sprintf(userAgentFormat, Version(), "@(Model.Namespace)", "@(Model.ApiVersion)")
-    }
-    return userAgent
+    return "@(Model.UserAgent)"
 }
 
 @EmptyLine
 // Version returns the semantic version (see http://semver.org) of the client.
 func Version() string {
-    if version == "" {
-        versionBuilder := bytes.NewBufferString(fmt.Sprintf("%s.%s.%s", major, minor, patch))
-        if tag != "" {
-            versionBuilder.WriteRune('-')
-            versionBuilder.WriteString(strings.TrimPrefix(tag, "-"))
-        }
-        version = string(versionBuilder.Bytes())
-    }
-    return version
+  return "@(Model.Version)"
 }


### PR DESCRIPTION
Fixing up generator to fix up Azure/azure-sdk-for-go#559.

As I pointed out in one of my commit messages, there is a larger problem I discovered while doing this work, which is that our Generator can only populate the UserAgent field which states that it is an instance of the "Azure-SDK-for-Go". I did not attempt to fix that in this PR. I'll file a new issue to track that.