### PR TITLE
[Linter] Renaming XmsClientNameValidation to XmsClientNamePropertyValidation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -213,3 +213,7 @@ src/client/**/*
 
 src/extension/old/**/*
 *.d.ts
+
+src/bootstrapper
+src/extension/out
+src/next-gen

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,10 +14,7 @@
         "**/.hg": true,
         "**/.DS_Store": true
     },
-    "editor.tabSize": 2,
-    "editor.detectIndentation": false,
     "csharp.suppressDotnetRestoreNotification": true,
-    "editor.formatOnSave": true,
     "[typescript]" :{
         "editor.formatOnSave": true,
         "editor.formatOnPaste": true,

--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -751,11 +751,11 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Value of &apos;x-ms-client-name&apos; cannot be the same as the property/model name..
+        ///   Looks up a localized string similar to Value of &apos;x-ms-client-name&apos; cannot be the same as &apos;{0}&apos; Property/Model..
         /// </summary>
-        public static string XmsClientNameInValid {
+        public static string XmsClientNameInvalid {
             get {
-                return ResourceManager.GetString("XmsClientNameInValid", resourceCulture);
+                return ResourceManager.GetString("XmsClientNameInvalid", resourceCulture);
             }
         }
         

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -238,8 +238,8 @@ Modelers:
   <data name="ResourceIsMsResourceNotValid" xml:space="preserve">
     <value>A 'Resource' definition must have x-ms-azure-resource extension enabled and set to true.</value>
   </data>
-  <data name="XmsClientNameInValid" xml:space="preserve">
-    <value>Value of 'x-ms-client-name' cannot be the same as the property/model name.</value>
+  <data name="XmsClientNameInvalid" xml:space="preserve">
+    <value>Value of 'x-ms-client-name' cannot be the same as '{0}' Property/Model.</value>
   </data>
   <data name="DeleteMustNotHaveRequestBody" xml:space="preserve">
     <value>'Delete' operation must not have a request body.</value>

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/swagger-ext-msclientname-validation.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/swagger-ext-msclientname-validation.json
@@ -34,7 +34,8 @@
             "in": "path",
             "required": true,
             "type": "string",
-            "description": "The name of the Redis cache."
+            "description": "The name of the Redis cache.",
+            "x-ms-client-name": "name"
           },
           {
             "$ref": "#/parameters/ApiVersionParameter"

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -100,7 +100,7 @@ namespace AutoRest.Swagger.Tests
         public void UniqueResourcePathsValidation()
         {
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "network-interfaces-api.json"));
-            messages.AssertOnlyValidationWarning(typeof(UniqueResourcePaths));
+            messages.AssertOnlyValidationMessage(typeof(UniqueResourcePaths));
         }
 
         [Fact]
@@ -123,14 +123,14 @@ namespace AutoRest.Swagger.Tests
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "operations-invalid-parameters.json"));
             messages.AssertOnlyValidationMessage(typeof(OperationParametersValidation));
         }
-        
+
         [Fact]
         public void ServiceDefinitionParametersValidation()
         {
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "service-def-invalid-parameters.json"));
             messages.AssertOnlyValidationMessage(typeof(ServiceDefinitionParameters));
         }
-        
+
         [Fact]
         public void OperationGroupSingleUnderscoreValidation()
         {
@@ -225,12 +225,6 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void InvalidConstraintValidation()
-        {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "swagger-validation.json"));
-            messages.AssertOnlyValidationWarning(typeof(InvalidConstraint), 18);
-        }
-        [Fact]
         public void BodyTopLevelPropertiesValidation()
         {
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "body-top-level-properties.json"));
@@ -283,7 +277,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void OperationNameValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "operation-name-not-valid.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "operation-name-not-valid.json"));
             messages.AssertOnlyValidationMessage(typeof(GetOperationNameValidation), 1);
             messages.AssertOnlyValidationMessage(typeof(PutOperationNameValidation), 1);
             messages.AssertOnlyValidationMessage(typeof(DeleteOperationNameValidation), 1);
