### PR TITLE
Plug PackageName parameter in Python

### DIFF
--- a/src/generator/AutoRest.Python/Model/CodeModelPy.cs
+++ b/src/generator/AutoRest.Python/Model/CodeModelPy.cs
@@ -171,7 +171,7 @@ namespace AutoRest.Python.Model
 
         public virtual bool HasAnyModel => ModelTemplateModels.Any();
 
-        public string PackageName => Name.ToPythonCase().Replace("_", "");
+        public string PackageName => Settings.Instance.PackageName.Else(Name.ToPythonCase().Replace("_", ""));
 
         //TODO: Proper namespace validation and formatting
         public string modelNamespace => Namespace.Else(Name.ToPythonCase()).ToLower();


### PR DESCRIPTION
Currently `PackageName` is ignored by Python. This PR allows Autorest to use `PackageName` and still use the same algorithm if `PackageName` is not defined.

This implies no tests/samples change, since the default value if `PackageName` is not used is still the same and no tests/samples use `PackageName` parameter.
