### PR TITLE
updating regex to allow 2 consecutive upper case chars for acronyms

### DIFF
--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/property-names-casing-valid.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/property-names-casing-valid.json
@@ -84,6 +84,10 @@
             "modelAsString": false
           }
         },
+        "startIP": {
+          "type": "string",
+          "description": "Required. Indicates the start IP range.",
+        },
         "location": {
           "type": "string",
           "description": "Required. Gets or sets the location of the resource. This will be one of the supported and registered Azure Geo Regions (e.g. West US, East US, Southeast Asia, etc.). The geo region of a resource cannot be changed once it is created, but if an identical geo region is specified on update the request will succeed."

--- a/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
@@ -97,13 +97,13 @@ namespace AutoRest.Swagger.Model.Utilities
         }
 
         /// <summary>
-        /// Returns whether a string follows camel case style.
+        /// Returns whether a string follows camel case style, allowing for 2 consecutive upper case characters for acronyms.
         /// </summary>
         /// <param name="name">String to check for style</param>
-        /// <returns>true if "name" follows camel case style, false otherwise.</returns>
+        /// <returns>true if "name" follows camel case style (allows for 2 consecutive upper case characters), false otherwise.</returns>
         public static bool isNameCamelCase(string name)
         {
-            Regex propNameRegEx = new Regex(@"^[a-z0-9]+([A-Z][a-z0-9]+)+|^[a-z0-9]+$|^[a-z0-9]+[A-Z]$");
+            Regex propNameRegEx = new Regex(@"^[a-z0-9\$-]+([A-Z]{1,2}[a-z0-9\$-]+)+$|^[a-z0-9\$-]+$|^[a-z0-9\$-]+([A-Z]{1,2}[a-z0-9\$-]+)*[A-Z]{1,2}$");
             return (propNameRegEx.IsMatch(name));
         }
 


### PR DESCRIPTION
Fixing https://github.com/Azure/autorest/issues/1981