### PR TITLE
[Python] Fix mock test and requests dep

### DIFF
--- a/src/generator/AutoRest.Python.Azure.Tests/AcceptanceTests/lro_tests.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/AcceptanceTests/lro_tests.py
@@ -41,6 +41,10 @@ log_level = int(os.environ.get('PythonLogLevel', 30))
 tests = realpath(join(cwd, pardir, "Expected", "AcceptanceTests"))
 sys.path.append(join(tests, "Lro"))
 
+# Import mock from Autorest.Python.Tests
+mockfiles = realpath(join(cwd, pardir, pardir, "AutoRest.Python.Tests", "AcceptanceTests"))
+sys.path.append(mockfiles)
+
 from msrest.serialization import Deserializer
 from msrest.exceptions import DeserializationError
 from msrest.authentication import BasicTokenAuthentication
@@ -49,15 +53,16 @@ from msrestazure.azure_exceptions import CloudError, CloudErrorData
 from autorestlongrunningoperationtestservice import AutoRestLongRunningOperationTestService
 from autorestlongrunningoperationtestservice.models import *
 
+from http_tests import TestAuthentication
+
 class LroTests(unittest.TestCase):
 
     def setUp(self):
 
         cred = BasicTokenAuthentication({"access_token" :str(uuid4())})
         self.client = AutoRestLongRunningOperationTestService(cred, base_url="http://localhost:3000")
-
+        self.client._client.creds = TestAuthentication()
         self.client.config.long_running_operation_timeout = 0
-        self.client._client._adapter.add_hook("request", self.client._client._adapter._test_pipeline)
         return super(LroTests, self).setUp()
 
     def assertRaisesWithMessage(self, msg, func, *args, **kwargs):

--- a/src/generator/AutoRest.Python.Azure.Tests/AcceptanceTests/paging_tests.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/AcceptanceTests/paging_tests.py
@@ -41,6 +41,10 @@ log_level = int(os.environ.get('PythonLogLevel', 30))
 tests = realpath(join(cwd, pardir, "Expected", "AcceptanceTests"))
 sys.path.append(join(tests, "Paging"))
 
+# Import mock from Autorest.Python.Tests
+mockfiles = realpath(join(cwd, pardir, pardir, "AutoRest.Python.Tests", "AcceptanceTests"))
+sys.path.append(mockfiles)
+
 from msrest.serialization import Deserializer
 from msrest.exceptions import DeserializationError
 from msrestazure.azure_exceptions import CloudError
@@ -49,12 +53,14 @@ from msrest.authentication import BasicTokenAuthentication
 from autorestpagingtestservice import AutoRestPagingTestService
 from autorestpagingtestservice.models import PagingGetMultiplePagesWithOffsetOptions
 
+from http_tests import TestAuthentication
+
 class PagingTests(unittest.TestCase):
 
     def setUp(self):
         cred = BasicTokenAuthentication({"access_token" :str(uuid4())})
         self.client = AutoRestPagingTestService(cred, base_url="http://localhost:3000")
-        self.client._client._adapter.add_hook("request", self.client._client._adapter._test_pipeline)
+        self.client._client.creds = TestAuthentication()
         return super(PagingTests, self).setUp()
 
     def test_paging_happy_path(self):

--- a/src/generator/AutoRest.Python.Azure.Tests/requirements.txt
+++ b/src/generator/AutoRest.Python.Azure.Tests/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.10.0
-msrestazure==0.4.7
+requests>=2.11.0
+msrestazure>=0.4.7

--- a/src/generator/AutoRest.Python.Azure.Tests/tox.ini
+++ b/src/generator/AutoRest.Python.Azure.Tests/tox.ini
@@ -5,7 +5,7 @@ skipsdist=True
 [testenv]
 commands=
     coverage run ./AcceptanceTests/__init__.py
-    coverage report --fail-under=60 --omit=AcceptanceTests*.py,*.tox*.py
+    coverage report --fail-under=60 --omit=*AutoRest.Python.Tests*,AcceptanceTests*.py,*.tox*.py
     flake8 . --exclude=*Python.Azure.Tests*AcceptanceTests*.py,*Python.Azure.Tests*bin*,*.tox*.py --statistics
     
 setenv =

--- a/src/generator/AutoRest.Python.Tests/AcceptanceTests/file_tests.py
+++ b/src/generator/AutoRest.Python.Tests/AcceptanceTests/file_tests.py
@@ -94,7 +94,7 @@ class FileTests(unittest.TestCase):
             response.headers['Content-Length'] = str(3000 * 1024 * 1024)
 
         file_length = 0
-        client._client.add_hook('response', add_headers)
+        # client._client.add_hook('response', add_headers)
         stream = client.files.get_file_large(callback=test_callback)
         #for data in stream:
         #    file_length += len(data)

--- a/src/generator/AutoRest.Python.Tests/requirements.txt
+++ b/src/generator/AutoRest.Python.Tests/requirements.txt
@@ -1,2 +1,2 @@
-requests==2.10.0
-msrest==0.4.3
+requests>=2.11.0
+msrest>=0.4.7


### PR DESCRIPTION
This PR is:
- Fixing https://github.com/Azure/msrest-for-python/issues/4 by pushing here mock code that was in `msrest` for no reason (used only for fake server)
- Fix the `requests` dependencies of the test. The current tests work only if `requests<=2.10.0`. This PR adapt the tests to work with `requests>=2.11.0`

Do not merge until I test Azure.Python as well please, to avoid the risk to break CI.