### PR TITLE
Awesome Features

### DIFF
--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -38,6 +38,13 @@ async function legacyMain(autorestArgs: string[]): Promise<void> {
     const currentDirUri = CreateFolderUri(currentDirectory());
     const dataStore = new DataStore();
     const config = await CreateConfiguration(currentDirUri, dataStore.CreateScope("input").AsFileScopeReadThrough(x => true /*unsafe*/), autorestArgs);
+
+    // autorest init
+    if (autorestArgs[0] === "init") {
+      console.log(JSON.stringify(config, null, 2));
+      return;
+    }
+
     config["base-folder"] = currentDirUri;
     const api = new AutoRest(new RealFileSystem());
     await api.AddConfiguration(config);

--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -10,7 +10,8 @@
 // this file should get 'required' by the boostrapper
 require("./lib/polyfill.min.js");
 
-import { CreateObject, parse } from "./lib/ref/jsonpath";
+import { Stringify } from "./lib/ref/yaml";
+import { CreateObject, nodes } from './lib/ref/jsonpath';
 import { OutstandingTaskAwaiter } from "./lib/outstanding-task-awaiter";
 import { AutoRest } from "./lib/autorest-core";
 import { resolve as currentDirectory } from "path";
@@ -41,7 +42,29 @@ async function legacyMain(autorestArgs: string[]): Promise<void> {
 
     // autorest init
     if (autorestArgs[0] === "init") {
-      console.log(JSON.stringify(config, null, 2));
+      console.log(`# AutoRest Configuration (auto-generated, please adjust title)
+
+> see https://aka.ms/autorest
+
+The following configuration was auto-generated and can be adjusted.
+
+~~~ yaml
+${Stringify(config).replace(/^---\n/, "")}
+~~~
+
+`.replace(/~/g, "`"));
+      return;
+    }
+    if (autorestArgs[0] === "init-cli") {
+      const args: string[] = [];
+      for (const node of nodes(config, "$..*")) {
+        const path = node.path.join(".");
+        const values = node.value instanceof Array ? node.value : (typeof node.value === "object" ? [] : [node.value]);
+        for (const value of values) {
+          args.push(`--${path}=${value}`);
+        }
+      }
+      console.log(args.join(" "));
       return;
     }
 

--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -34,7 +34,7 @@ function awaitable(child: ChildProcess): Promise<number> {
 }
 
 async function legacyMain(autorestArgs: string[]): Promise<void> {
-  if (autorestArgs.indexOf("-LEGACY") === -1) {
+  if (autorestArgs.indexOf("-FANCY") !== -1) {
     // generate virtual config file
     const currentDirUri = CreateFolderUri(currentDirectory());
     const dataStore = new DataStore();

--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -33,7 +33,7 @@ function awaitable(child: ChildProcess): Promise<number> {
 }
 
 async function legacyMain(autorestArgs: string[]): Promise<void> {
-  if (autorestArgs.indexOf("-FANCY") !== -1) {
+  if (autorestArgs.indexOf("-LEGACY") === -1) {
     // generate virtual config file
     const currentDirUri = CreateFolderUri(currentDirectory());
     const dataStore = new DataStore();

--- a/src/autorest-core/legacyCli.ts
+++ b/src/autorest-core/legacyCli.ts
@@ -21,8 +21,7 @@ async function ParseCompositeSwagger(inputScope: DataStoreViewReadonly, uri: str
   targetConfig["input-file"] = documents.map(d => ResolveUri(uri, d));
 
   // forward info section
-  targetConfig.__specials = targetConfig.__specials || {};
-  targetConfig.__specials.infoSectionOverride = data.info;
+  targetConfig["override-info"] = data.info;
 }
 
 export async function CreateConfiguration(baseFolderUri: string, inputScope: DataStoreViewReadonly, args: string[]): Promise<AutoRestConfigurationImpl> {
@@ -51,8 +50,7 @@ export async function CreateConfiguration(baseFolderUri: string, inputScope: Dat
 
   result["output-folder"] = switches["o"] || switches["output"] || switches["outputdirectory"] || "Generated";
 
-  result.__specials = result.__specials || {};
-  result.__specials.namespace = switches["n"] || switches["namespace"] || GetFilenameWithoutExtension(inputFile);
+  result["namespace"] = switches["n"] || switches["namespace"] || GetFilenameWithoutExtension(inputFile);
 
   const modeler = switches["m"] || switches["modeler"] || "Swagger";
   if (modeler === "CompositeSwagger") {
@@ -61,11 +59,10 @@ export async function CreateConfiguration(baseFolderUri: string, inputScope: Dat
 
   const codegenerator = switches["g"] || switches["codegenerator"] || "CSharp";
   const usedCodeGenerator = codegenerator.toLowerCase().replace("azure.", "").replace(".fluent", "");
-  result.__specials = result.__specials || {};
   if (codegenerator.toLowerCase() === "none") {
     result["azure-arm"] = true;
   } else {
-    result[usedCodeGenerator] = {};
+    (<any>result)[usedCodeGenerator] = {};
     if (codegenerator.toLowerCase().startsWith("azure.")) {
       result["azure-arm"] = true;
       result["disable-validation"] = true;
@@ -75,21 +72,23 @@ export async function CreateConfiguration(baseFolderUri: string, inputScope: Dat
     }
   }
 
-  result.__specials.header = switches["header"] || null;
+  result["license-header"] = switches["header"] || undefined;
 
-  result.__specials.payloadFlatteningThreshold = parseInt(switches["fs"] || switches["payloadflatteningthreshold"] || "0");
+  result["payload-flattening-threshold"] = parseInt(switches["fs"] || switches["payloadflatteningthreshold"] || "0");
 
-  result.__specials.syncMethods = <any>switches["syncmethods"] || null;
+  result["sync-methods"] = <any>switches["syncmethods"] || null;
 
-  result.__specials.addCredentials = switches["addcredentials"] === null || ((switches["addcredentials"] + "").toLowerCase() === "true");
+  result["add-credentials"] = switches["addcredentials"] === null || ((switches["addcredentials"] + "").toLowerCase() === "true");
 
-  result.__specials.rubyPackageName = GetFilenameWithoutExtension(inputFile).replace(/[^a-zA-Z0-9-_]/g, "").replace(/-/g, '_').replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase();
+  if (usedCodeGenerator === "ruby") {
+    result["package-name"] = GetFilenameWithoutExtension(inputFile).replace(/[^a-zA-Z0-9-_]/g, "").replace(/-/g, '_').replace(/([a-z])([A-Z])/g, "$1_$2").toLowerCase();
+  }
 
-  result.__specials.outputFile = switches["outputfilename"] || null;
+  result["output-file"] = switches["outputfilename"] || undefined;
 
   if (codegenerator.toLowerCase() === "swaggerresolver") {
     result["output-artifact"] = "swagger-document";
-    delete result[usedCodeGenerator];
+    delete (result as any)[usedCodeGenerator];
   }
 
   return result;

--- a/src/autorest-core/legacyCli.ts
+++ b/src/autorest-core/legacyCli.ts
@@ -33,7 +33,7 @@ export async function CreateConfiguration(baseFolderUri: string, inputScope: Dat
 
   // parse
   let lastValue: string | null = null;
-  for (const arg of args.reverse()) {
+  for (const arg of args.slice().reverse()) {
     if (arg.startsWith("-")) {
       switches[arg.substr(1).toLowerCase()] = lastValue;
       lastValue = null;

--- a/src/autorest-core/legacyCli.ts
+++ b/src/autorest-core/legacyCli.ts
@@ -86,6 +86,8 @@ export async function CreateConfiguration(baseFolderUri: string, inputScope: Dat
 
   result["output-file"] = switches["outputfilename"] || undefined;
 
+  result["message-format"] = switches["jsonvalidationmessages"] !== undefined ? "json" : undefined;
+
   if (codegenerator.toLowerCase() === "swaggerresolver") {
     result["output-artifact"] = "swagger-document";
     delete (result as any)[usedCodeGenerator];

--- a/src/autorest-core/lib/autorest-core.ts
+++ b/src/autorest-core/lib/autorest-core.ts
@@ -39,6 +39,7 @@ export class AutoRest extends EventEmitter {
    */
   public constructor(private fileSystem?: IFileSystem, public configFileUri?: string) {
     super();
+    this.Fatal.Subscribe((_, m) => console.error(m.Text));
   }
 
 

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -30,6 +30,7 @@ export interface AutoRestConfigurationImpl {
   "base-folder"?: string;
   "directive"?: Directive[] | Directive;
   "output-artifact"?: string[] | string;
+  "message-format"?: "json";
 
   // plugin specific
   "output-file"?: string;

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -149,7 +149,7 @@ export class ConfigurationView extends EventEmitter {
   }
 
   /* @internal */
-  public readonly DataStore: DataStore;
+  public DataStore: DataStore;
 
   private cancellationTokenSource = new CancellationTokenSource();
   /* @internal */
@@ -196,6 +196,10 @@ export class ConfigurationView extends EventEmitter {
     return this.ResolveAsFolder(this.config["output-folder"] || "generated");
   }
 
+  public get OutputArtifact(): Iterable<string> {
+    return ValuesOf<string>(this.config["output-artifact"]);
+  }
+
   public get __specials(): AutoRestConfigurationSpecials {
     return From(ValuesOf(this.config.__specials)).FirstOrDefault() || {};
   }
@@ -216,11 +220,19 @@ export class ConfigurationView extends EventEmitter {
     return this.config["fluent"] || false;
   }
 
-  public get OutputArtifact(): Iterable<string> {
-    return ValuesOf<string>(this.config["output-artifact"]);
+  public GetPluginView(pluginName: string): ConfigurationView {
+    const result = new ConfigurationView(this.configFileFolderUri, this.config[pluginName], this.config);
+    result.DataStore = this.DataStore;
+    result.cancellationTokenSource = this.cancellationTokenSource;
+    result.GeneratedFile = this.GeneratedFile;
+    result.Information = this.Information;
+    result.Warning = this.Warning;
+    result.Error = this.Error;
+    result.Debug = this.Debug;
+    result.Verbose = this.Verbose;
+    result.Fatal = this.Fatal;
+    return result;
   }
-
-  // TODO: stuff like generator specific settings (= YAML merging root with generator's section)
 }
 
 

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -224,13 +224,13 @@ export class ConfigurationView extends EventEmitter {
     const result = new ConfigurationView(this.configFileFolderUri, this.config[pluginName], this.config);
     result.DataStore = this.DataStore;
     result.cancellationTokenSource = this.cancellationTokenSource;
-    result.GeneratedFile = this.GeneratedFile;
-    result.Information = this.Information;
-    result.Warning = this.Warning;
-    result.Error = this.Error;
-    result.Debug = this.Debug;
-    result.Verbose = this.Verbose;
-    result.Fatal = this.Fatal;
+    result.GeneratedFile.Subscribe((_, m) => this.GeneratedFile.Dispatch(m));
+    result.Information.Subscribe((_, m) => this.Information.Dispatch(m));
+    result.Warning.Subscribe((_, m) => this.Warning.Dispatch(m));
+    result.Error.Subscribe((_, m) => this.Error.Dispatch(m));
+    result.Debug.Subscribe((_, m) => this.Debug.Dispatch(m));
+    result.Verbose.Subscribe((_, m) => this.Verbose.Dispatch(m));
+    result.Fatal.Subscribe((_, m) => this.Fatal.Dispatch(m));
     return result;
   }
 }

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -24,29 +24,28 @@ import { Message } from "./message";
 import { Artifact } from "./artifact";
 import { CancellationTokenSource, CancellationToken } from "./ref/cancallation";
 
-export interface AutoRestConfigurationSpecials {
-  infoSectionOverride?: any; // from composite swagger file, no equivalent (yet) in config file; IF DOING THAT: also make sure source maps are pulling it! (see "composite swagger" method)
-  header?: string | null;
-  namespace?: string;
-  payloadFlatteningThreshold?: number;
-  syncMethods?: "all" | "essential" | "none";
-  addCredentials?: boolean;
-  rubyPackageName?: string; // TODO: figure out which settings are really just cared about by plugins and then DON'T specify them here (maybe give conventions)
-  outputFile?: string | null;
-}
-
 export interface AutoRestConfigurationImpl {
-  [key: string]: any;
   __info?: string | null;
-  __specials?: AutoRestConfigurationSpecials;
   "input-file": string[] | string;
-  "output-folder"?: string; // TODO: could also be generator specific! (also makes a ton of sense, if you wanna generate for multiple languages at once...)
   "base-folder"?: string;
   "directive"?: Directive[] | Directive;
   "output-artifact"?: string[] | string;
-  "azure-arm"?: boolean | null;
-  "disable-validation"?: boolean | null;
-  "fluent"?: boolean | null;
+
+  // plugin specific
+  "output-file"?: string;
+  "output-folder"?: string;
+  "disable-validation"?: boolean;
+
+  // from here on: CONVENTION, not cared about by the core
+  "fluent"?: boolean; // TODO: pass to generator instead of handling here
+  "azure-arm"?: boolean; // TODO: pass to generator instead of handling here & enable tooling using guard in default config!
+  "override-info"?: any; // make sure source maps are pulling it! (see "composite swagger" method)
+  "namespace"?: string; // TODO: the modeler cares :( because it is badly designed
+  "license-header"?: string;
+  "add-credentials"?: boolean;
+  "package-name"?: string; // Ruby
+  "sync-methods"?: "all" | "essential" | "none";
+  "payload-flattening-threshold"?: number;
 }
 
 // TODO: operate on DataHandleRead and create source map!
@@ -200,12 +199,8 @@ export class ConfigurationView extends EventEmitter {
     return ValuesOf<string>(this.config["output-artifact"]);
   }
 
-  public get __specials(): AutoRestConfigurationSpecials {
-    return From(ValuesOf(this.config.__specials)).FirstOrDefault() || {};
-  }
-
-  public PluginSection(pluginName: string): AutoRestConfigurationImpl {
-    return this.config[pluginName];
+  public GetEntry(key: keyof AutoRestConfigurationImpl): any {
+    return (this.config as any)[key];
   }
 
   public get DisableValidation(): boolean {
@@ -221,7 +216,7 @@ export class ConfigurationView extends EventEmitter {
   }
 
   public GetPluginView(pluginName: string): ConfigurationView {
-    const result = new ConfigurationView(this.configFileFolderUri, this.config[pluginName], this.config);
+    const result = new ConfigurationView(this.configFileFolderUri, (this.config as any)[pluginName], this.config);
     result.DataStore = this.DataStore;
     result.cancellationTokenSource = this.cancellationTokenSource;
     result.GeneratedFile.Subscribe((_, m) => this.GeneratedFile.Dispatch(m));

--- a/src/autorest-core/lib/pipeline/commonmark-documentation.ts
+++ b/src/autorest-core/lib/pipeline/commonmark-documentation.ts
@@ -78,5 +78,5 @@ export async function ProcessCodeModel(codeModel: DataHandleRead, scope: DataSto
   }
 
   const targetHandle = await scope.Write("codeModel.yaml");
-  return await targetHandle.WriteData(JSON.stringify(ParseNode(ast), null, 4), mapping, [codeModel]);
+  return await targetHandle.WriteData(StringifyAst(ast), mapping, [codeModel]);
 }

--- a/src/autorest-core/lib/pipeline/commonmark-documentation.ts
+++ b/src/autorest-core/lib/pipeline/commonmark-documentation.ts
@@ -3,22 +3,23 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Mapping, SmartPosition } from '../ref/source-map';
-import { Parser, Node } from '../ref/commonmark';
-import { JsonPath } from '../ref/jsonpath';
+import { Mapping, SmartPosition } from "../ref/source-map";
+import { Parser, Node } from "../ref/commonmark";
+import { JsonPath } from "../ref/jsonpath";
 import {
   CloneAst,
   CreateYAMLMapping,
   CreateYAMLScalar,
   Descendants,
   Kind,
+  ParseNode,
   StringifyAst,
   YAMLMap,
   YAMLMapping
-} from '../ref/yaml';
-import { IdentitySourceMapping } from '../source-map/merging';
+} from "../ref/yaml";
+import { IdentitySourceMapping } from "../source-map/merging";
 import { From } from "../ref/linq";
-import { DataHandleRead, DataHandleWrite, DataStoreView } from '../data-store/data-store';
+import { DataHandleRead, DataHandleWrite, DataStoreView } from "../data-store/data-store";
 
 function IsDocumentationField(path: JsonPath) {
   const last = path[path.length - 1];
@@ -77,5 +78,5 @@ export async function ProcessCodeModel(codeModel: DataHandleRead, scope: DataSto
   }
 
   const targetHandle = await scope.Write("codeModel.yaml");
-  return await targetHandle.WriteData(StringifyAst(ast), mapping, [codeModel]);
+  return await targetHandle.WriteData(JSON.stringify(ParseNode(ast), null, 4), mapping, [codeModel]);
 }

--- a/src/autorest-core/lib/pipeline/commonmark-documentation.ts
+++ b/src/autorest-core/lib/pipeline/commonmark-documentation.ts
@@ -1,0 +1,81 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { Mapping, SmartPosition } from '../ref/source-map';
+import { Parser, Node } from '../ref/commonmark';
+import { JsonPath } from '../ref/jsonpath';
+import {
+  CloneAst,
+  CreateYAMLMapping,
+  CreateYAMLScalar,
+  Descendants,
+  Kind,
+  StringifyAst,
+  YAMLMap,
+  YAMLMapping
+} from '../ref/yaml';
+import { IdentitySourceMapping } from '../source-map/merging';
+import { From } from "../ref/linq";
+import { DataHandleRead, DataHandleWrite, DataStoreView } from '../data-store/data-store';
+
+function IsDocumentationField(path: JsonPath) {
+  const last = path[path.length - 1];
+  return last === "Description" || last === "Summary";
+}
+
+export function PlainTextVersion(commonmarkAst: Node): string {
+  let result = "";
+  const walker = commonmarkAst.walker();
+  let event;
+  while ((event = walker.next())) {
+    const node = event.node;
+    // console.log(node);
+    switch (node.type) {
+      case "text": result += node.literal; break;
+      case "code": result += node.literal; break;
+      case "softbreak": result += " "; break;
+      case "paragraph": if (!event.entering) { result += "\n"; } break;
+      case "heading": if (!event.entering) { result += "\n"; } break;
+    }
+  }
+  return result.trim();
+}
+
+export async function ProcessCodeModel(codeModel: DataHandleRead, scope: DataStoreView): Promise<DataHandleRead> {
+  const ast = CloneAst(await codeModel.ReadYamlAst());
+  let mapping = From(IdentitySourceMapping(codeModel.key, ast));
+
+  const cmParser = new Parser();
+
+  // transform
+  for (const d of Descendants(ast, [], true)) {
+    if (d.node.kind === Kind.MAPPING && IsDocumentationField(d.path)) {
+      const node = d.node as YAMLMapping;
+      const rawMarkdown = node.value.value;
+
+      // inject new child for original value into parent
+      const parent = node.parent as YAMLMap;
+      const nodeOriginal = CloneAst(node);
+      const key = nodeOriginal.key.value;
+      const origKey = key + "_Original";
+      nodeOriginal.key.value = origKey
+      parent.mappings.push(nodeOriginal);
+      mapping = mapping.Concat([<Mapping>{
+        name: "original gfm",
+        generated: <SmartPosition>{ path: d.path.map((x, i) => i === d.path.length - 1 ? origKey : x) },
+        original: <SmartPosition>{ path: d.path },
+        source: codeModel.key
+      }]);
+
+      // sanitize
+      const parsed = cmParser.parse(rawMarkdown);
+      const plainText = PlainTextVersion(parsed);
+      node.value = CreateYAMLScalar(plainText);
+    }
+  }
+
+  const targetHandle = await scope.Write("codeModel.yaml");
+  return await targetHandle.WriteData(StringifyAst(ast), mapping, [codeModel]);
+}

--- a/src/autorest-core/lib/pipeline/manipulation.ts
+++ b/src/autorest-core/lib/pipeline/manipulation.ts
@@ -38,12 +38,12 @@ export class Manipulator {
         for (const w of trans.where) {
           // transform
           for (const t of trans.transform) {
-            const target = await scope.Write("transform_" + nextId());
+            const target = await scope.Write(`transform_${nextId()}.yaml`);
             data = (await ManipulateObject(data, target, w, obj => safeEval(t, { $: obj }))).result;
           }
           // set
           for (const s of trans.set) {
-            const target = await scope.Write("set_" + nextId());
+            const target = await scope.Write(`set_${nextId()}.yaml`);
             data = (await ManipulateObject(data, target, w, obj => s)).result;
           }
         }

--- a/src/autorest-core/lib/pipeline/manipulation.ts
+++ b/src/autorest-core/lib/pipeline/manipulation.ts
@@ -1,0 +1,57 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { safeEval } from "../ref/safe-eval";
+import { ManipulateObject } from "./object-manipulator";
+import { DataHandleRead, DataStoreView } from "../data-store/data-store";
+import { DirectiveView } from "../configuration";
+import { ConfigurationView } from "../autorest-core";
+import { From } from "../ref/linq";
+
+export class Manipulator {
+  private transformations: DirectiveView[];
+
+  public constructor(private config: ConfigurationView) {
+    this.transformations = From(config.Directives).Where(x => [...x.transform].length > 0 || [...x.set].length > 0).ToArray();
+  }
+
+  private MatchesSourceFilter(document: string, transform: DirectiveView): boolean {
+    // from
+    const from = From(transform.from);
+    const matchesFrom = !from.Any() || from
+      .Select(d => d.toLowerCase())
+      .Any(d =>
+        document.toLowerCase().endsWith(d) ||
+        document.toLowerCase().indexOf("/" + d) !== -1);
+
+    return matchesFrom;
+  }
+
+  public async Process(data: DataHandleRead, scope: DataStoreView, documentId?: string): Promise<DataHandleRead> {
+    let nextId = (() => { let i = 0; return () => ++i; })();
+
+    for (const trans of this.transformations) {
+      // matches filter?
+      if (this.MatchesSourceFilter(documentId || data.key, trans)) {
+        for (const w of trans.where) {
+          // transform
+          for (const t of trans.transform) {
+            const target = await scope.Write("transform_" + nextId());
+            data = (await ManipulateObject(data, target, w, obj => safeEval(t, { $: obj }))).result;
+          }
+          // set
+          for (const s of trans.set) {
+            const target = await scope.Write("set_" + nextId());
+            data = (await ManipulateObject(data, target, w, obj => s)).result;
+          }
+        }
+      }
+    }
+
+    return data;
+  }
+
+  // TODO: make method that'll warn about transforms that weren't used!
+}

--- a/src/autorest-core/lib/pipeline/object-manipulator.ts
+++ b/src/autorest-core/lib/pipeline/object-manipulator.ts
@@ -3,18 +3,17 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { CreateAssignmentMapping } from '../source-map/source-map';
-import { IdentitySourceMapping } from '../source-map/merging';
-import { Descendants, StringifyAst, ToAst, YAMLNode } from '../ref/yaml';
-import { ReplaceNode, ResolvePath, ResolveRelativeNode } from '../parsing/yaml';
-import { DataHandleRead, DataStoreView } from '../data-store/data-store';
-import { IsPrefix, JsonPath, nodes, stringify } from '../ref/jsonpath';
-import { Mapping, SmartPosition } from '../ref/source-map';
-import { From } from '../ref/linq';
+import { IdentitySourceMapping } from "../source-map/merging";
+import { Descendants, StringifyAst, ToAst, YAMLNode } from "../ref/yaml";
+import { ReplaceNode, ResolveRelativeNode } from "../parsing/yaml";
+import { DataHandleRead, DataHandleWrite } from "../data-store/data-store";
+import { IsPrefix, JsonPath, nodes, stringify } from "../ref/jsonpath";
+import { Mapping, SmartPosition } from "../ref/source-map";
+import { From } from "../ref/linq";
 
 export async function ManipulateObject(
   src: DataHandleRead,
-  workingScope: DataStoreView,
+  target: DataHandleWrite,
   whereJsonQuery: string,
   transformer: (obj: any) => any, // transforming to `undefined` results in removal
   mappingInfo?: {
@@ -72,8 +71,7 @@ export async function ManipulateObject(
   }
 
   // write back
-  const targetHandle = await workingScope.Write("transformed");
-  const resultHandle = await targetHandle.WriteData(StringifyAst(ast), mapping, mappingInfo ? [src, mappingInfo.transformerSourceHandle] : [src]);
+  const resultHandle = await target.WriteData(StringifyAst(ast), mapping, mappingInfo ? [src, mappingInfo.transformerSourceHandle] : [src]);
   return {
     anyHit: true,
     result: resultHandle

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -49,7 +49,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
   // load Swaggers
   let inputs = From(config.InputFileUris).ToArray();
   if (inputs.length === 0) {
-    throw new Error("No input files provided.");
+    throw "No input files provided.\n\nUse --help to get help information.";
   }
 
   config.Debug.Dispatch({ Text: `Starting Pipeline - Loading literate swaggers ${inputs}` });

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -1,9 +1,10 @@
-import { IdentitySourceMapping } from '../source-map/merging';
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { ProcessCodeModel } from './commonmark-documentation';
+import { IdentitySourceMapping } from '../source-map/merging';
 import { OutstandingTaskAwaiter } from "../outstanding-task-awaiter";
 import { BlameTree } from '../source-map/blaming';
 import { Artifact } from '../artifact';
@@ -174,6 +175,9 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
         },
         messageSink);
 
+      // GFMer
+      const codeModelGFM = await ProcessCodeModel(codeModel, config.DataStore.CreateScope("modelgfm"));
+
       for (const usedCodeGenerator of usedCodeGenerators) {
         // get internal name
         const languages = [
@@ -187,7 +191,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
         const codeGenerator = (config.AzureArm ? "Azure." : "") + languages + (config.Fluent ? ".Fluent" : "");
 
         const getXmsCodeGenSetting = (name: string) => (() => { try { return rawSwagger.info["x-ms-code-generation-settings"][name]; } catch (e) { return null; } })();
-        let generatedFileScope = await autoRestDotNetPlugin.GenerateCode(codeModel, config.DataStore.CreateScope("generate"),
+        let generatedFileScope = await autoRestDotNetPlugin.GenerateCode(codeModelGFM, config.DataStore.CreateScope("generate"),
           {
             namespace: config.__specials.namespace || "",
             codeGenerator: codeGenerator,

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -75,7 +75,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
   config.Debug.Dispatch({ Text: `Done Composing Swaggers.` });
 
   // TRANSFORM
-  swagger = await manipulator.Process(swagger, config.DataStore.CreateScope("composed-transform"), "/composed.yaml");
+  swagger = await manipulator.Process(swagger, config.DataStore.CreateScope("composite-transform"), "/composite.yaml");
 
   // emit resolved swagger
   {
@@ -173,8 +173,6 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
       }
     };
 
-
-
     // code generators
     if (usedCodeGenerators.length > 0) {
       // modeler
@@ -192,6 +190,8 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
 
         // TRANSFORM
         const codeModelTransformed = await manipulator.Process(codeModelGFM, scope.CreateScope("transform"), "/model.yaml");
+
+        await emitArtifact("code-model-v1", "mem://code-model.yaml", codeModelTransformed);
 
         // get internal name
         const languages = [

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -3,6 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
+import { stringify } from '../ref/jsonpath';
 import { Manipulator } from "./manipulation";
 import { ProcessCodeModel } from "./commonmark-documentation";
 import { IdentitySourceMapping } from "../source-map/merging";
@@ -152,6 +153,22 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
 
         // forward
         if (mx !== null) {
+          // format message
+          switch (config.GetEntry("message-format")) {
+            case "json":
+              mx.Text = JSON.stringify(mx.Details, null, 2);
+              break;
+            default:
+              let text = (mx.Channel || Channel.Information).toString().toUpperCase() + ": " + mx.Text;
+              for (const source of mx.Source || []) {
+                if (source.Position && source.Position.path) {
+                  text += `\n        Path: ${source.document}#${stringify(source.Position.path)}`;
+                }
+              }
+              mx.Text = text;
+              break;
+          }
+
           sink.Dispatch(mx);
         }
       } catch (e) {

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -179,6 +179,8 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
       const codeModelGFM = await ProcessCodeModel(codeModel, config.DataStore.CreateScope("modelgfm"));
 
       for (const usedCodeGenerator of usedCodeGenerators) {
+        const scope = config.DataStore.CreateScope(usedCodeGenerator);
+
         // get internal name
         const languages = [
           "CSharp",
@@ -191,7 +193,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
         const codeGenerator = (config.AzureArm ? "Azure." : "") + languages + (config.Fluent ? ".Fluent" : "");
 
         const getXmsCodeGenSetting = (name: string) => (() => { try { return rawSwagger.info["x-ms-code-generation-settings"][name]; } catch (e) { return null; } })();
-        let generatedFileScope = await autoRestDotNetPlugin.GenerateCode(codeModelGFM, config.DataStore.CreateScope("generate"),
+        let generatedFileScope = await autoRestDotNetPlugin.GenerateCode(codeModelGFM, scope.CreateScope("generate"),
           {
             namespace: config.__specials.namespace || "",
             codeGenerator: codeGenerator,
@@ -208,7 +210,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
 
         // C# simplifier
         if (codeGenerator.toLowerCase().indexOf("csharp") !== -1) {
-          generatedFileScope = await autoRestDotNetPlugin.SimplifyCSharpCode(generatedFileScope, config.DataStore.CreateScope("simplify"), messageSink);
+          generatedFileScope = await autoRestDotNetPlugin.SimplifyCSharpCode(generatedFileScope, scope.CreateScope("simplify"), messageSink);
         }
 
         for (const fileName of await generatedFileScope.Enum()) {

--- a/src/autorest-core/lib/pipeline/supression.ts
+++ b/src/autorest-core/lib/pipeline/supression.ts
@@ -1,14 +1,14 @@
-import { Artifact } from '../artifact';
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DirectiveView } from '../configuration';
-import { Message, SourceLocation } from '../message';
-import { ConfigurationView } from '../autorest-core';
-import { IsPrefix, JsonPath, paths, stringify, matches } from '../ref/jsonpath';
-import { From } from '../ref/linq';
+import { Artifact } from "../artifact";
+import { DirectiveView } from "../configuration";
+import { Message, SourceLocation } from "../message";
+import { ConfigurationView } from "../autorest-core";
+import { IsPrefix, JsonPath, paths, stringify, matches } from "../ref/jsonpath";
+import { From } from "../ref/linq";
 
 export class Supressor {
   private suppressions: DirectiveView[];

--- a/src/autorest-core/lib/ref/yaml.ts
+++ b/src/autorest-core/lib/ref/yaml.ts
@@ -19,6 +19,9 @@ export type YAMLMap = yamlAst.YamlMap;
 export type YAMLSequence = yamlAst.YAMLSequence;
 export type YAMLAnchorReference = yamlAst.YAMLAnchorReference;
 
+export const CreateYAMLMapping: (key: YAMLScalar, value: YAMLNode) => YAMLMapping = yamlAst.newMapping;
+export const CreateYAMLScalar: (value: string) => YAMLScalar = yamlAst.newScalar;
+
 export interface YAMLNodeWithPath {
   path: JsonPath;
   node: YAMLNode;
@@ -116,8 +119,8 @@ export function ParseNode<T>(yamlNode: YAMLNode): T {
   return yamlNode.valueObject;
 }
 
-export function CloneAst(ast: YAMLNode): YAMLNode {
-  return ParseToAst(StringifyAst(ast));
+export function CloneAst<T extends YAMLNode>(ast: T): T {
+  return ParseToAst(StringifyAst(ast)) as T;
 }
 export function StringifyAst(ast: YAMLNode): string {
   return Stringify(ParseNode<any>(ast));

--- a/src/autorest-core/resources/default-configuration.json
+++ b/src/autorest-core/resources/default-configuration.json
@@ -1,6 +1,6 @@
 {
   "azure-arm": false,
-  "output-folder": "$(base-folder)/generated",
+  "output-folder": "generated",
   "disable-validation": false,
   "output-artifact": [
     "source-files-csharp",

--- a/src/autorest-core/test/commonmark.ts
+++ b/src/autorest-core/test/commonmark.ts
@@ -19,6 +19,8 @@ import { PlainTextVersion } from "../lib/pipeline/commonmark-documentation";
     compare("actual\n\nnewline", "actual\nnewline");
     compare("some **more** delicious *cowbell*", "some more delicious cowbell");
     compare("add some `code` in there", "add some code in there");
-    compare(`# Heading \n Body`, "Heading\nBody");
+    compare("# Heading \n Body", "Heading\nBody");
+    compare("Fancy <b>html</b> features", "Fancy html features");
+    compare("Even <code>fancier</code> <i>html</i> tags<br> and<hr> stuff", "Even fancier html tags and stuff");
   }
 }

--- a/src/autorest-core/test/commonmark.ts
+++ b/src/autorest-core/test/commonmark.ts
@@ -1,0 +1,24 @@
+import { suite, test, slow, timeout, skip, only } from "mocha-typescript";
+import * as assert from "assert";
+
+import { Node, Parser } from "../lib/ref/commonmark";
+import { PlainTextVersion } from "../lib/pipeline/commonmark-documentation";
+
+@suite class Commonmark {
+
+  private Parse(rawCommonmark: string): Node {
+    return new Parser().parse(rawCommonmark);
+  }
+
+  @test @timeout(30000) async "PlainTextVersion"() {
+    const compare = (raw: string, expected: string) =>
+      assert.strictEqual(PlainTextVersion(this.Parse(raw)), expected);
+
+    compare("Hello World", "Hello World");
+    compare("this\ntest\ncould\nuse\nmore\ncowbell", "this test could use more cowbell");
+    compare("actual\n\nnewline", "actual\nnewline");
+    compare("some **more** delicious *cowbell*", "some more delicious cowbell");
+    compare("add some `code` in there", "add some code in there");
+    compare(`# Heading \n Body`, "Heading\nBody");
+  }
+}

--- a/src/autorest-core/test/object-manipulator.ts
+++ b/src/autorest-core/test/object-manipulator.ts
@@ -44,7 +44,7 @@ definitions:
     const input = await inputWrite.WriteData(this.exampleObject);
 
     const expectHit = async (jsonQuery: string, anyHit: boolean) => {
-      const result = await ManipulateObject(input, dataStore.CreateScope(`manip${(await dataStore.Enum()).length}`), jsonQuery, x => x);
+      const result = await ManipulateObject(input, await dataStore.Write(`manip${(await dataStore.Enum()).length}`), jsonQuery, x => x);
       assert.strictEqual(result.anyHit, anyHit, jsonQuery);
     };
 
@@ -69,7 +69,7 @@ definitions:
     const input = await inputWrite.WriteData(this.exampleObject);
 
     // remove all models that don't have a description
-    const result = await ManipulateObject(input, dataStore.CreateScope(`manip1`), "$.definitions[?(!@.description)]", x => undefined);
+    const result = await ManipulateObject(input, await dataStore.Write(`manip1`), "$.definitions[?(!@.description)]", x => undefined);
     assert.strictEqual(result.anyHit, true);
     const resultRaw = await result.result.ReadData();
     assert.ok(resultRaw.indexOf("NodeA") !== -1);
@@ -85,7 +85,7 @@ definitions:
     {
       // override all existing model descriptions
       const bestDescriptionEver = "best description ever";
-      const result = await ManipulateObject(input, dataStore.CreateScope(`manip1`), "$.definitions.*.description", x => bestDescriptionEver);
+      const result = await ManipulateObject(input, await dataStore.Write(`manip1`), "$.definitions.*.description", x => bestDescriptionEver);
       assert.strictEqual(result.anyHit, true);
       const resultObject = await result.result.ReadObject<any>();
       assert.strictEqual(resultObject.definitions.NodeA.description, bestDescriptionEver);
@@ -93,7 +93,7 @@ definitions:
     {
       // override & insert all model descriptions
       const bestDescriptionEver = "best description ever";
-      const result = await ManipulateObject(input, dataStore.CreateScope(`manip2`), "$.definitions.*", x => { x.description = bestDescriptionEver; return x; });
+      const result = await ManipulateObject(input, await dataStore.Write(`manip2`), "$.definitions.*", x => { x.description = bestDescriptionEver; return x; });
       assert.strictEqual(result.anyHit, true);
       const resultObject = await result.result.ReadObject<any>();
       assert.strictEqual(resultObject.definitions.NodeA.description, bestDescriptionEver);
@@ -102,7 +102,7 @@ definitions:
     {
       // make all descriptions upper case
       const bestDescriptionEver = "best description ever";
-      const result = await ManipulateObject(input, dataStore.CreateScope(`manip3`), "$..description", x => (x as string).toUpperCase());
+      const result = await ManipulateObject(input, await dataStore.Write(`manip3`), "$..description", x => (x as string).toUpperCase());
       assert.strictEqual(result.anyHit, true);
       const resultObject = await result.result.ReadObject<any>();
       assert.strictEqual(resultObject.definitions.NodeA.description, "DESCRIPTION");
@@ -111,7 +111,7 @@ definitions:
     {
       // make all descriptions upper case by using safe-eval
       const bestDescriptionEver = "best description ever";
-      const result = await ManipulateObject(input, dataStore.CreateScope(`manip4`), "$..description", x => safeEval("$.toUpperCase()", { $: x }));
+      const result = await ManipulateObject(input, await dataStore.Write(`manip4`), "$..description", x => safeEval("$.toUpperCase()", { $: x }));
       assert.strictEqual(result.anyHit, true);
       const resultObject = await result.result.ReadObject<any>();
       assert.strictEqual(resultObject.definitions.NodeA.description, "DESCRIPTION");

--- a/src/autorest-core/test/resources/literate-example/readme-single.md
+++ b/src/autorest-core/test/resources/literate-example/readme-single.md
@@ -22,7 +22,7 @@ Some information about My Sample API. It's a great API, and it's mine.
 
 or you could have it in a JSON block:
 
-``` json
+``` json $(false)
 {
   "Azure.NodeJS" : {
     "ouput-folder": "dnsManagement/lib",
@@ -34,7 +34,7 @@ or you could have it in a JSON block:
 ## CSharp Settings - Generates the c# version of the API
 
 ~~~ yaml  enabled: $longRunningTest, filename: foo.yaml 
-Azure.CSharp:
+cSharp:
     output-folder: csharp # relative to base-output 
     namespace: Microsoft.Api.Mysample
 
@@ -44,8 +44,8 @@ Azure.CSharp:
 
 ## NodeJS Settings - Generates the javascript version of the API
 
-``` yaml 
-Azure.NodeJS:
+``` yaml $(false)
+nodejs:
     output-folder : javascript  # relative to base-output 
     namespace : Microsoft.Mysample
 
@@ -55,7 +55,7 @@ Azure.NodeJS:
 
 ## Python settings
 
-    Azure.Python:
+    pythony: # spelled wrongly so it doesn't actually trigger code gen
         namespace: Microsoft.MyPyhtonSample
 
     # some more pythony settings...

--- a/src/core/AutoRest/Plugins/Generator.cs
+++ b/src/core/AutoRest/Plugins/Generator.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Perks.JsonRPC;
 using AutoRest.Core.Extensibility;
 using AutoRest.Core;
+using AutoRest.Core.Parsing;
 
 public class Generator : NewPlugin
 {
@@ -47,7 +48,7 @@ public class Generator : NewPlugin
     }
 
     var plugin = ExtensionsLoader.GetPlugin(codeGenerator);
-    var modelAsJson = await ReadFile(files[0]);
+    var modelAsJson = (await ReadFile(files[0])).EnsureYamlIsJson();
 
     using (plugin.Activate())
     {

--- a/src/gulp_modules/regeneration.iced
+++ b/src/gulp_modules/regeneration.iced
@@ -13,6 +13,7 @@ regenExpected = (opts,done) ->
     optsMappingsValue = opts.mappings[key]
     swaggerFile = if optsMappingsValue instanceof Array then optsMappingsValue[0] else optsMappingsValue
     args = [
+      '-FANCY',
       '-SkipValidation',
       '-CodeGenerator', opts.codeGenerator,
       '-OutputDirectory', "#{outputDir}/#{key}",

--- a/src/gulp_modules/regeneration.iced
+++ b/src/gulp_modules/regeneration.iced
@@ -13,7 +13,6 @@ regenExpected = (opts,done) ->
     optsMappingsValue = opts.mappings[key]
     swaggerFile = if optsMappingsValue instanceof Array then optsMappingsValue[0] else optsMappingsValue
     args = [
-      '-FANCY',
       '-SkipValidation',
       '-CodeGenerator', opts.codeGenerator,
       '-OutputDirectory', "#{outputDir}/#{key}",


### PR DESCRIPTION
- `autorest init <legacy args>` will produce simple config file from legacy CLI args
- plugin-specific settings: `--csharp.output-folder=C:\output\csharp --nodejs.output-folder=C:\output\nodejs` is a thing now
- sanitize markdown in codemodel
- `transform`/`set` directives and tests
- code generators eat YAML instead of JSON