### PR TITLE
[Linter] Update regex to find resource, child resource and grandchild resource names from path

### DIFF
--- a/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
@@ -14,7 +14,7 @@ namespace AutoRest.Swagger.Logging.Core
     {
         private readonly List<Dictionary<string, string>> rawMessageCollection = new List<Dictionary<string, string>>();
 
-        private readonly Regex resPathPattern = new Regex(@"/providers/(?<providerNamespace>[^{/]+)((/(?<resource>[^{/]+)/)((?<resourceName>[^/]+)))+(/(?<resource>[^{/]+))");
+        private static readonly Regex resPathPattern = new Regex(@"/providers/(?<providerNamespace>[^{/]+)/((?<resourceType>[^{/]+)/)?");
 
         public void Log(LogMessage message)
         {
@@ -29,7 +29,7 @@ namespace AutoRest.Swagger.Logging.Core
                     .FirstOrDefault();
                 var pathComponents = resPathPattern.Match(path ?? "");
                 var pathComponentProviderNamespace = pathComponents.Groups["providerNamespace"];
-                var pathComponentResource = pathComponents.Groups["resource"];
+                var pathComponentResourceType = pathComponents.Groups["resourceType"];
 
                 var rawMessage = new Dictionary<string, string>();
                 rawMessage["type"] = validationMessage.Severity.ToString();
@@ -40,7 +40,7 @@ namespace AutoRest.Swagger.Logging.Core
                 rawMessage["id"] = validationMessage.Rule.Id;
                 rawMessage["validationCategory"] = validationMessage.Rule.ValidationCategory.ToString();
                 rawMessage["providerNamespace"] = pathComponentProviderNamespace.Success ? pathComponentProviderNamespace.Value : null;
-                rawMessage["resourceType"] = pathComponentResource.Success ? pathComponentResource.Value : null;
+                rawMessage["resourceType"] = pathComponentResourceType.Success ? pathComponentResourceType.Value : null;
                 rawMessageCollection.Add(rawMessage);
             }
         }

--- a/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
@@ -40,7 +40,7 @@ namespace AutoRest.Swagger.Logging.Core
                 rawMessage["id"] = validationMessage.Rule.Id;
                 rawMessage["validationCategory"] = validationMessage.Rule.ValidationCategory.ToString();
                 rawMessage["providerNamespace"] = pathComponentProviderNamespace.Success ? pathComponentProviderNamespace.Value : null;
-                rawMessage["resourceType"] = pathComponentResource.Value;
+                rawMessage["resourceType"] = pathComponentResource.Success ? pathComponentResource.Value : null;
                 rawMessageCollection.Add(rawMessage);
             }
         }

--- a/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
@@ -14,7 +14,7 @@ namespace AutoRest.Swagger.Logging.Core
     {
         private readonly List<Dictionary<string, string>> rawMessageCollection = new List<Dictionary<string, string>>();
 
-        private readonly Regex resPathPattern = new Regex(@"/providers/(?<providerNamespace>[^{/]+)/((?<resource>[^{/]+)/)?((?<resourceName>[^/]+)/)?((?<childResource>[^{/]+)/)?((?<childResourceName>[^/]+)/)?((?<grandChildResource>[^{/]+)/)?((?<grandChildResourceName>[^\/]+))?");
+        private readonly Regex resPathPattern = new Regex(@"/providers/(?<providerNamespace>[^{/]+)((/(?<resource>[^{/]+)/)((?<resourceName>[^/]+)))+(/(?<resource>[^{/]+))");
 
         public void Log(LogMessage message)
         {
@@ -30,22 +30,6 @@ namespace AutoRest.Swagger.Logging.Core
                 var pathComponents = resPathPattern.Match(path ?? "");
                 var pathComponentProviderNamespace = pathComponents.Groups["providerNamespace"];
                 var pathComponentResource = pathComponents.Groups["resource"];
-                var pathComponentChildResource = pathComponents.Groups["childResource"];
-                var pathComponentGrandChildResource = pathComponents.Groups["grandChildResource"];
-
-                string violatingResourceType = "";
-                if (pathComponentResource.Success)
-                {
-                    violatingResourceType = string.IsNullOrWhiteSpace(pathComponentResource.Value) ? violatingResourceType : pathComponentResource.Value;
-                }
-                if (pathComponentChildResource.Success)
-                {
-                    violatingResourceType = string.IsNullOrWhiteSpace(pathComponentChildResource.Value) ? violatingResourceType : pathComponentChildResource.Value;
-                }
-                if (pathComponentGrandChildResource.Success)
-                {
-                    violatingResourceType = string.IsNullOrWhiteSpace(pathComponentGrandChildResource.Value) ? violatingResourceType : pathComponentGrandChildResource.Value;
-                }
 
                 var rawMessage = new Dictionary<string, string>();
                 rawMessage["type"] = validationMessage.Severity.ToString();
@@ -56,7 +40,7 @@ namespace AutoRest.Swagger.Logging.Core
                 rawMessage["id"] = validationMessage.Rule.Id;
                 rawMessage["validationCategory"] = validationMessage.Rule.ValidationCategory.ToString();
                 rawMessage["providerNamespace"] = pathComponentProviderNamespace.Success ? pathComponentProviderNamespace.Value : null;
-                rawMessage["resourceType"] = violatingResourceType;
+                rawMessage["resourceType"] = pathComponentResource.Value;
                 rawMessageCollection.Add(rawMessage);
             }
         }

