### PR TITLE
Fix #1685 - Bad paged class name

### DIFF
--- a/src/generator/AutoRest.Python.Azure/Model/MethodPya.cs
+++ b/src/generator/AutoRest.Python.Azure/Model/MethodPya.cs
@@ -33,7 +33,7 @@ namespace AutoRest.Python.Azure.Model
                     return string.Empty;
                 }
 
-                return "models." + (string)ext["className"];
+                return "models." + this.ReturnType.Body.Name;
             }
         }
 


### PR DESCRIPTION
Fix #1685 

In all honesty, I'm not sure exactly why `className` in the extension is broken, but I use now the string I use for generating the documentation (`ReturnType.Body.Name`) that seems to be correct in all cases. So anyway this is more consistent.

I checked this fix IotHub as declared in #1685, and I tested with some Python SDK (Compute) and so far so good.