### PR TITLE
Fixed race condition in gulp scripts and made them simpler

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "moment": "^2.17.1",
     "run-sequence": "*",
     "shelljs": "^0.7.6",
-    "through2": "^2.0.3",
+    "through2-parallel": "^0.1.3",
     "typescript": "^2.3.0-dev.20170314",
     "vinyl-paths": "^2.1.0",
     "vinyl-fs": "^2.4.4",

--- a/src/gulp_modules/common.iced
+++ b/src/gulp_modules/common.iced
@@ -7,8 +7,8 @@ vfs = require('vinyl-fs');
 
 module.exports =
   # lets us just handle each item in a stream easily.
-  foreach: (delegate) -> 
-    through.obj ( each, enc, done ) -> 
+  foreach: (delegate) ->
+    through.obj { concurrency: threshold }, ( each, enc, done ) -> 
       delegate each, done, this
 
   toArray: (result,passthru) => 

--- a/src/gulp_modules/dotnet.iced
+++ b/src/gulp_modules/dotnet.iced
@@ -85,42 +85,24 @@ task 'sign-assemblies','', (done) ->
 task 'restore','restores the dotnet packages for the projects', (done) -> 
   if ! test '-d', "#{os.homedir()}/.nuget"
     global.force = true
-  instances = 1
-  _done = () ->
-    if instances is 0
-      instances--
-      done();
 
   projects()
-    .on 'end', ->
-      instances--
-      _done() 
     .pipe where (each) ->  # check for project.assets.json files are up to date  
       return true if force
       assets = "#{folder each.path}/obj/project.assets.json"
       return false if (exists assets) and (newer assets, each.path)
       return true
-    .pipe foreach (each,next)->
-      instances++
+    .pipe foreach (each,done)->
       execute "dotnet restore #{ each.path } /nologo", {retry:1},(code,stderr,stdout) ->
-        instances--
-        _done()
-      next null  
-  return null
+        done()
   
 ############################################### 
 task 'test-dotnet', 'runs dotnet tests',['restore'] , (done) ->
-  instances = 0    
-
   # run xunit test in parallel with each other.
   tests()
-    .pipe foreach (each,next)->
-      instances++
+    .pipe foreach (each,done)->
       execute "dotnet test #{ each.path } /nologo",{retry:1}, (code,stderr,stdout) ->
-        instances--
-        done() if instances is 0
-      next null  
-  return null
+        done()
 
 global['codesign'] = (description, keywords, input, output, certificate1, certificate2, done)-> 
   done = if done? then done else if certificate2? then certificate2 else if certificate1? then certificate1 else ()->

--- a/src/gulp_modules/dotnet.iced
+++ b/src/gulp_modules/dotnet.iced
@@ -2,7 +2,7 @@
 csu = "c:/ci-signing/adxsdk/tools/csu/csu.exe"
 
 dotnet = (cmd) ->
-  through.obj (file, enc, callback) ->
+  foreach (file, callback) ->
     # check if the file is an actual file. 
     # if it's not, just skip this tool.
     if !file or !file.path

--- a/src/gulp_modules/gulp.iced
+++ b/src/gulp_modules/gulp.iced
@@ -33,7 +33,7 @@ Install 'chalk'
 Install 'yargs'
 Install 'ghrelease', 'gulp-github-release'
 Install 'eol', 'gulp-line-ending-corrector'
-Install 'through', 'through2'
+Install 'through', 'through2-parallel'
 Install 'run', 'run-sequence'
 Install 'except', './except.iced'
 

--- a/src/gulp_modules/regeneration.iced
+++ b/src/gulp_modules/regeneration.iced
@@ -5,11 +5,10 @@
 
 regenExpected = (opts,done) ->
   outputDir = if !!opts.outputBaseDir then "#{opts.outputBaseDir}/#{opts.outputDir}" else opts.outputDir
-  instances = 0    
+  keys = Object.getOwnPropertyNames(opts.mappings)
+  instances = keys.length
 
-  for key of opts.mappings
-    instances++
-
+  for key in keys
     optsMappingsValue = opts.mappings[key]
     swaggerFiles = (if optsMappingsValue instanceof Array then optsMappingsValue[0] else optsMappingsValue).split(";")
     args = [
@@ -51,7 +50,7 @@ regenExpected = (opts,done) ->
       args.push("--override-info.description=#{opts['override-info.description']}")
 
     autorest args,() =>
-      instances = instances- 1
+      instances--
       return done() if instances is 0 
 
 defaultMappings = {


### PR DESCRIPTION
@mcardosos discovered another race condition that led to failure due to multiple resolve calls (see "explanatory" commit https://github.com/olydis/autorest/commit/49ac676827412c8066b1fc5df3623750499fa19e).

Problem:
In some cases, the pipe handler would be called AND FINISH for the first item of the stream before it is called for the second one.
As a result, `instances` would already be 0 and hence resolve the entire stage.
Afterwards, the pipe handler will be called for further items which will ultimately resolve another time.

"Solution":
Initialize `instances` with `1` instead of `0` and also decrement it in the `end` event. Hence, "premature" resolution will no longer happen.

Solution:
Use `through2-parallel` and get rid of this madness once and for all.