### PR TITLE
Fix some Python bugs

### DIFF
--- a/Samples/2a-arm-validation/Python/storage/storage_management_client.py
+++ b/Samples/2a-arm-validation/Python/storage/storage_management_client.py
@@ -57,9 +57,9 @@ class StorageManagementClient(object):
     :vartype config: StorageManagementClientConfiguration
 
     :ivar storage_accounts: StorageAccounts operations
-    :vartype storage_accounts: .operations.StorageAccountsOperations
+    :vartype storage_accounts: storage.operations.StorageAccountsOperations
     :ivar usage: Usage operations
-    :vartype usage: .operations.UsageOperations
+    :vartype usage: storage.operations.UsageOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/fixtures/acceptancetestsazurebodyduration/auto_rest_duration_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureBodyDuration/fixtures/acceptancetestsazurebodyduration/auto_rest_duration_test_service.py
@@ -51,7 +51,7 @@ class AutoRestDurationTestService(object):
     :vartype config: AutoRestDurationTestServiceConfiguration
 
     :ivar duration: Duration operations
-    :vartype duration: .operations.DurationOperations
+    :vartype duration: fixtures.acceptancetestsazurebodyduration.operations.DurationOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/fixtures/acceptancetestsazureparametergrouping/auto_rest_parameter_grouping_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureParameterGrouping/fixtures/acceptancetestsazureparametergrouping/auto_rest_parameter_grouping_test_service.py
@@ -51,7 +51,7 @@ class AutoRestParameterGroupingTestService(object):
     :vartype config: AutoRestParameterGroupingTestServiceConfiguration
 
     :ivar parameter_grouping: ParameterGrouping operations
-    :vartype parameter_grouping: .operations.ParameterGroupingOperations
+    :vartype parameter_grouping: fixtures.acceptancetestsazureparametergrouping.operations.ParameterGroupingOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/fixtures/acceptancetestsazurespecials/auto_rest_azure_special_parameters_test_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/AzureSpecials/fixtures/acceptancetestsazurespecials/auto_rest_azure_special_parameters_test_client.py
@@ -66,21 +66,21 @@ class AutoRestAzureSpecialParametersTestClient(object):
     :vartype config: AutoRestAzureSpecialParametersTestClientConfiguration
 
     :ivar xms_client_request_id: XMsClientRequestId operations
-    :vartype xms_client_request_id: .operations.XMsClientRequestIdOperations
+    :vartype xms_client_request_id: fixtures.acceptancetestsazurespecials.operations.XMsClientRequestIdOperations
     :ivar subscription_in_credentials: SubscriptionInCredentials operations
-    :vartype subscription_in_credentials: .operations.SubscriptionInCredentialsOperations
+    :vartype subscription_in_credentials: fixtures.acceptancetestsazurespecials.operations.SubscriptionInCredentialsOperations
     :ivar subscription_in_method: SubscriptionInMethod operations
-    :vartype subscription_in_method: .operations.SubscriptionInMethodOperations
+    :vartype subscription_in_method: fixtures.acceptancetestsazurespecials.operations.SubscriptionInMethodOperations
     :ivar api_version_default: ApiVersionDefault operations
-    :vartype api_version_default: .operations.ApiVersionDefaultOperations
+    :vartype api_version_default: fixtures.acceptancetestsazurespecials.operations.ApiVersionDefaultOperations
     :ivar api_version_local: ApiVersionLocal operations
-    :vartype api_version_local: .operations.ApiVersionLocalOperations
+    :vartype api_version_local: fixtures.acceptancetestsazurespecials.operations.ApiVersionLocalOperations
     :ivar skip_url_encoding: SkipUrlEncoding operations
-    :vartype skip_url_encoding: .operations.SkipUrlEncodingOperations
+    :vartype skip_url_encoding: fixtures.acceptancetestsazurespecials.operations.SkipUrlEncodingOperations
     :ivar odata: Odata operations
-    :vartype odata: .operations.OdataOperations
+    :vartype odata: fixtures.acceptancetestsazurespecials.operations.OdataOperations
     :ivar header: Header operations
