### PR TITLE
Code Changes for Issue 1957 - Validate Security Definitions

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -656,6 +656,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A swagger must have security definitions and must adhere to the specific structure..
+        /// </summary>
+        public static string SecurityDefinitionsStructureValidation {
+            get {
+                return ResourceManager.GetString("SecurityDefinitionsStructureValidation", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Parameter &quot;{0}&quot; is referenced but not defined in the global parameters section of Service Definition.
         /// </summary>
         public static string ServiceDefinitionParametersMissingMessage {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -223,6 +223,9 @@ Modelers:
   <data name="AnonymousTypesDiscouraged" xml:space="preserve">
     <value>Inline/anonymous models must not be used, instead define a schema with a model name in the "definitions" section and refer to it. This allows operations to share the models.</value>
   </data>
+  <data name="SecurityDefinitionsStructureValidation" xml:space="preserve">
+    <value>A swagger must have security definitions and must adhere to the specific structure.</value>
+  </data>
   <data name="MsdnReferencesDiscouraged" xml:space="preserve">
     <value>For better generated code quality, remove all references to "msdn.microsoft.com".</value>
   </data>

--- a/src/modeler/AutoRest.Swagger.Tests/AutoRest.Swagger.Tests.csproj
+++ b/src/modeler/AutoRest.Swagger.Tests/AutoRest.Swagger.Tests.csproj
@@ -11,6 +11,39 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-11.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-10.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-9.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-8.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-7.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-6.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-5.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-4.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-3.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-2.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Resource\Swagger\Validation\security-definitions-validations-1.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
     <Content Include="Resource\Swagger\Validation\positive\property-names-casing-valid.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/clean-complex-spec.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/clean-complex-spec.json
@@ -18,6 +18,17 @@
   "produces": [
     "application/json"
   ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.Cdn/operations": {
       "get": {
@@ -306,7 +317,7 @@
       }
     },
     "OperationsListResult": {
-      "description":  "List of operations",
+      "description": "List of operations",
       "properties": {
         "value": {
           "type": "array",
@@ -326,7 +337,7 @@
           "type": "string"
         },
         "display": {
-          "description":  "foo",
+          "description": "foo",
           "properties": {
             "provider": {
               "description": "Service provider",

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/collection-objects-naming-valid.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/collection-objects-naming-valid.json
@@ -16,6 +16,17 @@
     "application/json"
   ],
   "basePath": "/",
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
   "paths": {
     "/foo": {
       "post": {

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/pageable-nextlink-defined-allof.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/pageable-nextlink-defined-allof.json
@@ -16,6 +16,17 @@
   "consumes": [
     "application/json"
   ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.Cdn/operations": {
       "get": {

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/required-property-defined-allof.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/required-property-defined-allof.json
@@ -10,6 +10,17 @@
     "https"
   ],
   "basePath": "/",
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
   "paths": {
     "/subscriptions/{subscriptionId}/providers/Microsoft.Cdn/operations": {
       "get": {

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-1.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-1.json
@@ -1,0 +1,61 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-10.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-10.json
@@ -1,0 +1,73 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": "impersonate your user account",
+        "generic_entry": "generic description"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-11.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-11.json
@@ -1,0 +1,72 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": ""
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-2.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-2.json
@@ -1,0 +1,63 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-3.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-3.json
@@ -1,0 +1,81 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    },
+    "generic_auth": {
+      "type": "apikey",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "application",
+      "description": "dummy description",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-4.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-4.json
@@ -1,0 +1,72 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "generic_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-5.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-5.json
@@ -1,0 +1,71 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-6.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-6.json
@@ -1,0 +1,72 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-7.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-7.json
@@ -1,0 +1,72 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "none",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-8.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-8.json
@@ -1,0 +1,69 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit"
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-9.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/security-definitions-validations-9.json
@@ -1,0 +1,71 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Uses 'required' & 'readonly' properties.",
+    "description": "Show an error/warning if a definition property is marked readOnly: true plus it appears under the required array of properties.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "flow": "implicit",
+      "scopes": {
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -425,6 +425,83 @@ namespace AutoRest.Swagger.Tests
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "swagger-putgetpatch-response-validation.json"));
             messages.AssertOnlyValidationMessage(typeof(PutGetPatchResponseValidation), 1);
         }
+
+        [Fact]
+        public void SecurityDefinitionStructurePresenceValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-1.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureEmptyValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-2.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureMultipleEntriesValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-3.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureIncorrectKeyValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-4.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureMissingDescriptionValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-5.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureEmptyDescriptionValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-6.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureIncorrectDefValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-7.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureMissingScopesValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-8.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureEmptyScopesValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-9.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureMultipleScopesValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-10.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
+
+        [Fact]
+        public void SecurityDefinitionStructureMissingScopesDescriptionValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "security-definitions-validations-11.json"));
+            messages.AssertOnlyValidationMessage(typeof(SecurityDefinitionsStructureValidation), 1);
+        }
     }
 
     #region Positive tests

--- a/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ServiceDefinition.cs
@@ -137,6 +137,7 @@ namespace AutoRest.Swagger.Model
         /// <summary>
         /// Key is the object serviceTypeName and the value is swagger security definition.
         /// </summary>
+        [Rule(typeof(SecurityDefinitionsStructureValidation))]
         public Dictionary<string, SecurityDefinition> SecurityDefinitions { get; set; }
 
         /// <summary>

--- a/src/modeler/AutoRest.Swagger/Validation/SecurityDefinitionsStructureValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/SecurityDefinitionsStructureValidation.cs
@@ -1,0 +1,96 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using AutoRest.Core.Properties;
+using AutoRest.Swagger.Model;
+using AutoRest.Swagger.Validation.Core;
+using System;
+using System.Collections.Generic;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class SecurityDefinitionsStructureValidation : TypedRule<Dictionary<string, SecurityDefinition>>
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2054";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Error;
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.SecurityDefinitionsStructureValidation;
+
+        /// <summary>
+        /// Checks for the presence and existence of the security definiton
+        /// </summary>
+        /// <param name="entity"></param>
+        /// <returns></returns>
+        public override bool IsValid(Dictionary<string, SecurityDefinition> securityDefinitions)        
+        {
+            if (securityDefinitions.Count != 1)
+            {
+                return false;
+            }
+
+            foreach(KeyValuePair<string, SecurityDefinition> sd in securityDefinitions)
+            {
+                SecurityDefinition securityDefinition = sd.Value;
+                if(!sd.Key.Equals("azure_auth", StringComparison.CurrentCultureIgnoreCase) || !IsSecurityDefinitionModelValid(securityDefinition))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private bool IsSecurityDefinitionModelValid(SecurityDefinition securityDefinition)
+        {
+            if(
+                securityDefinition.SecuritySchemeType == SecuritySchemeType.OAuth2 && 
+                securityDefinition.AuthorizationUrl.Equals("https://login.microsoftonline.com/common/oauth2/authorize", StringComparison.CurrentCultureIgnoreCase) &&
+                securityDefinition.Flow == OAuthFlow.Implicit &&
+                !String.IsNullOrEmpty(securityDefinition.Description) &&
+                IsSecurityDefinitionScopesValid(securityDefinition.Scopes)
+              )
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private bool IsSecurityDefinitionScopesValid(Dictionary<string, string> scopes)
+        {
+            if(scopes == null || scopes.Count != 1)
+            {
+                return false;
+            }
+
+            foreach(KeyValuePair<string, string> scope in scopes)
+            {
+                if(!scope.Key.Equals("user_impersonation", StringComparison.CurrentCultureIgnoreCase) || String.IsNullOrEmpty(scope.Value))
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
**Rel Issue**: https://github.com/Azure/autorest/issues/1957 

**Sample Message**
"A swagger must have security definitions and must adhere to the specific structure."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/security-definitions-validations.json#/securityDefinitions"

@dsgouda @vishrutshah @veronicagg @salameer Please review and approve