### PR TITLE
Code changes related to Issue 1374

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -638,6 +638,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Property &apos;{0}&apos; is a required property. It should not be marked as &apos;readonly&apos;..
+        /// </summary>
+        public static string RequiredReadOnlyPropertiesValidation {
+            get {
+                return ResourceManager.GetString("RequiredReadOnlyPropertiesValidation", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to A &apos;Resource&apos; definition must have x-ms-azure-resource extension enabled and set to true..
         /// </summary>
         public static string ResourceIsMsResourceNotValid {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -232,6 +232,9 @@ Modelers:
   <data name="HttpVerbIsNotValid" xml:space="preserve">
     <value>Permissible values for HTTP Verb are delete,get,put,patch,head,options,post. </value>
   </data>
+  <data name="RequiredReadOnlyPropertiesValidation" xml:space="preserve">
+    <value>Property '{0}' is a required property. It should not be marked as 'readonly'.</value>
+  </data>
   <data name="ResourceModelIsNotValid" xml:space="preserve">
     <value>The id, name, type, location and tags properties of the Resource must be present with id, name and type as read-only</value>
   </data>

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-2.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-2.json
@@ -1,0 +1,112 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "properties": {
+                "id": {
+                  "readOnly": true,
+                  "type": "string",
+                  "description": "Resource Id"
+                },
+                "name": {
+                  "readOnly": true,
+                  "type": "string",
+                  "description": "Resource name"
+                },
+                "type": {
+                  "readOnly": true,
+                  "type": "string",
+                  "description": "Resource type"
+                },
+                "location": {
+                  "type": "string",
+                  "description": "Resource location"
+                },
+                "tags": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Resource tags"
+                }
+              },
+              "required": [
+                "location",
+                "name"
+              ],
+              "description": "The Resource definition."
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResponseResource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "description": "The Resource definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-3.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-3.json
@@ -1,0 +1,114 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description",
+            "schema": {
+              "properties": {
+                "id": {
+                  "readOnly": true,
+                  "type": "string",
+                  "description": "Resource Id"
+                },
+                "name": {
+                  "readOnly": true,
+                  "type": "string",
+                  "description": "Resource name"
+                },
+                "type": {
+                  "readOnly": true,
+                  "type": "string",
+                  "description": "Resource type"
+                },
+                "location": {
+                  "type": "string",
+                  "description": "Resource location"
+                },
+                "tags": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  },
+                  "description": "Resource tags"
+                }
+              },
+              "required": [
+                "location", "name"
+              ],
+              "description": "The Resource definition."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseResource"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResponseResource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "description": "The Resource definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-4.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-4.json
@@ -1,0 +1,93 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseResource"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResponseResource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "properties": {
+            "param1": {
+              "readOnly": true,
+              "type": "string",
+              "description": "Param I"
+            },
+            "param2": {
+              "readOnly": true,
+              "type": "string",
+              "description": "Param II"
+            }
+          },
+          "required":  [ "param2" ],
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "description": "The Resource definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-5.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties-5.json
@@ -1,0 +1,106 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseResource"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResponseResource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location"
+      ],
+      "description": "The Resource definition."
+    },
+    "ResourceListResult": {
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "properties": {
+              "param1": {
+                "readOnly": true,
+                "type": "string",
+                "description": "Param I"
+              },
+              "param2": {
+                "readOnly": true,
+                "type": "string",
+                "description": "Param II"
+              }
+            },
+            "required": [ "param2" ],
+            "description": "Sample Description"
+          },
+          "description": "Resource List Result properties description."
+        }
+      },
+      "description": "Resource List Result properties description."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/required-readonly-properties.json
@@ -1,0 +1,81 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/ResponseResource"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "ResponseResource": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        },
+        "type": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource type"
+        },
+        "location": {
+          "type": "string",
+          "description": "Resource location"
+        },
+        "tags": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Resource tags"
+        }
+      },
+      "required": [
+        "location", "name"
+      ],
+      "description": "The Resource definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -425,6 +425,46 @@ namespace AutoRest.Swagger.Tests
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-putgetpatch-response-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(PutGetPatchResponseValidation), 1);
         }
