### PR TITLE
use default value in constructor (if you ask for it nicely)

### DIFF
--- a/Samples/3b-custom-transformations/readme.md
+++ b/Samples/3b-custom-transformations/readme.md
@@ -31,15 +31,14 @@ directive:
 directive:
 - from: storage.json
   where: $.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}"].put.description
-  # The following can be an arbitrary JavaScript expression that will be evaluated to determine the new value.
+  # The following can be arbitrary JavaScript code that will be evaluated to determine the new value.
   # The original value is accessible via variable "$".
   # Here: We append a string to the existing value.
-  transform: >
-    $ + " Make sure you add that extra cowbell."
+  transform: $ += " Make sure you add that extra cowbell."
   reason: Make sure people know.
 - from: storage.json
   where: $.definitions.Usage.description
-  transform: $.toUpperCase()
+  transform: return $.toUpperCase()
   reason: Our new guidelines require upper case descriptions here. Customers love it.
 ```
 
@@ -50,24 +49,22 @@ directive:
   from: composite # do it globally (in case there are multiple input OpenAPI definitions)
   where: $.paths..operationId
   # Replace operation IDs ending in "...ies" with "...y", because that's the safest way to make stuff singular.
-  transform: >
-    $.replace(/ies$/, "y")
+  transform: return $.replace(/ies$/, "y")
   reason: I don't like plural.
 ```
 
 ### CodeModel: Use endpoint URIs to determine operation group names
+
+By default (without an explicit return statement), `$` is considered the result of the transformation.
 
 ``` yaml 
 directive:
   from: model
   where: $.operations[*]
   transform: >
-    (() => {
       const url = $.methods[0]["#url"];
       const res = url.split("/Microsoft.Storage/")[1].split("/")[0];
       $["#name"] = res;
       $.summary = JSON.stringify($, null, 2);
-      return $;
-    })()
   reason: We wanna group methods by URI.
 ```

--- a/Samples/3b-custom-transformations/readme.md
+++ b/Samples/3b-custom-transformations/readme.md
@@ -46,7 +46,7 @@ directive:
 
 ``` yaml 
 directive:
-  from: composite # do it globally (in case there are multiple input OpenAPI definitions)
+  from: swagger-document # do it globally (in case there are multiple input OpenAPI definitions)
   where: $.paths..operationId
   # Replace operation IDs ending in "...ies" with "...y", because that's the safest way to make stuff singular.
   transform: return $.replace(/ies$/, "y")
@@ -59,7 +59,7 @@ By default (without an explicit return statement), `$` is considered the result 
 
 ``` yaml 
 directive:
-  from: model
+  from: code-model-v1
   where: $.operations[*]
   transform: >
       const url = $.methods[0]["#url"];

