### PR TITLE
Removing APIVersion from client.

### DIFF
--- a/Samples/petstore/Go/client.go
+++ b/Samples/petstore/Go/client.go
@@ -15,8 +15,6 @@ import (
 )
 
 const (
-    // APIVersion is the version of the Petstore
-    APIVersion = "1.0.0"
 
         // DefaultBaseURI is the default URI used for the service Petstore
         DefaultBaseURI = "http://petstore.swagger.io/v2"
@@ -26,8 +24,7 @@ const (
 type ManagementClient struct {
     autorest.Client
         BaseURI string
-    APIVersion string
-}
+    }
 
 // New creates an instance of the ManagementClient client.
 func New()ManagementClient {
@@ -39,7 +36,6 @@ func New()ManagementClient {
         return ManagementClient{
             Client: autorest.NewClientWithUserAgent(UserAgent()),
             BaseURI: baseURI,
-            APIVersion: APIVersion,
         }
     }
 

--- a/Samples/petstore/Go/client.go
+++ b/Samples/petstore/Go/client.go
@@ -15,7 +15,6 @@ import (
 )
 
 const (
-
         // DefaultBaseURI is the default URI used for the service Petstore
         DefaultBaseURI = "http://petstore.swagger.io/v2"
 )

--- a/src/generator/AutoRest.Go/Model/CodeModelGo.cs
+++ b/src/generator/AutoRest.Go/Model/CodeModelGo.cs
@@ -145,7 +145,7 @@ namespace AutoRest.Go.Model
     public string GlobalDefaultParameters
     {
       get
-      {   
+      {
         var declarations = new List<string>();
         foreach (var p in Properties)
         {

--- a/src/generator/AutoRest.Go/Model/CodeModelGo.cs
+++ b/src/generator/AutoRest.Go/Model/CodeModelGo.cs
@@ -145,7 +145,7 @@ namespace AutoRest.Go.Model
     public string GlobalDefaultParameters
     {
       get
-      {
+      {   
         var declarations = new List<string>();
         foreach (var p in Properties)
         {

--- a/src/generator/AutoRest.Go/Model/MethodGo.cs
+++ b/src/generator/AutoRest.Go/Model/MethodGo.cs
@@ -22,6 +22,8 @@ namespace AutoRest.Go.Model
 
     public string PackageName { get; private set; }
 
+    public string APIVersion {get; private set; }
+
     private readonly string lroDescription = " This method may poll for completion. Polling can be canceled by passing the cancel channel argument. " +
                                              "The channel will be used to cancel polling and any outstanding HTTP requests.";
 
@@ -40,6 +42,18 @@ namespace AutoRest.Go.Model
       Owner = (MethodGroup as MethodGroupGo).ClientName;
       PackageName = cmg.Namespace;
       NextAlreadyDefined = NextMethodExists(cmg.Methods.Cast<MethodGo>());
+
+      var apiVersionParam =
+        from p in Parameters
+        let name = p.SerializedName.Value
+        where name != null && name.IsApiVersion()
+        select p.DefaultValue.Value?.Trim(new[]{'"'});
+
+      APIVersion = apiVersionParam.SingleOrDefault();
+      if(APIVersion == default(string))
+      {
+        APIVersion = cmg.ApiVersion;
+      }
 
       var parameter = Parameters.ToList().Find(p => p.ModelType.PrimaryType(KnownPrimaryType.Stream)
                                           && !(p.Location == ParameterLocation.Body || p.Location == ParameterLocation.FormData));

--- a/src/generator/AutoRest.Go/Model/MethodGo.cs
+++ b/src/generator/AutoRest.Go/Model/MethodGo.cs
@@ -49,6 +49,9 @@ namespace AutoRest.Go.Model
         where name != null && name.IsApiVersion()
         select p.DefaultValue.Value?.Trim(new[]{'"'});
 
+      // When APIVersion is blank, it means that it was unavailable at the method level
+      // and we should default back to whatever is present at the client level. However,
+      // we will continue embedding that in each method to have broader support.
       APIVersion = apiVersionParam.SingleOrDefault();
       if(APIVersion == default(string))
       {

--- a/src/generator/AutoRest.Go/Model/ParameterGo.cs
+++ b/src/generator/AutoRest.Go/Model/ParameterGo.cs
@@ -43,13 +43,16 @@ namespace AutoRest.Go.Model
     public string GetParameterName()
     {
       string retval;
-      if (IsAPIVersion) {
+      if (IsAPIVersion) 
+      {
         retval = APIVersionName;
       }
-      else if (IsClientProperty) {
+      else if (IsClientProperty) 
+      {
         retval = "client." + Name.Value.Capitalize();
       }
-      else {
+      else 
+      {
         retval = Name.Value;
       }
       return retval;
@@ -236,9 +239,12 @@ namespace AutoRest.Go.Model
 
       foreach (var p in parameters)
       {
-        var name = p.IsAPIVersion
-            ? "APIVersion"
-            : !p.IsClientProperty
+        if (p.IsAPIVersion) 
+        {
+          continue;
+        }
+
+        var name = !p.IsClientProperty
                 ? p.Name.Value
                 : "client." + p.Name.Value.Capitalize();
 

--- a/src/generator/AutoRest.Go/Model/ParameterGo.cs
+++ b/src/generator/AutoRest.Go/Model/ParameterGo.cs
@@ -84,7 +84,7 @@ namespace AutoRest.Go.Model
     /// <returns></returns>
     public string ValueForMap()
     {
-      if (SerializedName.Value.IsApiVersion())
+      if (IsAPIVersion)
       {
         return APIVersionName;
       }
@@ -236,8 +236,8 @@ namespace AutoRest.Go.Model
 
       foreach (var p in parameters)
       {
-        var name = p.SerializedName.Value.IsApiVersion()
-            ? "client." + ParameterGo.APIVersionName
+        var name = p.IsAPIVersion
+            ? "APIVersion"
             : !p.IsClientProperty
                 ? p.Name.Value
                 : "client." + p.Name.Value.Capitalize();

--- a/src/generator/AutoRest.Go/Model/ParameterGo.cs
+++ b/src/generator/AutoRest.Go/Model/ParameterGo.cs
@@ -13,7 +13,7 @@ namespace AutoRest.Go.Model
 {
   public class ParameterGo : Parameter
   {
-    public const string ApiVersionName = "APIVersion";
+    public const string APIVersionName = "APIVersion";
     public ParameterGo()
     {
 
@@ -42,14 +42,24 @@ namespace AutoRest.Go.Model
 
     public string GetParameterName()
     {
-      return IsClientProperty
-                      ? "client." + Name.Value.Capitalize()
-                      : Name.Value;
+      string retval;
+      if (IsAPIVersion) {
+        retval = APIVersionName;
+      }
+      else if (IsClientProperty) {
+        retval = "client." + Name.Value.Capitalize();
+      }
+      else {
+        retval = Name.Value;
+      }
+      return retval;
     }
 
-    public override bool IsClientProperty => base.IsClientProperty == true || SerializedName.Value.IsApiVersion();
+    public override bool IsClientProperty => base.IsClientProperty == true && !IsAPIVersion;
 
-    public bool IsMethodArgument => !IsClientProperty;
+    public virtual bool IsAPIVersion => SerializedName.Value.IsApiVersion();
+
+    public virtual bool IsMethodArgument => !IsClientProperty && !IsAPIVersion;
 
     /// <summary>
     /// Get Name for parameter for Go map. 
@@ -58,9 +68,9 @@ namespace AutoRest.Go.Model
     /// <returns></returns>
     public string NameForMap()
     {
-      return SerializedName.Value.IsApiVersion()
-                  ? AzureExtensions.ApiVersion
-                  : SerializedName.Value;
+      return IsAPIVersion
+               ? AzureExtensions.ApiVersion
+               : SerializedName.Value;
     }
 
     public bool RequiresUrlEncoding()
@@ -76,8 +86,9 @@ namespace AutoRest.Go.Model
     {
       if (SerializedName.Value.IsApiVersion())
       {
-        return "client." + ApiVersionName;
+        return APIVersionName;
       }
+
       var value = IsClientProperty
           ? "client." + CodeNamerGo.Instance.GetPropertyName(Name.Value)
           : Name.Value;
@@ -226,7 +237,7 @@ namespace AutoRest.Go.Model
       foreach (var p in parameters)
       {
         var name = p.SerializedName.Value.IsApiVersion()
-            ? "client." + ParameterGo.ApiVersionName
+            ? "client." + ParameterGo.APIVersionName
             : !p.IsClientProperty
                 ? p.Name.Value
                 : "client." + p.Name.Value.Capitalize();

--- a/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
@@ -73,18 +73,22 @@ func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignat
 @EmptyLine
 // @(Model.PreparerMethodName) prepares the @(Model.Name) request.
 func (client @(Model.Owner)) @(Model.PreparerMethodName)(@(Model.MethodParametersSignature)) (*http.Request, error) {
-@if (Model.IsCustomBaseUri && Model.URLParameters.Count() > 0)
+@if (Model.IsCustomBaseUri && Model.URLParameters.Any())
 {
     @:@(Model.URLMap)
     @:@EmptyLine
 }
-@if (Model.PathParameters.Count() > 0)
+@if (Model.PathParameters.Any())
 {
     @:@(Model.PathMap)
     @:@EmptyLine
 }
-@if (Model.QueryParameters.Count() > 0)
+@if (Model.QueryParameters.Any())
 {
+    @if (Model.QueryParameters.Any(p => p.GetParameterName().IsApiVersion())) 
+    {
+        @:@(string.Format("const APIVersion = \"{0}\"", Model.APIVersion))
+    }
     @:@(Model.QueryMap)
     foreach (var p in Model.OptionalQueryParameters)
     {

--- a/src/generator/AutoRest.Go/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/ServiceClientTemplate.cshtml
@@ -28,7 +28,6 @@ import (
 const (
     @if (!Model.IsCustomBaseUri)
     {
-        @EmptyLine
         @:// DefaultBaseURI is the default URI used for the service @(Model.ServiceName)
         @:DefaultBaseURI = "@Model.BaseUrl"
     }

--- a/src/generator/AutoRest.Go/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/ServiceClientTemplate.cshtml
@@ -26,8 +26,6 @@ import (
 
 @EmptyLine
 const (
-    // APIVersion is the version of the @(Model.ServiceName)
-    APIVersion = "@Model.ApiVersion"
     @if (!Model.IsCustomBaseUri)
     {
         @EmptyLine
@@ -47,8 +45,7 @@ type @(Model.BaseClient) struct {
     @if (!Model.IsCustomBaseUri)
     {
         @:BaseURI string
-    }    
-    APIVersion string
+    }
     @foreach (var p in Model.Properties)
     {
         if (!p.SerializedName.FixedValue.IsApiVersion())
@@ -83,7 +80,6 @@ func New(@(Model.GlobalParameters))@(Model.BaseClient) {
         return @(Model.BaseClient){
             Client: autorest.NewClientWithUserAgent(UserAgent()),
             BaseURI: baseURI,
-            APIVersion: APIVersion,
             @foreach (var p in Model.Properties)
             {
                 if (!p.SerializedName.Value.IsApiVersion())
@@ -103,7 +99,6 @@ else
     func NewWithoutDefaults(@(Model.AllGlobalParameters)) @(Model.BaseClient) {
         return @(Model.BaseClient){
             Client: autorest.NewClientWithUserAgent(UserAgent()),
-            APIVersion: APIVersion,
             @foreach(var p in Model.Properties)
             {
                 if (!p.SerializedName.Value.IsApiVersion())


### PR DESCRIPTION
Instead, a const is generated in each method that will serve to provide the APIVersion if present. This was done in order to ensure that composite swaggers which have multiple APIVersions associated with their operations are supported.

One upside, is that APIVersion will no longer be present in swaggers that do not contain it. Pet Store should not have a reference to APIVersion.

Regenerating samples.