### PR TITLE
Long-running operations will now return the object they create.

### DIFF
--- a/src/generator/AutoRest.Go/Model/MethodGo.cs
+++ b/src/generator/AutoRest.Go/Model/MethodGo.cs
@@ -106,7 +106,7 @@ namespace AutoRest.Go.Model
     {
       get
       {
-        return !IsLongRunningOperation() && HasReturnValue()
+        return HasReturnValue()
             ? string.Format("result {0}, err error", ReturnValue().Body.Name)
             : "result autorest.Response, err error";
       }
@@ -290,7 +290,7 @@ namespace AutoRest.Go.Model
         decorators.Add("client.ByInspecting()");
         decorators.Add(string.Format("azure.WithErrorUnlessStatusCode({0})", string.Join(",", ResponseCodes.ToArray())));
 
-        if (!IsLongRunningOperation() && HasReturnValue() && !ReturnValue().Body.IsStreamType())
+        if (HasReturnValue() && !ReturnValue().Body.IsStreamType())
         {
           if (((CompositeTypeGo)ReturnValue().Body).IsWrapperType)
           {
@@ -315,7 +315,7 @@ namespace AutoRest.Go.Model
     {
       get
       {
-        return !IsLongRunningOperation() && HasReturnValue()
+        return HasReturnValue()
             ? "result.Response = autorest.Response{Response: resp}"
             : "result.Response = resp";
       }


### PR DESCRIPTION
LROs have been returning an autorest.Response object instead of the object
they create which requires the end-user to make a separate API call to
retrieve the object which is clunky and inefficient.  This change remove
that behavior so the API will return the object the LRO created.