+
+        [Fact]
+        public void RequiredReadOnlyPropertiesValidation()
+        {
+            // This test validates if a definition has required properties which are marked as readonly true
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties.json"));
+            messages.AssertOnlyValidationMessage(typeof(RequiredReadOnlyPropertiesValidation), 1);
+        }
+
+        [Fact]
+        public void RequiredReadOnlyPropertiesValidationII()
+        {
+            // This test validates if a definition has required properties which are marked as readonly true
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-2.json"));
+            messages.AssertOnlyValidationMessage(typeof(RequiredReadOnlyPropertiesValidation), 1);
+        }
+
+        [Fact]
+        public void RequiredReadOnlyPropertiesValidationIII()
+        {
+            // This test validates if a definition has required properties which are marked as readonly true
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-3.json"));
+            messages.AssertOnlyValidationMessage(typeof(RequiredReadOnlyPropertiesValidation), 1);
+        }
+
+        [Fact]
+        public void RequiredReadOnlyPropertiesValidationIV()
+        {
+            // This test validates if a definition has required properties which are marked as readonly true
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-4.json"));
+            messages.AssertOnlyValidationMessage(typeof(RequiredReadOnlyPropertiesValidation), 1);
+        }
+
+        [Fact]
+        public void RequiredReadOnlyPropertiesValidationV()
+        {
+            // This test validates if a definition has required properties which are marked as readonly true
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-5.json"));
+            messages.AssertOnlyValidationMessage(typeof(RequiredReadOnlyPropertiesValidation), 1);
+        }
     }
 
     #region Positive tests

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -427,7 +427,7 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void RequiredReadOnlyPropertiesValidation()
+        public void RequiredReadOnlyPropertiesValidationInDefinitions()
         {
             // This test validates if a definition has required properties which are marked as readonly true
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties.json"));
@@ -435,7 +435,7 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void RequiredReadOnlyPropertiesValidationII()
+        public void RequiredReadOnlyPropertiesValidationInResponses()
         {
             // This test validates if a definition has required properties which are marked as readonly true
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-2.json"));
@@ -443,7 +443,7 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void RequiredReadOnlyPropertiesValidationIII()
+        public void RequiredReadOnlyPropertiesValidationInParameters()
         {
             // This test validates if a definition has required properties which are marked as readonly true
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-3.json"));
@@ -451,7 +451,7 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void RequiredReadOnlyPropertiesValidationIV()
+        public void RequiredReadOnlyPropertiesValidationInNestedSchema()
         {
             // This test validates if a definition has required properties which are marked as readonly true
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-4.json"));
@@ -459,7 +459,7 @@ namespace AutoRest.Swagger.Tests
         }
 
         [Fact]
-        public void RequiredReadOnlyPropertiesValidationV()
+        public void RequiredReadOnlyPropertiesValidationInItems()
         {
             // This test validates if a definition has required properties which are marked as readonly true
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-5.json"));

--- a/src/modeler/AutoRest.Swagger/Model/Response.cs
+++ b/src/modeler/AutoRest.Swagger/Model/Response.cs
@@ -25,6 +25,7 @@ namespace AutoRest.Swagger.Model
 
         [Rule(typeof(AvoidAnonymousTypes))]
         [Rule(typeof(BooleanPropertyNotRecommended))]
+        [Rule(typeof(RequiredReadOnlyPropertiesValidation))]
         public Schema Schema { get; set; }
 
         public Dictionary<string, Header> Headers { get; set; }

--- a/src/modeler/AutoRest.Swagger/Model/Schema.cs
+++ b/src/modeler/AutoRest.Swagger/Model/Schema.cs
@@ -37,6 +37,7 @@ namespace AutoRest.Swagger.Model
         [CollectionRule(typeof(AvoidNestedProperties))]
         [Rule(typeof(XmsClientNamePropertyValidation))]
         [Rule(typeof(DescriptionMissing))]
+        [CollectionRule(typeof(RequiredReadOnlyPropertiesValidation))]
         public Dictionary<string, Schema> Properties { get; set; }
 
         public bool ReadOnly { get; set; }

--- a/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
@@ -119,6 +119,7 @@ namespace AutoRest.Swagger.Model
         [Rule(typeof(SkuModelValidation))]
         [Rule(typeof(DefinitionsPropertiesNamesCamelCase))]
         [Rule(typeof(DescriptionMissing))]
+        [CollectionRule(typeof(RequiredReadOnlyPropertiesValidation))]
         public Dictionary<string, Schema> Definitions { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
+++ b/src/modeler/AutoRest.Swagger/Model/SwaggerObject.cs
@@ -47,6 +47,7 @@ namespace AutoRest.Swagger.Model
         /// <summary>
         /// Describes the type of items in the array.
         /// </summary>
+        [Rule(typeof(RequiredReadOnlyPropertiesValidation))]
         public virtual Schema Items { get; set; }
 
         [JsonProperty(PropertyName = "$ref")]

--- a/src/modeler/AutoRest.Swagger/Model/SwaggerParameter.cs
+++ b/src/modeler/AutoRest.Swagger/Model/SwaggerParameter.cs
@@ -39,6 +39,7 @@ namespace AutoRest.Swagger.Model
         /// <summary>
         /// The schema defining the type used for the body parameter.
         /// </summary>
+        [Rule(typeof(RequiredReadOnlyPropertiesValidation))]
         public Schema Schema { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Validation/RequiredReadOnlyPropertiesValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/RequiredReadOnlyPropertiesValidation.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Swagger.Validation.Core;
+using System.Collections.Generic;
+using AutoRest.Core.Properties;
+using AutoRest.Swagger.Model;
+using AutoRest.Core.Logging;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class RequiredReadOnlyPropertiesValidation : TypedRule<Schema>
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2062";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.RequiredReadOnlyPropertiesValidation;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Error;
+
+        /// <summary>
+        /// Validates if a property is marked as required, it should not be read only.
+        /// </summary>
+        /// <param name="definition"></param>
+        /// <param name="context"></param>
+        /// <returns></returns>
+        public override IEnumerable<ValidationMessage> GetValidationMessages(Schema definition, RuleContext context)
+        {
+            if(definition.Properties != null)
+            {
+                foreach (KeyValuePair<string, Schema> property in definition.Properties)
+                {
+                    if (property.Value.ReadOnly && definition.Required.Contains(property.Key))
+                    {
+                        yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, property.Key);
+                    }
+                }
+            }            
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/Azure/autorest/issues/1374 

@dsgouda @vishrutshah @veronicagg @salameer Please review and approve 

**Sample Error Messages**
**Sample I** 
"Property 'name' is a required property. It should not be marked as 'readonly'."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/required-readonly-properties.json#/definitions/ResponseResource"

**Sample II**
"Property 'name' is a required property. It should not be marked as 'readonly'."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/required-readonly-properties-2.json#/paths/foo/get/responses/200/schema"

**Sample III**
"Property 'name' is a required property. It should not be marked as 'readonly'."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/required-readonly-properties-3.json#/paths/foo/get/parameters[1]/schema"

**Sample IV**
"Property 'param2' is a required property. It should not be marked as 'readonly'."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/required-readonly-properties-4.json#/definitions/ResponseResource/properties/location"

**Sample V** 
"Property 'param2' is a required property. It should not be marked as 'readonly'."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/required-readonly-properties-5.json#/definitions/ResourceListResult/properties/value/items"