### PR TITLE
Fix exception when running AutoRest with empty arguments

### DIFF
--- a/src/core/AutoRest/Program.cs
+++ b/src/core/AutoRest/Program.cs
@@ -25,7 +25,7 @@ namespace AutoRest
         {
             int exitCode = (int)ExitCode.Error;
 
-            if( args[0] == "--server") {
+            if(args != null && args.Length > 0 && args[0] == "--server") {
               return new AutoRestAsAsService().Run().Result;
             }
 


### PR DESCRIPTION
Exception: 
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at AutoRest.Program.Main(String[] args)

Regression of commit:
https://github.com/Azure/autorest/commit/5d824d19b6f861daccf110042c6bc026fc402e57