--- a/src/autorest-core/lib/pipeline/manipulation.ts
+++ b/src/autorest-core/lib/pipeline/manipulation.ts
@@ -38,7 +38,7 @@ export class Manipulator {
           // transform
           for (const t of trans.transform) {
             const target = await scope.Write(`transform_${nextId()}.yaml`);
-            data = (await ManipulateObject(data, target, w, obj => safeEval(t, { $: obj, $doc: data.ReadObject() }))).result;
+            data = (await ManipulateObject(data, target, w, obj => safeEval(`(() => { { ${t} }; return $; })()`, { $: obj, $doc: data.ReadObject() }))).result;
           }
           // set
           for (const s of trans.set) {

--- a/src/autorest-core/lib/pipeline/manipulation.ts
+++ b/src/autorest-core/lib/pipeline/manipulation.ts
@@ -31,7 +31,6 @@ export class Manipulator {
 
   public async Process(data: DataHandleRead, scope: DataStoreView, documentId?: string): Promise<DataHandleRead> {
     let nextId = (() => { let i = 0; return () => ++i; })();
-
     for (const trans of this.transformations) {
       // matches filter?
       if (this.MatchesSourceFilter(documentId || data.key, trans)) {

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -65,7 +65,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
   config.Message({ Channel: Channel.Debug, Text: `Done Composing Swaggers.` });
 
   // TRANSFORM
-  swagger = await manipulator.Process(swagger, config.DataStore.CreateScope("composite-transform"), "/composite.yaml");
+  swagger = await manipulator.Process(swagger, config.DataStore.CreateScope("composite-transform"), "/swagger-document.yaml");
 
   // emit resolved swagger
   {
@@ -135,7 +135,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
           const scope = genConfig.DataStore.CreateScope("plugin_" + ++pluginCtr);
 
           // TRANSFORM
-          const codeModelTransformed = await manipulator.Process(codeModelGFM, scope.CreateScope("transform"), "/model.yaml");
+          const codeModelTransformed = await manipulator.Process(codeModelGFM, scope.CreateScope("transform"), "/code-model-v1.yaml");
 
           emitArtifact(genConfig, "code-model-v1", ResolveUri(config.OutputFolderUri, "code-model.yaml"), codeModelTransformed);
 

--- a/src/autorest-core/test/directive.ts
+++ b/src/autorest-core/test/directive.ts
@@ -110,13 +110,13 @@ import { Message, Channel } from "../lib/message";
     const codeModelRef = await GenerateCodeModel({});
 
     // set descriptions in resolved swagger
-    const codeModelSetDescr1 = await GenerateCodeModel({ directive: { from: "composite", where: "$..description", set: "cowbell" } });
+    const codeModelSetDescr1 = await GenerateCodeModel({ directive: { from: "swagger-document", where: "$..description", set: "cowbell" } });
 
     // set descriptions in code model
-    const codeModelSetDescr2 = await GenerateCodeModel({ directive: { from: "model", where: ["$..description", "$..documentation", "$..['#documentation']"], set: "cowbell" } });
+    const codeModelSetDescr2 = await GenerateCodeModel({ directive: { from: "code-model-v1", where: ["$..description", "$..documentation", "$..['#documentation']"], set: "cowbell" } });
 
     // transform descriptions in resolved swagger
-    const codeModelSetDescr3 = await GenerateCodeModel({ directive: { from: "composite", where: "$..description", transform: "'cowbell'" } });
+    const codeModelSetDescr3 = await GenerateCodeModel({ directive: { from: "swagger-document", where: "$..description", transform: "return 'cowbell'" } });
 
     assert.ok(codeModelRef.indexOf("description: cowbell") === -1 && codeModelRef.indexOf("\"description\": \"cowbell\"") === -1);
     assert.ok(codeModelSetDescr1.indexOf("description: cowbell") !== -1 || codeModelSetDescr1.indexOf("\"description\": \"cowbell\"") !== -1);
@@ -124,7 +124,7 @@ import { Message, Channel } from "../lib/message";
     assert.strictEqual(codeModelSetDescr1, codeModelSetDescr3);
 
     // transform descriptions in resolved swagger to uppercase
-    const codeModelSetDescr4 = await GenerateCodeModel({ directive: { from: "composite", where: "$..description", transform: "$.toUpperCase()" } });
+    const codeModelSetDescr4 = await GenerateCodeModel({ directive: { from: "swagger-document", where: "$..description", transform: "return $.toUpperCase()" } });
     assert.notEqual(codeModelRef, codeModelSetDescr4);
     assert.strictEqual(codeModelRef.toLowerCase(), codeModelSetDescr4.toLowerCase());
   }

--- a/src/autorest-core/test/plugin.ts
+++ b/src/autorest-core/test/plugin.ts
@@ -43,7 +43,7 @@ import { LoadLiterateSwagger } from "../lib/pipeline/swagger-loader";
   }
 
   // TODO: remodel if we figure out acquisition story
-  @test @timeout(60000) async "openapi-validation-tools"() {
+  @test @timeout(0) async "openapi-validation-tools"() {
     const autoRest = new AutoRest(new RealFileSystem());
     autoRest.AddConfiguration({ "input-file": "https://github.com/olydis/azure-rest-api-specs/blob/amar-tests/arm-logic/2016-06-01/swagger/logic.json" });
     autoRest.AddConfiguration({ amar: true });

--- a/src/generator/AutoRest.CSharp/Model/CompositeTypeCs.cs
+++ b/src/generator/AutoRest.CSharp/Model/CompositeTypeCs.cs
@@ -145,9 +145,14 @@ namespace AutoRest.CSharp.Model
                 get
                 {
                     var declarations = new List<string>();
-                    foreach (var property in Parameters.Where(p => !p.UnderlyingProperty.IsConstant).Select(p => p.UnderlyingProperty))
+                    foreach (PropertyCs property in Parameters.Where(p => !p.UnderlyingProperty.IsConstant).Select(p => p.UnderlyingProperty))
                     {
                         string format = (property.IsRequired ? "{0} {1}" : "{0} {1} = default({0})");
+                        // for people who really want defaults to properties (be aware of the PATCH operation consequences!)
+                        if (property.UseDefaultInConstructor && property.DefaultValue != null)
+                        {
+                            format = "{0} {1} = " + property.DefaultValue;
+                        }
                         declarations.Add(string.Format(CultureInfo.InvariantCulture,
                             format, property.ModelTypeName, CodeNamer.Instance.CamelCase(property.Name)));
                     }

--- a/src/generator/AutoRest.CSharp/Model/PropertyCs.cs
+++ b/src/generator/AutoRest.CSharp/Model/PropertyCs.cs
@@ -13,5 +13,7 @@ namespace AutoRest.CSharp.Model
 
         public string HeaderCollectionPrefix => Extensions.GetValue<string>(SwaggerExtensions.HeaderCollectionPrefix);
         public bool IsHeaderCollection => !string.IsNullOrEmpty(HeaderCollectionPrefix);
+
+        public string InitialValueAssignment => IsRequired && DefaultValue != null ? $" = {DefaultValue};" : "";
     }
 }

--- a/src/generator/AutoRest.CSharp/Model/PropertyCs.cs
+++ b/src/generator/AutoRest.CSharp/Model/PropertyCs.cs
@@ -4,6 +4,7 @@
 using AutoRest.Core.Model;
 using AutoRest.Core.Utilities;
 using AutoRest.Extensions;
+using Newtonsoft.Json;
 
 namespace AutoRest.CSharp.Model
 {
@@ -14,6 +15,8 @@ namespace AutoRest.CSharp.Model
         public string HeaderCollectionPrefix => Extensions.GetValue<string>(SwaggerExtensions.HeaderCollectionPrefix);
         public bool IsHeaderCollection => !string.IsNullOrEmpty(HeaderCollectionPrefix);
 
-        public string InitialValueAssignment => IsRequired && DefaultValue != null ? $" = {DefaultValue};" : "";
+        // not spec copmpliant
+        [JsonProperty("useDefaultInConstructor")]
+        public bool UseDefaultInConstructor { get; set; } = false;
     }
 }

--- a/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
@@ -132,7 +132,7 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
         partial void CustomInit();
         
         @EmptyLine
-        @foreach (var property in Model.Properties.Where(p => !p.IsConstant))
+        @foreach (PropertyCs property in Model.Properties.Where(p => !p.IsConstant))
         {
         @:/// <summary>
         @:@WrapComment("/// ", property.GetFormattedPropertySummary())
@@ -168,7 +168,7 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
             {
         @:[Newtonsoft.Json.JsonProperty(PropertyName = "@property.SerializedName")]
             }
-        @:public @property.ModelTypeName @property.Name { get; @(property.IsReadOnly ? "private " : "")set; }
+        @:public @property.ModelTypeName @property.Name { get; @(property.IsReadOnly ? "private " : "")set; }@property.InitialValueAssignment
         @EmptyLine
         }
 

--- a/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
+++ b/src/generator/AutoRest.CSharp/Templates/Rest/Common/ModelTemplate.cshtml
@@ -168,7 +168,7 @@ namespace @(Settings.Namespace).@(Settings.ModelsName)
             {
         @:[Newtonsoft.Json.JsonProperty(PropertyName = "@property.SerializedName")]
             }
-        @:public @property.ModelTypeName @property.Name { get; @(property.IsReadOnly ? "private " : "")set; }@property.InitialValueAssignment
+        @:public @property.ModelTypeName @property.Name { get; @(property.IsReadOnly ? "private " : "")set; }
         @EmptyLine
         }
 


### PR DESCRIPTION
This PR puts a customization point into the C# generator that allows enabling default values on model constructors. 

This is how you activate it (for all composite types):
``` yaml
  directive:
    from: code-model-v1
    where: $..*[?(@.$type == "AutoRest.Core.Model.CompositeType, AutoRest.Core")].properties[*]
    transform: $.useDefaultInConstructor = true
```