### PR TITLE
Make long-running operations asynchronous.

### DIFF
--- a/Samples/1b-code-generation-multilang/Go/client.go
+++ b/Samples/1b-code-generation-multilang/Go/client.go
@@ -41,13 +41,15 @@ func New()ManagementClient {
     func (client ManagementClient) CreatePets() (result autorest.Response, err error) {
         req, err := client.CreatePetsPreparer()
         if err != nil {
-            return result, autorest.NewErrorWithError(err, ".ManagementClient", "CreatePets", nil , "Failure preparing request")
+            err = autorest.NewErrorWithError(err, ".ManagementClient", "CreatePets", nil , "Failure preparing request")
+            return
         }
 
         resp, err := client.CreatePetsSender(req)
         if err != nil {
             result.Response = resp
-            return result, autorest.NewErrorWithError(err, ".ManagementClient", "CreatePets", resp, "Failure sending request")
+            err = autorest.NewErrorWithError(err, ".ManagementClient", "CreatePets", resp, "Failure sending request")
+            return
         }
 
         result, err = client.CreatePetsResponder(resp)
@@ -91,13 +93,15 @@ func New()ManagementClient {
     func (client ManagementClient) ListPets(limit *int32) (result ListPetType, err error) {
         req, err := client.ListPetsPreparer(limit)
         if err != nil {
-            return result, autorest.NewErrorWithError(err, ".ManagementClient", "ListPets", nil , "Failure preparing request")
+            err = autorest.NewErrorWithError(err, ".ManagementClient", "ListPets", nil , "Failure preparing request")
+            return
         }
 
         resp, err := client.ListPetsSender(req)
         if err != nil {
             result.Response = autorest.Response{Response: resp}
-            return result, autorest.NewErrorWithError(err, ".ManagementClient", "ListPets", resp, "Failure sending request")
+            err = autorest.NewErrorWithError(err, ".ManagementClient", "ListPets", resp, "Failure sending request")
+            return
         }
 
         result, err = client.ListPetsResponder(resp)
@@ -149,13 +153,15 @@ func New()ManagementClient {
     func (client ManagementClient) ShowPetByID(petID string) (result ListPetType, err error) {
         req, err := client.ShowPetByIDPreparer(petID)
         if err != nil {
-            return result, autorest.NewErrorWithError(err, ".ManagementClient", "ShowPetByID", nil , "Failure preparing request")
+            err = autorest.NewErrorWithError(err, ".ManagementClient", "ShowPetByID", nil , "Failure preparing request")
+            return
         }
 
         resp, err := client.ShowPetByIDSender(req)
         if err != nil {
             result.Response = autorest.Response{Response: resp}
-            return result, autorest.NewErrorWithError(err, ".ManagementClient", "ShowPetByID", resp, "Failure sending request")
+            err = autorest.NewErrorWithError(err, ".ManagementClient", "ShowPetByID", resp, "Failure sending request")
+            return
         }
 
         result, err = client.ShowPetByIDResponder(resp)

--- a/src/generator/AutoRest.Go/Model/MethodGo.cs
+++ b/src/generator/AutoRest.Go/Model/MethodGo.cs
@@ -102,6 +102,21 @@ namespace AutoRest.Go.Model
             }
         }
 
+        /// <summary>
+        /// Returns true if this method should return its results via channels.
+        /// </summary>
+        public bool ReturnViaChannel
+        {
+            get
+            {
+                // pageable operations will be handled separately
+                return IsLongRunningOperation() && !IsPageable;
+            }
+        }
+
+        /// <summary>
+        /// Gets the return type name for this method.
+        /// </summary>
         public string MethodReturnType
         {
             get
@@ -110,6 +125,11 @@ namespace AutoRest.Go.Model
             }
         }
 
+        /// <summary>
+        /// Returns the method return signature for this method (e.g. "foo, bar").
+        /// </summary>
+        /// <param name="helper">Indicates if this method is a helper method (i.e. preparer/sender/responder).</param>
+        /// <returns>The method signature for this method.</returns>
         public string MethodReturnSignature(bool helper)
         {
             var retValType = MethodReturnType;

--- a/src/generator/AutoRest.Go/Model/MethodGo.cs
+++ b/src/generator/AutoRest.Go/Model/MethodGo.cs
@@ -102,14 +102,30 @@ namespace AutoRest.Go.Model
             }
         }
 
-        public string MethodReturnSignature
+        public string MethodReturnType
         {
             get
             {
-                return HasReturnValue()
-                    ? string.Format("result {0}, err error", ReturnValue().Body.Name)
-                    : "result autorest.Response, err error";
+                return HasReturnValue() ? ReturnValue().Body.Name.ToString() : "autorest.Response";
             }
+        }
+
+        public string MethodReturnSignature(bool helper)
+        {
+            var retValType = MethodReturnType;
+            var retVal = $"result {retValType}";
+            var errVal = "err error";
+
+            // for LROs return the response types via a channel.
+            // only do this for the "real" API; for "helper" methods
+            // i.e. preparer/sender/responder don't use a channel.
+            if (!helper && IsLongRunningOperation())
+            {
+                retVal = $"<-chan {retValType}";
+                errVal = "<-chan error";
+            }
+
+            return $"{retVal}, {errVal}";
         }
 
         public string NextMethodName => $"{Name}NextResults";

--- a/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
@@ -40,19 +40,21 @@
 }
 
 func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignature(false)) {
-@if (Model.IsLongRunningOperation())
+@if (Model.ReturnViaChannel)
 {
+    @:resultChan := make(chan @(Model.MethodReturnType), 1)
     @:errChan:= make(chan error, 1)
 }
 @if (Model.ParameterValidations.Length > 0)
 {
     @:if err := validation.Validate([]validation.Validation{
     @:@(Model.ParameterValidations)}); err != nil {
-    @if (Model.IsLongRunningOperation())
+    @if (Model.ReturnViaChannel)
     {
-    @:errChan <- validation.NewErrorWithValidationError(err, "redis.GroupClient", "Create")
+    @:errChan <- @(Model.ValidationError)
     @:close(errChan)
-    @:return nil, errChan
+    @:close(resultChan)
+    @:return resultChan, errChan
     }
     else
     {
@@ -61,9 +63,8 @@ func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignat
 @:}
 @:@EmptyLine
 }
-@if (Model.IsLongRunningOperation())
+@if (Model.ReturnViaChannel)
 {
-    @:resultChan := make(chan @(Model.MethodReturnType), 1)
     @:go func() {
         @:var err error
         @:var result @(Model.MethodReturnType)
@@ -92,7 +93,7 @@ func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignat
     if err != nil {
         err = @(Model.AutorestError("Failure responding to request", "resp"))
     }
-@if (Model.IsLongRunningOperation())
+@if (Model.ReturnViaChannel)
 {
     @:}()
     @:return resultChan, errChan

--- a/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
@@ -39,35 +39,69 @@
 @WrapComment("// ", sb.ToString())
 }
 
-func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignature) {
-    @if (Model.ParameterValidations.Length > 0)
-    {
+func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignature(false)) {
+@if (Model.IsLongRunningOperation())
+{
+    @:errChan:= make(chan error, 1)
+}
+@if (Model.ParameterValidations.Length > 0)
+{
     @:if err := validation.Validate([]validation.Validation{
-         @:@(Model.ParameterValidations)}); err != nil {
-             @:return result, @(Model.ValidationError)
-    @:}
-    @:@EmptyLine
+    @:@(Model.ParameterValidations)}); err != nil {
+    @if (Model.IsLongRunningOperation())
+    {
+    @:errChan <- validation.NewErrorWithValidationError(err, "redis.GroupClient", "Create")
+    @:close(errChan)
+    @:return nil, errChan
     }
+    else
+    {
+    @:return result, @(Model.ValidationError)
+    }
+@:}
+@:@EmptyLine
+}
+@if (Model.IsLongRunningOperation())
+{
+    @:resultChan := make(chan @(Model.MethodReturnType), 1)
+    @:go func() {
+        @:var err error
+        @:var result @(Model.MethodReturnType)
+
+        @:defer func() {
+            @:resultChan <- result
+            @:errChan <- err
+            @:close(resultChan)
+            @:close(errChan)
+        @:}()
+}
     req, err := client.@(Model.PreparerMethodName)(@(Model.HelperInvocationParameters))
     if err != nil {
-        return result, @(Model.AutorestError("Failure preparing request"))
+        err = @(Model.AutorestError("Failure preparing request"))
+        return
     }
-
-    @EmptyLine
+@EmptyLine
     resp, err := client.@(Model.SenderMethodName)(req)
     if err != nil {
         @(Model.Response)
-        return result, @(Model.AutorestError("Failure sending request", "resp"))
+        err = @(Model.AutorestError("Failure sending request", "resp"))
+        return
     }
-
-    @EmptyLine
+@EmptyLine
     result, err = client.@(Model.ResponderMethodName)(resp)
     if err != nil {
         err = @(Model.AutorestError("Failure responding to request", "resp"))
     }
-
+@if (Model.IsLongRunningOperation())
+{
+    @:}()
+    @:return resultChan, errChan
+}
+else
+{
     @EmptyLine
-    return
+    @:return
+}
 }
 
 @EmptyLine
@@ -151,7 +185,7 @@ func (client @(Model.Owner)) @(Model.SenderMethodName)(req *http.Request) (*http
 @EmptyLine
 // @(Model.ResponderMethodName) handles the response to the @(Model.Name) request. The method always
 // closes the http.Response Body.
-func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (@(Model.MethodReturnSignature)) { 
+func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (@(Model.MethodReturnSignature(true))) { 
     @if (Model.ReturnValue().Body.IsStreamType())
     {
     @:result.Value = &resp.Body
@@ -167,7 +201,7 @@ func (client @(Model.Owner)) @(Model.ResponderMethodName)(resp *http.Response) (
 {
 @:@EmptyLine
 @:// @(Model.NextMethodName) retrieves the next set of results, if any.
-@:func (client @(Model.Owner)) @(Model.NextMethodName)(lastResults @(Model.ReturnValue().Body.Name)) (@Model.MethodReturnSignature) {
+@:func (client @(Model.Owner)) @(Model.NextMethodName)(lastResults @(Model.ReturnValue().Body.Name)) (@Model.MethodReturnSignature(true)) {
     @:req, err := lastResults.@((Model.ReturnValue().Body as CompositeTypeGo).PreparerMethodName)()
     @:if err != nil {
         @:return result, @(Model.AutorestError("Failure preparing next results request"))


### PR DESCRIPTION
The current implementation requires end-users to write their own logic to
make LROs asynchronous; this change provides a default implementation.
LROs will execute in a go routine, using channels to communicate their
return values.