--- a/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Core/JsonValidationLogListener.cs
@@ -14,7 +14,7 @@ namespace AutoRest.Swagger.Logging.Core
     {
         private readonly List<Dictionary<string, string>> rawMessageCollection = new List<Dictionary<string, string>>();
 
-        private readonly Regex resPathPattern = new Regex(@"/providers/(?<providerNamespace>[^{/]+)/((?<resourceType>[^{/]+)/)?");
+        private readonly Regex resPathPattern = new Regex(@"/providers/(?<providerNamespace>[^{/]+)/((?<resource>[^{/]+)/)?((?<resourceName>[^/]+)/)?((?<childResource>[^{/]+)/)?((?<childResourceName>[^/]+)/)?((?<grandChildResource>[^{/]+)/)?((?<grandChildResourceName>[^\/]+))?");
 
         public void Log(LogMessage message)
         {
@@ -29,7 +29,23 @@ namespace AutoRest.Swagger.Logging.Core
                     .FirstOrDefault();
                 var pathComponents = resPathPattern.Match(path ?? "");
                 var pathComponentProviderNamespace = pathComponents.Groups["providerNamespace"];
-                var pathComponentResourceType = pathComponents.Groups["resourceType"];
+                var pathComponentResource = pathComponents.Groups["resource"];
+                var pathComponentChildResource = pathComponents.Groups["childResource"];
+                var pathComponentGrandChildResource = pathComponents.Groups["grandChildResource"];
+
+                string violatingResourceType = "";
+                if (pathComponentResource.Success)
+                {
+                    violatingResourceType = string.IsNullOrWhiteSpace(pathComponentResource.Value) ? violatingResourceType : pathComponentResource.Value;
+                }
+                if (pathComponentChildResource.Success)
+                {
+                    violatingResourceType = string.IsNullOrWhiteSpace(pathComponentChildResource.Value) ? violatingResourceType : pathComponentChildResource.Value;
+                }
+                if (pathComponentGrandChildResource.Success)
+                {
+                    violatingResourceType = string.IsNullOrWhiteSpace(pathComponentGrandChildResource.Value) ? violatingResourceType : pathComponentGrandChildResource.Value;
+                }
 
                 var rawMessage = new Dictionary<string, string>();
                 rawMessage["type"] = validationMessage.Severity.ToString();
@@ -40,7 +56,7 @@ namespace AutoRest.Swagger.Logging.Core
                 rawMessage["id"] = validationMessage.Rule.Id;
                 rawMessage["validationCategory"] = validationMessage.Rule.ValidationCategory.ToString();
                 rawMessage["providerNamespace"] = pathComponentProviderNamespace.Success ? pathComponentProviderNamespace.Value : null;
-                rawMessage["resourceType"] = pathComponentResourceType.Success ? pathComponentResourceType.Value : null;
+                rawMessage["resourceType"] = violatingResourceType;
                 rawMessageCollection.Add(rawMessage);
             }
         }


### PR DESCRIPTION
Fixes https://github.com/Azure/autorest/issues/1988

Example:
```
{
    "type": "Error",
    "code": "OperationIdNounInVerb",
    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Recommendations' should not appear after the underscore.",
    "jsonref": "file:///D:/Repos/azure-rest-api-specs/arm-advisor/2016-07-12-preview/swagger/advisor.json#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Sql~1servers~1{serverName}~1databases~1{databaseName}~1pause/get/operationId",
    "json-path": "file:///D:/Repos/azure-rest-api-specs/arm-advisor/2016-07-12-preview/swagger/advisor.json#/paths/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Sql/servers/{serverName}/databases/{databaseName}/pause/get/operationId",
    "id": "M1001",
    "validationCategory": "SDKViolation",
    "providerNamespace": "Microsoft.Sql",
    "resourceType": "databases"
  },
  {
    "type": "Error",
    "code": "BodyTopLevelProperties",
    "message": "Top level properties should be one of name, type, id, location, properties, tags, plan, sku, etag, managedBy, identity. Extra properties found: \"SuppressionContract/suppressionId, SuppressionContract/ttl\".",
    "jsonref": "file:///D:/Repos/azure-rest-api-specs/arm-advisor/2016-07-12-preview/swagger/advisor.json#/paths/~1{resourceUri}~1providers~1Microsoft.Advisor~1recommendations~1{recommendationId}~1suppressions~1{name}",
    "json-path": "file:///D:/Repos/azure-rest-api-specs/arm-advisor/2016-07-12-preview/swagger/advisor.json#/paths/{resourceUri}/providers/Microsoft.Advisor/recommendations/{recommendationId}/suppressions/{name}",
    "id": "M3006",
    "validationCategory": "RPCViolation",
    "providerNamespace": "Microsoft.Advisor",
    "resourceType": "suppressions"
  }
```