@@ -292,98 +286,99 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void LongRunningResponseForPutValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "long-running-invalid-response-put.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "long-running-invalid-response-put.json"));
             messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation));
         }
 
         [Fact]
         public void LongRunningResponseForPostValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "long-running-invalid-response-post.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "long-running-invalid-response-post.json"));
             messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation));
         }
 
         [Fact]
         public void LongRunningResponseForDeleteValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "long-running-invalid-response-delete.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "long-running-invalid-response-delete.json"));
             messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation));
         }
 
         [Fact]
         public void MutabilityNotModeledWithReadOnlyValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "mutability-invalid-values-for-readonly.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "mutability-invalid-values-for-readonly.json"));
             messages.AssertOnlyValidationMessage(typeof(MutabilityWithReadOnlyRule), 2);
         }
 
         [Fact]
         public void VersionFormatValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-version-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-version-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(APIVersionPattern), 1);
         }
 
         [Fact]
         public void GuidUsageValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-guid-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-guid-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(GuidValidation), 1);
         }
 
         [Fact]
         public void DeleteRequestBodyValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-delete-request-body-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-delete-request-body-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(DeleteMustNotHaveRequestBody), 1);
         }
 
         [Fact]
         public void ResourceExtensionValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-ext-msresource-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-ext-msresource-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(ResourceIsMsResourceValidation), 1);
         }
 
         [Fact]
         public void MsClientNameExtensionValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-ext-msclientname-validation.json"));
-            messages.AssertOnlyValidationMessage(typeof(XmsClientNameValidation), 1);
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-ext-msclientname-validation.json"));
+            messages.AssertOnlyValidationMessage(typeof(XmsClientNamePropertyValidation), 1);
+            messages.AssertOnlyValidationMessage(typeof(XmsClientNameParameterValidation), 1);
         }
 
         [Fact]
         public void OperationsApiValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-operations-api-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-operations-api-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(OperationsAPIImplementationValidation), 1);
         }
 
         [Fact]
         public void ResourceModelValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-ext-resource-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-ext-resource-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(ResourceModelValidation), 1);
         }
 
         [Fact]
         public void SkuModelValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-skumodel-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-skumodel-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(SkuModelValidation), 1);
         }
 
         [Fact]
         public void TrackedResource1Validation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-tracked-resource-1-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-tracked-resource-1-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(TrackedResourceValidation), 1);
         }
 
         [Fact]
         public void TrackedResource2Validation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-tracked-resource-2-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-tracked-resource-2-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(TrackedResourceValidation), 1);
         }
 
@@ -404,21 +399,21 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void TrackedResource3Validation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-tracked-resource-3-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-tracked-resource-3-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(TrackedResourceValidation), 1);
         }
 
         [Fact]
         public void TrackedResource4Validation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-tracked-resource-4-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-tracked-resource-4-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(TrackedResourceValidation), 1);
         }
 
         [Fact]
         public void PutGetPatchResponseValidation()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "swagger-putgetpatch-response-validation.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-putgetpatch-response-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(PutGetPatchResponseValidation), 1);
         }
     }
@@ -453,7 +448,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void RequiredPropertyDefinedAllOf()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "positive", "required-property-defined-allof.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "positive", "required-property-defined-allof.json"));
             Assert.Empty(messages.Where(m => m.Severity >= Category.Warning));
         }
 
@@ -463,7 +458,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void PageableNextLinkDefinedAllOf()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "positive", "pageable-nextlink-defined-allof.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "positive", "pageable-nextlink-defined-allof.json"));
             Assert.Empty(messages.Where(m => m.Severity >= Category.Warning));
         }
 
@@ -473,7 +468,7 @@ namespace AutoRest.Swagger.Tests
         [Fact]
         public void LongRunningResponseDefined()
         {
-            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource","Swagger", "Validation", "positive", "long-running-valid-response.json"));
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "positive", "long-running-valid-response.json"));
             messages.AssertOnlyValidationMessage(typeof(LongRunningResponseValidation), 0);
         }
 

--- a/src/modeler/AutoRest.Swagger/Model/Schema.cs
+++ b/src/modeler/AutoRest.Swagger/Model/Schema.cs
@@ -36,7 +36,7 @@ namespace AutoRest.Swagger.Model
         /// Key is a type serviceTypeName.
         /// </summary>
         [CollectionRule(typeof(AvoidNestedProperties))]
-        [Rule(typeof(XmsClientNameValidation))]
+        [Rule(typeof(XmsClientNamePropertyValidation))]
         public Dictionary<string, Schema> Properties { get; set; }
 
         public bool ReadOnly { get; set; }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameParameterValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameParameterValidation.cs
@@ -3,8 +3,10 @@
 
 using AutoRest.Core.Logging;
 using AutoRest.Core.Properties;
-using AutoRest.Swagger.Validation.Core;
+using AutoRest.Core.Utilities;
 using AutoRest.Swagger.Model;