-    :vartype header: .operations.HeaderOperations
+    :vartype header: fixtures.acceptancetestsazurespecials.operations.HeaderOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/fixtures/acceptancetestscustombaseuri/auto_rest_parameterized_host_test_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/CustomBaseUri/fixtures/acceptancetestscustombaseuri/auto_rest_parameterized_host_test_client.py
@@ -57,7 +57,7 @@ class AutoRestParameterizedHostTestClient(object):
     :vartype config: AutoRestParameterizedHostTestClientConfiguration
 
     :ivar paths: Paths operations
-    :vartype paths: .operations.PathsOperations
+    :vartype paths: fixtures.acceptancetestscustombaseuri.operations.PathsOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/fixtures/acceptancetestshead/auto_rest_head_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Head/fixtures/acceptancetestshead/auto_rest_head_test_service.py
@@ -50,7 +50,7 @@ class AutoRestHeadTestService(object):
     :vartype config: AutoRestHeadTestServiceConfiguration
 
     :ivar http_success: HttpSuccess operations
-    :vartype http_success: .operations.HttpSuccessOperations
+    :vartype http_success: fixtures.acceptancetestshead.operations.HttpSuccessOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/fixtures/acceptancetestsheadexceptions/auto_rest_head_exception_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/HeadExceptions/fixtures/acceptancetestsheadexceptions/auto_rest_head_exception_test_service.py
@@ -50,7 +50,7 @@ class AutoRestHeadExceptionTestService(object):
     :vartype config: AutoRestHeadExceptionTestServiceConfiguration
 
     :ivar head_exception: HeadException operations
-    :vartype head_exception: .operations.HeadExceptionOperations
+    :vartype head_exception: fixtures.acceptancetestsheadexceptions.operations.HeadExceptionOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/fixtures/acceptancetestslro/auto_rest_long_running_operation_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Lro/fixtures/acceptancetestslro/auto_rest_long_running_operation_test_service.py
@@ -54,13 +54,13 @@ class AutoRestLongRunningOperationTestService(object):
     :vartype config: AutoRestLongRunningOperationTestServiceConfiguration
 
     :ivar lr_os: LROs operations
-    :vartype lr_os: .operations.LROsOperations
+    :vartype lr_os: fixtures.acceptancetestslro.operations.LROsOperations
     :ivar lro_retrys: LRORetrys operations
-    :vartype lro_retrys: .operations.LRORetrysOperations
+    :vartype lro_retrys: fixtures.acceptancetestslro.operations.LRORetrysOperations
     :ivar lrosa_ds: LROSADs operations
-    :vartype lrosa_ds: .operations.LROSADsOperations
+    :vartype lrosa_ds: fixtures.acceptancetestslro.operations.LROSADsOperations
     :ivar lr_os_custom_header: LROsCustomHeader operations
-    :vartype lr_os_custom_header: .operations.LROsCustomHeaderOperations
+    :vartype lr_os_custom_header: fixtures.acceptancetestslro.operations.LROsCustomHeaderOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/fixtures/acceptancetestspaging/auto_rest_paging_test_service.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/Paging/fixtures/acceptancetestspaging/auto_rest_paging_test_service.py
@@ -51,7 +51,7 @@ class AutoRestPagingTestService(object):
     :vartype config: AutoRestPagingTestServiceConfiguration
 
     :ivar paging: Paging operations
-    :vartype paging: .operations.PagingOperations
+    :vartype paging: fixtures.acceptancetestspaging.operations.PagingOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/fixtures/acceptancetestsstoragemanagementclient/storage_management_client.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/StorageManagementClient/fixtures/acceptancetestsstoragemanagementclient/storage_management_client.py
@@ -61,9 +61,9 @@ class StorageManagementClient(object):
     :vartype config: StorageManagementClientConfiguration
 
     :ivar storage_accounts: StorageAccounts operations
-    :vartype storage_accounts: .operations.StorageAccountsOperations
+    :vartype storage_accounts: fixtures.acceptancetestsstoragemanagementclient.operations.StorageAccountsOperations
     :ivar usage: Usage operations
-    :vartype usage: .operations.UsageOperations
+    :vartype usage: fixtures.acceptancetestsstoragemanagementclient.operations.UsageOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/fixtures/acceptancetestssubscriptionidapiversion/microsoft_azure_test_url.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/Expected/AcceptanceTests/SubscriptionIdApiVersion/fixtures/acceptancetestssubscriptionidapiversion/microsoft_azure_test_url.py
@@ -58,7 +58,7 @@ class MicrosoftAzureTestUrl(object):
     :vartype config: MicrosoftAzureTestUrlConfiguration
 
     :ivar group: Group operations
