### PR TITLE
Code changes related to Issue 2019 - Check Name of Body Parameters

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -116,6 +116,15 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A body parameter must be named &apos;parameters&apos;..
+        /// </summary>
+        public static string BodyParametersNotValid {
+            get {
+                return ResourceManager.GetString("BodyParametersNotValid", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Property named: &quot;{0}&quot;, must follow camelCase style. Example: &quot;{1}&quot;..
         /// </summary>
         public static string BodyPropertyNameCamelCase {

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -232,6 +232,9 @@ Modelers:
   <data name="HttpVerbIsNotValid" xml:space="preserve">
     <value>Permissible values for HTTP Verb are delete,get,put,patch,head,options,post. </value>
   </data>
+  <data name="BodyParametersNotValid" xml:space="preserve">
+    <value>A body parameter must be named 'parameters'.</value>
+  </data>
   <data name="RequiredReadOnlyPropertiesValidation" xml:space="preserve">
     <value>Property '{0}' is a required property. It should not be marked as 'readonly'.</value>
   </data>

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/body-parameters-validation-1.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/body-parameters-validation-1.json
@@ -1,0 +1,80 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Checks if the body parameter is named 'parameters'",
+    "description": "Show an error/warning if a body parameter is not named 'parameters'",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "type": "string",
+            "required": true,
+            "description": "Test Description"
+          },
+          {
+            "name": "parameter_2",
+            "in": "body",
+            "type": "string",
+            "required": true,
+            "description": "Test Description"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/body-parameters-validation-2.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/body-parameters-validation-2.json
@@ -1,0 +1,85 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Checks if the body parameter is named 'parameters'",
+    "description": "Show an error/warning if a body parameter is not named 'parameters'",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "https"
+  ],
+  "basePath": "/",
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "flow": "implicit",
+      "description": "Azure Active Directory OAuth2 Flow",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "paths": {
+    "/foo": {
+      "get": {
+        "tags": [ "SampleTag" ],
+        "operationId": "Foo_Get",
+        "description": "Test Description",
+        "parameters": [
+          {
+            "name": "parameter_1",
+            "in": "path",
+            "type": "string",
+            "required": true,
+            "description": "Test Description"
+          },
+          {
+            "$ref": "#/parameters/SecondParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/Response"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Response": {
+      "properties": {
+        "id": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource Id"
+        },
+        "name": {
+          "readOnly": true,
+          "type": "string",
+          "description": "Resource name"
+        }
+      },
+      "description": "The Response definition."
+    }
+  },
+  "parameters": {
+    "SecondParameter": {
+      "name": "parameter_2",
+      "in": "body",
+      "type": "string",
+      "required": true,
+      "description": "Test Description"
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/clean-complex-spec.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/clean-complex-spec.json
@@ -169,7 +169,7 @@
         "parameters": [
           {
             "in": "body",
-            "name": "fooPost",
+            "name": "parameters",
             "schema": {
               "type": "object",
               "description": "A foo object"
@@ -196,7 +196,7 @@
         "parameters": [
           {
             "in": "body",
-            "name": "fooPost",
+            "name": "parameters",
             "schema": {
               "type": "object",
               "description": "A foo object"

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -465,6 +465,20 @@ namespace AutoRest.Swagger.Tests
             var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "required-readonly-properties-5.json"));
             messages.AssertOnlyValidationMessage(typeof(RequiredReadOnlyPropertiesValidation), 1);
         }
+
+        [Fact]
+        public void BodyParametersInlineValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "body-parameters-validation-1.json"));
+            messages.AssertOnlyValidationMessage(typeof(BodyParametersValidation), 1);
+        }
+
+        [Fact]
+        public void BodyParametersReferencedValidation()
+        {
+            var messages = ValidateSwagger(Path.Combine(Core.Utilities.Extensions.CodeBaseDirectory, "Resource", "Swagger", "Validation", "body-parameters-validation-2.json"));
+            messages.AssertOnlyValidationMessage(typeof(BodyParametersValidation), 1);
+        }
     }
 
     #region Positive tests

--- a/src/modeler/AutoRest.Swagger/Model/SwaggerParameter.cs
+++ b/src/modeler/AutoRest.Swagger/Model/SwaggerParameter.cs
@@ -16,6 +16,7 @@ namespace AutoRest.Swagger.Model
     /// </summary>
     [Rule(typeof(ParameterDescriptionRequired))]
     [Rule(typeof(XmsClientNameParameterValidation))]
+    [Rule(typeof(BodyParametersValidation))]
     public class SwaggerParameter : SwaggerObject
     {
         private bool _isRequired;

--- a/src/modeler/AutoRest.Swagger/Validation/BodyParametersValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/BodyParametersValidation.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Swagger.Validation.Core;
+using AutoRest.Core.Properties;
+using AutoRest.Swagger.Model;
+using AutoRest.Core.Logging;
+using System;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class BodyParametersValidation : TypedRule<SwaggerParameter>
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2063";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.BodyParametersNotValid;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Error;
+
+        /// <summary>
+        /// Validates if the 'body' parameter is named 'parameters'.
+        /// </summary>
+        /// <param name="swaggerParameter"></param>
+        /// <returns></returns>
+        public override bool IsValid(SwaggerParameter swaggerParameter) =>
+            (swaggerParameter.In != ParameterLocation.Body) || (swaggerParameter.Name.Equals("parameters", StringComparison.CurrentCultureIgnoreCase));
+    }
+}


### PR DESCRIPTION
Related to issue https://github.com/Azure/autorest/issues/2019 

@dsgouda @vishrutshah @veronicagg @salameer Please review and approve

**Sample Message I**
"A body parameter must be named 'parameters'."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/body-parameters-validation-1.json#/paths/foo/get/parameters[2]"

**Sample Message II**
"A body parameter must be named 'parameters'."
"file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/body-parameters-validation-2.json#/parameters/SecondParameter"