### PR TITLE
Expose AutoRest Swagger resolver

### DIFF
--- a/src/autorest-core/legacyCli.ts
+++ b/src/autorest-core/legacyCli.ts
@@ -84,5 +84,7 @@ export async function CreateConfiguration(baseFolderUri: string, inputScope: Dat
 
   result.__specials.rubyPackageName = GetFilenameWithoutExtension(inputFile).replace(/[^a-zA-Z0-9-_]/g, "").replace(/-/g, '_').replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase();
 
+  result.__specials.outputFile = switches["outputfilename"] || null;
+
   return result;
 }

--- a/src/autorest-core/lib/configuration/configuration.ts
+++ b/src/autorest-core/lib/configuration/configuration.ts
@@ -19,6 +19,7 @@ export interface AutoRestConfigurationSpecials {
   syncMethods?: "all" | "essential" | "none";
   addCredentials?: boolean;
   rubyPackageName?: string;
+  outputFile?: string | null;
 }
 
 export interface AutoRestConfiguration {


### PR DESCRIPTION
...so we don't get a *4th* buggy version of a resolver!
We literally maintain 3 implementations right now, the docs team is about to create the 4th.
- docs for network is blocked because of that
- service teams "reduplicate" models across there Swaggers in current PRs just because of that!

Usage: `autorest -FANCY -g SwaggerResolver`