-    :vartype group: .operations.GroupOperations
+    :vartype group: fixtures.acceptancetestssubscriptionidapiversion.operations.GroupOperations
 
     :param credentials: Credentials needed for the client to connect to Azure.
     :type credentials: :mod:`A msrestazure Credentials

--- a/src/generator/AutoRest.Python.Azure/Templates/AzureServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Python.Azure/Templates/AzureServiceClientTemplate.cshtml
@@ -112,7 +112,7 @@ class @(Model.Name)(object):
     foreach (var methodGroup in Model.MethodGroupModels)
     {
 @:    :ivar @(((string) methodGroup.Name).ToPythonCase()): @((string) methodGroup.Name) operations
-@:    :vartype @(((string) methodGroup.Name).ToPythonCase()): .operations.@((string) methodGroup.TypeName)
+@:    :vartype @(((string) methodGroup.Name).ToPythonCase()): @(Model.Namespace).operations.@((string) methodGroup.TypeName)
     }
 }
 @EmptyLine

--- a/src/generator/AutoRest.Python.Azure/TransformerPya.cs
+++ b/src/generator/AutoRest.Python.Azure/TransformerPya.cs
@@ -249,7 +249,6 @@ namespace AutoRest.Python.Azure
             codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "long_running_operation_retry_timeout"));
             codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "generate_client_request_id"));
             codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "accept_language"));
-            codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "api_version"));
 
             if (acceptLanguage != null) // && acceptLanguage.DefaultValue != "en-US"
             {

--- a/src/generator/AutoRest.Python.Tests/AcceptanceTests/validation_tests.py
+++ b/src/generator/AutoRest.Python.Tests/AcceptanceTests/validation_tests.py
@@ -55,8 +55,8 @@ class ValidationTests(unittest.TestCase):
     def test_constant_values(self):
         client = AutoRestValidationTest(
             "abc123",
-            "12-34-5678",
             base_url="http://localhost:3000")
+        client.api_version = "12-34-5678"
 
         client.get_with_constant_in_path()
 
@@ -67,8 +67,8 @@ class ValidationTests(unittest.TestCase):
     def test_validation(self):
         client = AutoRestValidationTest(
             "abc123",
-            "12-34-5678",
             base_url="http://localhost:3000")
+        client.api_version = "12-34-5678"
 
         try:
             client.validation_of_method_parameters("1", 100)
@@ -130,14 +130,14 @@ class ValidationTests(unittest.TestCase):
 
         client2 = AutoRestValidationTest(
             "abc123",
-            "abc",
             base_url="http://localhost:3000")
+        client2.api_version = "abc"
 
         try:
             client2.validation_of_method_parameters("123", 150)
         except ValidationError as err:
             self.assertEqual(err.rule, "pattern")
-            self.assertEqual(err.target, "self.config.api_version")
+            self.assertEqual(err.target, "self.api_version")
 
 
 if __name__ == '__main__':

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyArray/auto_rest_swagger_bat_array_service/auto_rest_swagger_bat_array_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyArray/auto_rest_swagger_bat_array_service/auto_rest_swagger_bat_array_service.py
@@ -42,7 +42,7 @@ class AutoRestSwaggerBATArrayService(object):
     :vartype config: AutoRestSwaggerBATArrayServiceConfiguration
 
     :ivar array: Array operations
-    :vartype array: .operations.ArrayOperations
+    :vartype array: fixtures.acceptancetestsbodyarray.operations.ArrayOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyBoolean/auto_rest_bool_test_service/auto_rest_bool_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyBoolean/auto_rest_bool_test_service/auto_rest_bool_test_service.py
@@ -42,7 +42,7 @@ class AutoRestBoolTestService(object):
     :vartype config: AutoRestBoolTestServiceConfiguration
 
     :ivar bool_model: BoolModel operations
-    :vartype bool_model: .operations.BoolModelOperations
+    :vartype bool_model: fixtures.acceptancetestsbodyboolean.operations.BoolModelOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyByte/auto_rest_swagger_bat_byte_service/auto_rest_swagger_bat_byte_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyByte/auto_rest_swagger_bat_byte_service/auto_rest_swagger_bat_byte_service.py
@@ -42,7 +42,7 @@ class AutoRestSwaggerBATByteService(object):
     :vartype config: AutoRestSwaggerBATByteServiceConfiguration
 
     :ivar byte: Byte operations
-    :vartype byte: .operations.ByteOperations
+    :vartype byte: fixtures.acceptancetestsbodybyte.operations.ByteOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/auto_rest_complex_test_service/auto_rest_complex_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/auto_rest_complex_test_service/auto_rest_complex_test_service.py
@@ -28,8 +28,6 @@ class AutoRestComplexTestServiceConfiguration(Configuration):
     Note that all parameters used to create this instance are saved as instance
     attributes.
 
-    :ivar api_version: API ID.
-    :type api_version: str
     :param str base_url: Service URL
     """
 
@@ -42,8 +40,6 @@ class AutoRestComplexTestServiceConfiguration(Configuration):
         super(AutoRestComplexTestServiceConfiguration, self).__init__(base_url)
 
         self.add_user_agent('autorestcomplextestservice/{}'.format(VERSION))
-
-        self.api_version = "2014-04-01-preview"
 
 
 class AutoRestComplexTestService(object):

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/auto_rest_complex_test_service/auto_rest_complex_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyComplex/auto_rest_complex_test_service/auto_rest_complex_test_service.py
@@ -49,21 +49,21 @@ class AutoRestComplexTestService(object):
     :vartype config: AutoRestComplexTestServiceConfiguration
 
     :ivar basic: Basic operations
-    :vartype basic: .operations.BasicOperations
+    :vartype basic: fixtures.acceptancetestsbodycomplex.operations.BasicOperations
     :ivar primitive: Primitive operations
-    :vartype primitive: .operations.PrimitiveOperations
+    :vartype primitive: fixtures.acceptancetestsbodycomplex.operations.PrimitiveOperations
     :ivar array: Array operations
-    :vartype array: .operations.ArrayOperations
+    :vartype array: fixtures.acceptancetestsbodycomplex.operations.ArrayOperations
     :ivar dictionary: Dictionary operations
-    :vartype dictionary: .operations.DictionaryOperations
+    :vartype dictionary: fixtures.acceptancetestsbodycomplex.operations.DictionaryOperations
     :ivar inheritance: Inheritance operations
-    :vartype inheritance: .operations.InheritanceOperations
+    :vartype inheritance: fixtures.acceptancetestsbodycomplex.operations.InheritanceOperations
     :ivar polymorphism: Polymorphism operations
-    :vartype polymorphism: .operations.PolymorphismOperations
+    :vartype polymorphism: fixtures.acceptancetestsbodycomplex.operations.PolymorphismOperations
     :ivar polymorphicrecursive: Polymorphicrecursive operations
-    :vartype polymorphicrecursive: .operations.PolymorphicrecursiveOperations
+    :vartype polymorphicrecursive: fixtures.acceptancetestsbodycomplex.operations.PolymorphicrecursiveOperations
     :ivar readonlyproperty: Readonlyproperty operations
-    :vartype readonlyproperty: .operations.ReadonlypropertyOperations
+    :vartype readonlyproperty: fixtures.acceptancetestsbodycomplex.operations.ReadonlypropertyOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDate/auto_rest_date_test_service/auto_rest_date_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDate/auto_rest_date_test_service/auto_rest_date_test_service.py
@@ -42,7 +42,7 @@ class AutoRestDateTestService(object):
     :vartype config: AutoRestDateTestServiceConfiguration
 
     :ivar date_model: DateModel operations
-    :vartype date_model: .operations.DateModelOperations
+    :vartype date_model: fixtures.acceptancetestsbodydate.operations.DateModelOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTime/auto_rest_date_time_test_service/auto_rest_date_time_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTime/auto_rest_date_time_test_service/auto_rest_date_time_test_service.py
@@ -42,7 +42,7 @@ class AutoRestDateTimeTestService(object):
     :vartype config: AutoRestDateTimeTestServiceConfiguration
 
     :ivar datetime_model: DatetimeModel operations
-    :vartype datetime_model: .operations.DatetimeModelOperations
+    :vartype datetime_model: fixtures.acceptancetestsbodydatetime.operations.DatetimeModelOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/auto_rest_rfc1123_date_time_test_service/auto_rest_rfc1123_date_time_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDateTimeRfc1123/auto_rest_rfc1123_date_time_test_service/auto_rest_rfc1123_date_time_test_service.py
@@ -42,7 +42,7 @@ class AutoRestRFC1123DateTimeTestService(object):
     :vartype config: AutoRestRFC1123DateTimeTestServiceConfiguration
 
     :ivar datetimerfc1123: Datetimerfc1123 operations
-    :vartype datetimerfc1123: .operations.Datetimerfc1123Operations
+    :vartype datetimerfc1123: fixtures.acceptancetestsbodydatetimerfc1123.operations.Datetimerfc1123Operations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDictionary/auto_rest_swagger_ba_tdictionary_service/auto_rest_swagger_ba_tdictionary_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDictionary/auto_rest_swagger_ba_tdictionary_service/auto_rest_swagger_ba_tdictionary_service.py
@@ -42,7 +42,7 @@ class AutoRestSwaggerBATdictionaryService(object):
     :vartype config: AutoRestSwaggerBATdictionaryServiceConfiguration
 
     :ivar dictionary: Dictionary operations
-    :vartype dictionary: .operations.DictionaryOperations
+    :vartype dictionary: fixtures.acceptancetestsbodydictionary.operations.DictionaryOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDuration/auto_rest_duration_test_service/auto_rest_duration_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyDuration/auto_rest_duration_test_service/auto_rest_duration_test_service.py
@@ -42,7 +42,7 @@ class AutoRestDurationTestService(object):
     :vartype config: AutoRestDurationTestServiceConfiguration
 
     :ivar duration: Duration operations
-    :vartype duration: .operations.DurationOperations
+    :vartype duration: fixtures.acceptancetestsbodyduration.operations.DurationOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFile/auto_rest_swagger_bat_file_service/auto_rest_swagger_bat_file_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFile/auto_rest_swagger_bat_file_service/auto_rest_swagger_bat_file_service.py
@@ -42,7 +42,7 @@ class AutoRestSwaggerBATFileService(object):
     :vartype config: AutoRestSwaggerBATFileServiceConfiguration
 
     :ivar files: Files operations
-    :vartype files: .operations.FilesOperations
+    :vartype files: fixtures.acceptancetestsbodyfile.operations.FilesOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFormData/auto_rest_swagger_bat_form_data_service/auto_rest_swagger_bat_form_data_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyFormData/auto_rest_swagger_bat_form_data_service/auto_rest_swagger_bat_form_data_service.py
@@ -42,7 +42,7 @@ class AutoRestSwaggerBATFormDataService(object):
     :vartype config: AutoRestSwaggerBATFormDataServiceConfiguration
 
     :ivar formdata: Formdata operations
-    :vartype formdata: .operations.FormdataOperations
+    :vartype formdata: fixtures.acceptancetestsbodyformdata.operations.FormdataOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyInteger/auto_rest_integer_test_service/auto_rest_integer_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyInteger/auto_rest_integer_test_service/auto_rest_integer_test_service.py
@@ -42,7 +42,7 @@ class AutoRestIntegerTestService(object):
     :vartype config: AutoRestIntegerTestServiceConfiguration
 
     :ivar int_model: IntModel operations
-    :vartype int_model: .operations.IntModelOperations
+    :vartype int_model: fixtures.acceptancetestsbodyinteger.operations.IntModelOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyNumber/auto_rest_number_test_service/auto_rest_number_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyNumber/auto_rest_number_test_service/auto_rest_number_test_service.py
@@ -42,7 +42,7 @@ class AutoRestNumberTestService(object):
     :vartype config: AutoRestNumberTestServiceConfiguration
 
     :ivar number: Number operations
-    :vartype number: .operations.NumberOperations
+    :vartype number: fixtures.acceptancetestsbodynumber.operations.NumberOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyString/auto_rest_swagger_bat_service/auto_rest_swagger_bat_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/BodyString/auto_rest_swagger_bat_service/auto_rest_swagger_bat_service.py
@@ -43,9 +43,9 @@ class AutoRestSwaggerBATService(object):
     :vartype config: AutoRestSwaggerBATServiceConfiguration
 
     :ivar string: String operations
-    :vartype string: .operations.StringOperations
+    :vartype string: fixtures.acceptancetestsbodystring.operations.StringOperations
     :ivar enum: Enum operations
-    :vartype enum: .operations.EnumOperations
+    :vartype enum: fixtures.acceptancetestsbodystring.operations.EnumOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUri/auto_rest_parameterized_host_test_client/auto_rest_parameterized_host_test_client.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUri/auto_rest_parameterized_host_test_client/auto_rest_parameterized_host_test_client.py
@@ -49,7 +49,7 @@ class AutoRestParameterizedHostTestClient(object):
     :vartype config: AutoRestParameterizedHostTestClientConfiguration
 
     :ivar paths: Paths operations
-    :vartype paths: .operations.PathsOperations
+    :vartype paths: fixtures.acceptancetestscustombaseuri.operations.PathsOperations
 
     :param host: A string value that is used as a global part of the
      parameterized host

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/auto_rest_parameterized_custom_host_test_client/auto_rest_parameterized_custom_host_test_client.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/CustomBaseUriMoreOptions/auto_rest_parameterized_custom_host_test_client/auto_rest_parameterized_custom_host_test_client.py
@@ -56,7 +56,7 @@ class AutoRestParameterizedCustomHostTestClient(object):
     :vartype config: AutoRestParameterizedCustomHostTestClientConfiguration
 
     :ivar paths: Paths operations
-    :vartype paths: .operations.PathsOperations
+    :vartype paths: fixtures.acceptancetestscustombaseurimoreoptions.operations.PathsOperations
 
     :param subscription_id: The subscription id with value 'test12'.
     :type subscription_id: str

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Header/auto_rest_swagger_bat_header_service/auto_rest_swagger_bat_header_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Header/auto_rest_swagger_bat_header_service/auto_rest_swagger_bat_header_service.py
@@ -42,7 +42,7 @@ class AutoRestSwaggerBATHeaderService(object):
     :vartype config: AutoRestSwaggerBATHeaderServiceConfiguration
 
     :ivar header: Header operations
-    :vartype header: .operations.HeaderOperations
+    :vartype header: fixtures.acceptancetestsheader.operations.HeaderOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Http/auto_rest_http_infrastructure_test_service/auto_rest_http_infrastructure_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Http/auto_rest_http_infrastructure_test_service/auto_rest_http_infrastructure_test_service.py
@@ -49,19 +49,19 @@ class AutoRestHttpInfrastructureTestService(object):
     :vartype config: AutoRestHttpInfrastructureTestServiceConfiguration
 
     :ivar http_failure: HttpFailure operations
-    :vartype http_failure: .operations.HttpFailureOperations
+    :vartype http_failure: fixtures.acceptancetestshttp.operations.HttpFailureOperations
     :ivar http_success: HttpSuccess operations
-    :vartype http_success: .operations.HttpSuccessOperations
+    :vartype http_success: fixtures.acceptancetestshttp.operations.HttpSuccessOperations
     :ivar http_redirects: HttpRedirects operations
-    :vartype http_redirects: .operations.HttpRedirectsOperations
+    :vartype http_redirects: fixtures.acceptancetestshttp.operations.HttpRedirectsOperations
     :ivar http_client_failure: HttpClientFailure operations
-    :vartype http_client_failure: .operations.HttpClientFailureOperations
+    :vartype http_client_failure: fixtures.acceptancetestshttp.operations.HttpClientFailureOperations
     :ivar http_server_failure: HttpServerFailure operations
-    :vartype http_server_failure: .operations.HttpServerFailureOperations
+    :vartype http_server_failure: fixtures.acceptancetestshttp.operations.HttpServerFailureOperations
     :ivar http_retry: HttpRetry operations
-    :vartype http_retry: .operations.HttpRetryOperations
+    :vartype http_retry: fixtures.acceptancetestshttp.operations.HttpRetryOperations
     :ivar multiple_responses: MultipleResponses operations
-    :vartype multiple_responses: .operations.MultipleResponsesOperations
+    :vartype multiple_responses: fixtures.acceptancetestshttp.operations.MultipleResponsesOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ParameterFlattening/auto_rest_parameter_flattening/auto_rest_parameter_flattening.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/ParameterFlattening/auto_rest_parameter_flattening/auto_rest_parameter_flattening.py
@@ -43,7 +43,7 @@ class AutoRestParameterFlattening(object):
     :vartype config: AutoRestParameterFlatteningConfiguration
 
     :ivar availability_sets: AvailabilitySets operations
-    :vartype availability_sets: .operations.AvailabilitySetsOperations
+    :vartype availability_sets: fixtures.acceptancetestsparameterflattening.operations.AvailabilitySetsOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/RequiredOptional/auto_rest_required_optional_test_service/auto_rest_required_optional_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/RequiredOptional/auto_rest_required_optional_test_service/auto_rest_required_optional_test_service.py
@@ -61,9 +61,9 @@ class AutoRestRequiredOptionalTestService(object):
     :vartype config: AutoRestRequiredOptionalTestServiceConfiguration
 
     :ivar implicit: Implicit operations
-    :vartype implicit: .operations.ImplicitOperations
+    :vartype implicit: fixtures.acceptancetestsrequiredoptional.operations.ImplicitOperations
     :ivar explicit: Explicit operations
-    :vartype explicit: .operations.ExplicitOperations
+    :vartype explicit: fixtures.acceptancetestsrequiredoptional.operations.ExplicitOperations
 
     :param required_global_path: number of items to skip
     :type required_global_path: str

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Url/auto_rest_url_test_service/auto_rest_url_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Url/auto_rest_url_test_service/auto_rest_url_test_service.py
@@ -58,11 +58,11 @@ class AutoRestUrlTestService(object):
     :vartype config: AutoRestUrlTestServiceConfiguration
 
     :ivar paths: Paths operations
-    :vartype paths: .operations.PathsOperations
+    :vartype paths: fixtures.acceptancetestsurl.operations.PathsOperations
     :ivar queries: Queries operations
-    :vartype queries: .operations.QueriesOperations
+    :vartype queries: fixtures.acceptancetestsurl.operations.QueriesOperations
     :ivar path_items: PathItems operations
-    :vartype path_items: .operations.PathItemsOperations
+    :vartype path_items: fixtures.acceptancetestsurl.operations.PathItemsOperations
 
     :param global_string_path: A string value 'globalItemStringPath' that
      appears in the path

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/auto_rest_url_mutli_collection_format_test_service/auto_rest_url_mutli_collection_format_test_service.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/UrlMultiCollectionFormat/auto_rest_url_mutli_collection_format_test_service/auto_rest_url_mutli_collection_format_test_service.py
@@ -42,7 +42,7 @@ class AutoRestUrlMutliCollectionFormatTestService(object):
     :vartype config: AutoRestUrlMutliCollectionFormatTestServiceConfiguration
 
     :ivar queries: Queries operations
-    :vartype queries: .operations.QueriesOperations
+    :vartype queries: fixtures.acceptancetestsurlmulticollectionformat.operations.QueriesOperations
 
     :param str base_url: Service URL
     """

--- a/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Validation/auto_rest_validation_test/auto_rest_validation_test.py
+++ b/src/generator/AutoRest.Python.Tests/Expected/AcceptanceTests/Validation/auto_rest_validation_test/auto_rest_validation_test.py
@@ -24,22 +24,16 @@ class AutoRestValidationTestConfiguration(Configuration):
 
     :param subscription_id: Subscription ID.
     :type subscription_id: str
-    :param api_version: Required string following pattern \\d{2}-\\d{2}-\\d{4}
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, subscription_id, api_version, base_url=None):
+            self, subscription_id, base_url=None):
 
         if subscription_id is None:
             raise ValueError("Parameter 'subscription_id' must not be None.")
         if not isinstance(subscription_id, str):
             raise TypeError("Parameter 'subscription_id' must be str.")
-        if api_version is None:
-            raise ValueError("Parameter 'api_version' must not be None.")
-        if not isinstance(api_version, str):
-            raise TypeError("Parameter 'api_version' must be str.")
         if not base_url:
             base_url = 'http://localhost'
 
@@ -48,7 +42,6 @@ class AutoRestValidationTestConfiguration(Configuration):
         self.add_user_agent('autorestvalidationtest/{}'.format(VERSION))
 
         self.subscription_id = subscription_id
-        self.api_version = api_version
 
 
 class AutoRestValidationTest(object):
@@ -59,15 +52,13 @@ class AutoRestValidationTest(object):
 
     :param subscription_id: Subscription ID.
     :type subscription_id: str
-    :param api_version: Required string following pattern \\d{2}-\\d{2}-\\d{4}
-    :type api_version: str
     :param str base_url: Service URL
     """
 
     def __init__(
-            self, subscription_id, api_version, base_url=None):
+            self, subscription_id, base_url=None):
 
-        self.config = AutoRestValidationTestConfiguration(subscription_id, api_version, base_url)
+        self.config = AutoRestValidationTestConfiguration(subscription_id, base_url)
         self._client = ServiceClient(None, self.config)
 
         client_models = {k: v for k, v in models.__dict__.items() if isinstance(v, type)}
@@ -108,7 +99,7 @@ class AutoRestValidationTest(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['apiVersion'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str', pattern='\d{2}-\d{2}-\d{4}')
+        query_parameters['apiVersion'] = self._serialize.query("self.api_version", self.api_version, 'str', pattern='\d{2}-\d{2}-\d{4}')
 
         # Construct headers
         header_parameters = {}
@@ -169,7 +160,7 @@ class AutoRestValidationTest(object):
 
         # Construct parameters
         query_parameters = {}
-        query_parameters['apiVersion'] = self._serialize.query("self.config.api_version", self.config.api_version, 'str', pattern='\d{2}-\d{2}-\d{4}')
+        query_parameters['apiVersion'] = self._serialize.query("self.api_version", self.api_version, 'str', pattern='\d{2}-\d{2}-\d{4}')
 
         # Construct headers
         header_parameters = {}

--- a/src/generator/AutoRest.Python/Model/ParameterPy.cs
+++ b/src/generator/AutoRest.Python/Model/ParameterPy.cs
@@ -13,14 +13,13 @@ namespace AutoRest.Python.Model
     {
         public ParameterPy()
         {
-            // constant properties should be prefixed with ".self"
             Name.OnGet += value =>
             {
                 if (!value.StartsWith("self."))
                 {
                     // api_version is always at the first level, operation group or client
                     // if it's a client property (could be a method property)
-                    if (value == "api_version" && IsClientProperty && IsConstant)
+                    if (value == "api_version" && IsClientProperty)
                     {
                         return $"self.{value}";
                     }
@@ -29,12 +28,6 @@ namespace AutoRest.Python.Model
                     {
                         return $"self.config.{value}";
                     }
-
-                    if (IsConstant && IsClientProperty)
-                    {
-                        return $"self.{value}";
-                    }
-                   
                 }
                 return value;
             };

--- a/src/generator/AutoRest.Python/Templates/ServiceClientTemplate.cshtml
+++ b/src/generator/AutoRest.Python/Templates/ServiceClientTemplate.cshtml
@@ -102,7 +102,7 @@ class @(Model.Name)(object):
   foreach (var methodGroup in Model.MethodGroupModels)
   {
 @:    :ivar @(((string) methodGroup.Name).ToPythonCase()): @((string) methodGroup.Name) operations
-@:    :vartype @(((string) methodGroup.Name).ToPythonCase()): .operations.@((string) methodGroup.TypeName)
+@:    :vartype @(((string) methodGroup.Name).ToPythonCase()): @(Model.Namespace).operations.@((string) methodGroup.TypeName)
   }
 }
 @EmptyLine

--- a/src/generator/AutoRest.Python/TransformerPy.cs
+++ b/src/generator/AutoRest.Python/TransformerPy.cs
@@ -25,6 +25,9 @@ namespace AutoRest.Python
             // provides a default value now for Namespace, so Namespace is never empty.
             codeModel.Namespace = Settings.Instance.Namespace.Else(codeModel.Name.ToPythonCase().ToLower());
 
+            // api_version is no longer a parameter of the constructor
+            codeModel.Remove(codeModel.Properties.FirstOrDefault(p => p.Name == "api_version"));
+
             TransformGroupApiVersionToLocal(codeModel);
             SwaggerExtensions.NormalizeClientModel(codeModel);
             PopulateAdditionalProperties(codeModel);


### PR DESCRIPTION
- Fix scenarios I missed in https://github.com/Azure/autorest/pull/1916:
   - If methods are directly in the client (seen in KV)
   - Move transfomer code from Python.Azure to Python, so both generator get the improvement

- Fix a missing Namespace in Docstring that breaks generated documentation cross links