+using AutoRest.Swagger.Validation.Core;
+using System.Collections.Generic;
 
 namespace AutoRest.Swagger.Validation
 {
@@ -31,7 +33,7 @@ namespace AutoRest.Swagger.Validation
         /// <remarks>
         /// This may contain placeholders '{0}' for parameterized messages.
         /// </remarks>
-        public override string MessageTemplate => Resources.XmsClientNameInValid;
+        public override string MessageTemplate => Resources.XmsClientNameInvalid;
 
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
@@ -39,21 +41,20 @@ namespace AutoRest.Swagger.Validation
         public override Category Severity => Category.Error;
 
         /// <summary>
-        /// Validates if the name of property and x-ms-client-name(if exists) does not match.
+        /// Validates if the name of parameter model and x-ms-client-name(if exists) does not match.
         /// </summary>
-        /// <param name="definitions">Operation Definition to validate</param>
-        /// <returns>true if the validation succeeds. false otherwise.</returns>
-        public override bool IsValid(SwaggerParameter parameter)
+        /// <param name="parameter">Paramter model.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns></returns>
+        public override IEnumerable<ValidationMessage> GetValidationMessages(SwaggerParameter parameter, RuleContext context)
         {
-            if(parameter.Extensions != null && parameter.Extensions.Count != 0)
+            if (parameter?.Extensions?.ContainsKey(extensionToCheck) == true)
             {
-                string valueToCompare = (string)parameter.Extensions.GetValueOrNull(extensionToCheck);
-                if (valueToCompare != null && valueToCompare.Equals(parameter.Name))
+                if (parameter.Extensions[extensionToCheck].ToString().EqualsIgnoreCase(parameter.Name))
                 {
-                    return false;
+                    yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, parameter.Name);
                 }
             }
-            return true;
         }
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNamePropertyValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNamePropertyValidation.cs
@@ -6,13 +6,14 @@ using AutoRest.Core.Properties;
 using AutoRest.Swagger.Validation.Core;
 using System.Collections.Generic;
 using AutoRest.Swagger.Model;
+using AutoRest.Core.Utilities;
 
 namespace AutoRest.Swagger.Validation
 {
     /// <summary>
     /// Validates if the name of property and x-ms-client-name(if exists) does not match.
     /// </summary>
-    public class XmsClientNameValidation : TypedRule<Dictionary<string, Schema>>
+    public class XmsClientNamePropertyValidation : TypedRule<Dictionary<string, Schema>>
     {
         private static readonly string extensionToCheck = "x-ms-client-name";
 
@@ -32,7 +33,7 @@ namespace AutoRest.Swagger.Validation
         /// <remarks>
         /// This may contain placeholders '{0}' for parameterized messages.
         /// </remarks>
-        public override string MessageTemplate => Resources.XmsClientNameInValid;
+        public override string MessageTemplate => Resources.XmsClientNameInvalid;
 
         /// <summary>
         /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
@@ -42,26 +43,22 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// Validates if the name of property and x-ms-client-name(if exists) does not match.
         /// </summary>
-        /// <param name="definitions">Operation Definition to validate</param>
-        /// <returns>true if the validation succeeds. false otherwise.</returns>
-        public override bool IsValid(Dictionary<string, Schema> definitions)
+        /// <param name="properties">Properties.</param>
+        /// <param name="context">Rule context.</param>
+        /// <returns></returns>
+        public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> properties, RuleContext context)
         {
-            foreach (string key in definitions.Keys)
+            foreach(KeyValuePair<string, Schema> property in properties)
             {
-                Schema schema = definitions.GetValueOrNull(key);
-                if(schema != null)
+                if ((property.Value?.Extensions?.Count ?? 0) != 0)
                 {
-                    if(schema.Extensions != null && schema.Extensions.Count !=0)
+                    string valueOfXmsExtensionProperty = (string)property.Value.Extensions.GetValueOrNull(extensionToCheck);
+                    if (valueOfXmsExtensionProperty != null && valueOfXmsExtensionProperty.EqualsIgnoreCase(property.Key))
                     {
-                        string valueToCompare = (string)schema.Extensions.GetValueOrNull(extensionToCheck);
-                        if (valueToCompare != null && valueToCompare.Equals(key))
-                        {
-                            return false;
-                        }
+                        yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, property.Key);
                     }
                 }
             }
-            return true;
         }
     }
 }


### PR DESCRIPTION
fix for #1947 