### PR TITLE
Document that dotnet sdk is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,14 @@ AutoRest has been thru a lot of changes recently, most notably:
 
 # Installing Autorest 
 
-Installing AutoRest on Windows, MacOS or Linux involves two steps:
+Installing AutoRest on Windows, MacOS or Linux involves three steps:
 
-1. __Install [Node.js](https://nodejs.org/en/)__ (6.9.5 or greater)
+1. __Install [.NET Core SDK](https://www.microsoft.com/net/core)__
+
+2. __Install [Node.js](https://nodejs.org/en/)__ (6.9.5 or greater)
 > for more help, check out [Installing Node.JS on different platforms](./docs/developer/workstation.md#nodejs)
 
-2. __Install AutoRest__ using `npm`
+3. __Install AutoRest__ using `npm`
 
   ``` powershell
   # Depending on your configuration you may need to be elevated or root to run this. (on OSX/Linux use 'sudo' )


### PR DESCRIPTION
Without dotnet sdk installed I get this error:

```
(c) 2017 Microsoft Corporation. https://aka.ms/autorest
  Build Information
  Autorest Bootstrapper :  0.9.21
  NetCore framework :      1.0.3
  Latest Core Installed :  1.0.1-20170327-2300-nightly
  Requested Core Version : <none>

Output Verbosity

  --verbose            show verbose output information
  --debug              show internal debug information
  --quiet              suppress output

Versions

  --list-installed     show all installed versions of AutoRest tools
  --list-available=nn  lists the last nn releases available from github
                        (defaults to 10)

Installation

  --version=version    uses version of AutoRest, installing if necessary.
                        for version you can
                        use a version label (see --list-available) or
                          latest         - get latest nightly build
                          latest-release - get latest release version
  --reset              remove all installed versions of AutoRest tools
                        and install the latest (override with --version)

Using AutoRest
{ Error: spawn dotnet ENOENT
    at exports._errnoException (util.js:1018:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:367:16)
    at _combinedTickCallback (internal/process/next_tick.js:80:11)
    at process._tickCallback (internal/process/next_tick.js:104:9)
  code: 'ENOENT',
  errno: 'ENOENT',
  syscall: 'spawn dotnet',
  path: 'dotnet',
  spawnargs:
   [ 'C:\\Users\\jaredmoo\\.autorest\\plugins\\autorest\\1.0.1-20170327-2300-nightly\\AutoRest.dll',
     '-Help' ] }
```