### PR TITLE
Fixing bug to return all violating properties

### DIFF
--- a/src/modeler/AutoRest.Swagger/Validation/ArmResourcePropertiesBag.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/ArmResourcePropertiesBag.cs
@@ -48,8 +48,9 @@ namespace AutoRest.Swagger.Validation
                                                          && definitions[res].Properties["properties"]?.Properties?.Keys.Intersect(ArmPropertiesBag).Any() == true);
             foreach (var violatingModel in violatingModels)
             {
+                var violatingProperties = definitions[violatingModel].Properties.Keys.Union(definitions[violatingModel].Properties["properties"].Properties.Keys).Intersect(ArmPropertiesBag);
                 yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, violatingModel, 
-                                                   string.Join(", ", definitions[violatingModel].Properties.Keys.Intersect(ArmPropertiesBag)));
+                                                   string.Join(", ", violatingProperties));
             }
         }
     }

--- a/src/modeler/AutoRest.Swagger/Validation/PatchBodyParametersSchemaValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/PatchBodyParametersSchemaValidation.cs
@@ -59,13 +59,13 @@ namespace AutoRest.Swagger.Validation
                     
                     foreach (var reqProp in reqProps)
                     {
-                        var modelContainingReqProp = definitions.Where(pair => pair.Value.Required.Contains(reqProp)).Select(pair => pair.Key).First();
+                        var modelContainingReqProp = ValidationUtilities.EnumerateModelHierarchy(reqModel, definitions).First(model => definitions[model].Required?.Contains(reqProp)==true);
                         yield return new ValidationMessage(new FileObjectPath(context.File, context.Path.AppendProperty(modelContainingReqProp).AppendProperty("required")), this, "required", op.OperationId, modelContainingReqProp, reqProp);
                     }
                     
                     foreach (var defValProp in defValProps)
                     {
-                        var modelContainingDefValProp = definitions.Where(pair => pair.Value.Properties?.ContainsKey(defValProp.Key) == true && pair.Value.Properties[defValProp.Key] == defValProp.Value).Select(pair => pair.Key).First();
+                        var modelContainingDefValProp = ValidationUtilities.EnumerateModelHierarchy(reqModel, definitions).First(model => definitions[model].Properties?.Contains(defValProp) == true);
                         yield return new ValidationMessage(new FileObjectPath(context.File, context.Path.AppendProperty(modelContainingDefValProp).AppendProperty("properties").AppendProperty(defValProp.Key)), this, "default-valued", op.OperationId, modelContainingDefValProp, defValProp.Key);
                     }
                     

--- a/src/modeler/AutoRest.Swagger/Validation/PatchBodyParametersSchemaValidation.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/PatchBodyParametersSchemaValidation.cs
@@ -56,16 +56,18 @@ namespace AutoRest.Swagger.Validation
                     
                     // select all models that have properties with default values
                     var defValProps = ValidationUtilities.EnumerateDefaultValuedProperties(reqModel, definitions);
-                    
+
+                    var modelHierarchy = ValidationUtilities.EnumerateModelHierarchy(reqModel, definitions);
+
                     foreach (var reqProp in reqProps)
                     {
-                        var modelContainingReqProp = ValidationUtilities.EnumerateModelHierarchy(reqModel, definitions).First(model => definitions[model].Required?.Contains(reqProp)==true);
+                        var modelContainingReqProp = modelHierarchy.First(model => definitions[model].Required?.Contains(reqProp) == true);
                         yield return new ValidationMessage(new FileObjectPath(context.File, context.Path.AppendProperty(modelContainingReqProp).AppendProperty("required")), this, "required", op.OperationId, modelContainingReqProp, reqProp);
                     }
                     
                     foreach (var defValProp in defValProps)
                     {
-                        var modelContainingDefValProp = ValidationUtilities.EnumerateModelHierarchy(reqModel, definitions).First(model => definitions[model].Properties?.Contains(defValProp) == true);
+                        var modelContainingDefValProp = modelHierarchy.First(model => definitions[model].Properties?.Contains(defValProp) == true);
                         yield return new ValidationMessage(new FileObjectPath(context.File, context.Path.AppendProperty(modelContainingDefValProp).AppendProperty("properties").AppendProperty(defValProp.Key)), this, "default-valued", op.OperationId, modelContainingDefValProp, defValProp.Key);
                     }
                     


### PR DESCRIPTION
ArmResourcePropertiesBag validation rule does not indicate violating properties in the properties bag (2nd level)
Example json [here](https://raw.githubusercontent.com/Azure/azure-rest-api-specs/master/arm-web/2015-04-01/swagger/TopLevelDomains.json) as pointed by @ravbhatnagar 
Also, a minor fix for displaying properties that are marked readOnly or required (if multiple models have properties with the same name anywhere in the document they'd get reported instead)