### PR TITLE
Code change to exclude CRs from List By RG/Subscription rules

### DIFF
--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/swagger-tracked-resource-2-validation.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/swagger-tracked-resource-2-validation.json
@@ -16,12 +16,57 @@
     "application/json"
   ],
   "paths": {
-    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}": {      
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}": {
       "get": {
         "tags": [
           "Zones"
         ],
         "operationId": "Zones_Get",
+        "description": "Gets a DNS zone. Retrieves the zone properties, but not the record sets within the zone.",
+        "parameters": [
+          {
+            "name": "resourceGroupName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the resource group."
+          },
+          {
+            "name": "zoneName",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "description": "The name of the DNS zone (without a terminating dot)."
+          },
+          {
+            "$ref": "#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/SubscriptionIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success.",
+            "schema": {
+              "$ref": "#/definitions/Zone"
+            }
+          },
+          "default": {
+            "description": "Default response. It will be deserialized as per the Error definition.",
+            "schema": {
+              "$ref": "#/definitions/Zone"
+            }
+          }
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/dnsZones/{zoneName}/crs/{cr1}": {
+      "get": {
+        "tags": [
+          "Zones"
+        ],
+        "operationId": "Crs_Get",
         "description": "Gets a DNS zone. Retrieves the zone properties, but not the record sets within the zone.",
         "parameters": [
           {

--- a/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
@@ -505,6 +505,13 @@ namespace AutoRest.Swagger.Model.Utilities
             return pathToEvaluate.Substring(pathToEvaluate.LastIndexOf("/") + 1);
         }
 
+        /// <summary>
+        /// Gets the actual parent resource name. For example, the name in Path could be 'servers'. The actual parent name is 'server'.
+        /// </summary>
+        /// <param name="nameInPath"></param>
+        /// <param name="paths"></param>
+        /// <param name="definitions"></param>
+        /// <returns></returns>
         private static string GetActualParentResourceName(string nameInPath, Dictionary<string, Dictionary<string, Operation>> paths, Dictionary<string, Schema> definitions)
         {
             Regex pathRegEx = new Regex("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/.*/" + nameInPath + "/{[^/]+}$", RegexOptions.IgnoreCase);

--- a/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
+++ b/src/modeler/AutoRest.Swagger/Model/ValidationUtilities.cs
@@ -457,5 +457,140 @@ namespace AutoRest.Swagger.Model.Utilities
         /// <returns>HTTP verb corresponding to the operationId</returns>
         public static string GetOperationIdVerb(string operationId, KeyValuePair<string, Dictionary<string, Operation>> pathObj)
             => pathObj.Value.First(opObj => opObj.Value.OperationId == operationId).Key;
+
+        /// <summary>
+        /// Get the list of all ChildTrackedResources along with their immediate parents.
+        /// </summary>
+        /// <param name="serviceDefinition">Service Definition</param>
+        /// <returns>list of child tracked resources</returns>
+        public static IEnumerable<KeyValuePair<string, string>> GetChildTrackedResourcesWithImmediateParent(ServiceDefinition serviceDefinition)
+        {
+            LinkedList<KeyValuePair<string, string>> result = new LinkedList<KeyValuePair<string, string>>();
+            foreach (KeyValuePair<string, Dictionary<string, Operation>> pathDefinition in serviceDefinition.Paths)
+            {
+                KeyValuePair<string, string> childResourceMapping = GetChildAndImmediateParentResource(pathDefinition.Key, serviceDefinition.Paths, serviceDefinition.Definitions);
+                if (childResourceMapping.Key != null && childResourceMapping.Value != null)
+                {
+                    result.AddLast(new LinkedListNode<KeyValuePair<string, string>>(new KeyValuePair<string, string>(childResourceMapping.Key, childResourceMapping.Value)));
+                }
+            }
+
+            return result;
+        }
+
+        private static KeyValuePair<string, string> GetChildAndImmediateParentResource(string path, Dictionary<string, Dictionary<string, Operation>> paths, Dictionary<string, Schema> definitions)
+        {
+            Match match = resourcePathPattern.Match(path);
+            KeyValuePair<string, string> result = new KeyValuePair<string, string>();
+            if (match.Success)
+            {
+                string childResourceName = match.Groups["childresource"].Value;
+                string immediateParentResourceNameInPath = GetImmediateParentResourceName(path);
+                string immediateParentResourceNameActual = GetActualParentResourceName(immediateParentResourceNameInPath, paths, definitions);
+                result = new KeyValuePair<string, string>(childResourceName, immediateParentResourceNameActual);
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the immediate parent resource name
+        /// </summary>
+        /// <param name="childResourcePaths">paths that fits the child resource criteria</param>
+        /// <returns>name of the immediate parent resource name</returns>
+        private static string GetImmediateParentResourceName(string pathToEvaluate)
+        {
+            pathToEvaluate = pathToEvaluate.Substring(0, pathToEvaluate.LastIndexOf("/{"));
+            pathToEvaluate = pathToEvaluate.Substring(0, pathToEvaluate.LastIndexOf("/{"));
+            return pathToEvaluate.Substring(pathToEvaluate.LastIndexOf("/") + 1);
+        }
+
+        private static string GetActualParentResourceName(string nameInPath, Dictionary<string, Dictionary<string, Operation>> paths, Dictionary<string, Schema> definitions)
+        {
+            Regex pathRegEx = new Regex("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/.*/" + nameInPath + "/{[^/]+}$", RegexOptions.IgnoreCase);
+
+            IEnumerable<KeyValuePair<string, Dictionary<string, Operation>>> matchingPaths = paths.Where((KeyValuePair<string, Dictionary<string, Operation>> pth) => pathRegEx.IsMatch(pth.Key));
+            if (!matchingPaths.Any()) return null;
+            KeyValuePair<string, Dictionary<string, Operation>> path = matchingPaths.First();
+
+            IEnumerable<KeyValuePair<string, Operation>> operations = path.Value.Where(op => op.Key.Equals("get", StringComparison.CurrentCultureIgnoreCase));
+            if (!operations.Any()) return null;
+            KeyValuePair<string, Operation> operation = operations.First();
+
+            IEnumerable<KeyValuePair<string, OperationResponse>> responses = operation.Value.Responses.Where(resp => resp.Key.Equals("200"));
+            if (!responses.Any()) return null;
+            KeyValuePair<string, OperationResponse> response = responses.First();
+
+            return GetReferencedModel(response.Value.Schema.Reference, definitions);
+        }
+
+        private static string GetReferencedModel(String schema, Dictionary<string, Schema> definitions)
+        {
+            Schema referencedSchema = Schema.FindReferencedSchema(schema, definitions);
+
+            if (referencedSchema == null) return null;
+
+            if (referencedSchema.Reference == null)
+            {
+                IEnumerable<KeyValuePair<string, Schema>> definition = definitions.Where(def => def.Value == referencedSchema);
+                if (!definition.Any()) return null;
+                return definition.First().Key;
+            }
+
+            return GetReferencedModel(referencedSchema.Reference, definitions);
+        }
+
+        /*
+         * This regular expression tries to filter the paths which has child resources. Now we could take the following paths:
+         *
+         *      Case 1: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}
+         *      Case 2: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/poweroff
+         *      Case 3: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases
+         *      Case 4: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{database1}
+         *      Case 5: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{database1}/restart
+         *
+         * Case 1 does not have a child resource. So, this can be rejected.
+         *
+         * Case 2 & Case 3 are special cases. Here, Case 3 does have a child resource - 'databases'. But, Case 2 does not have a child resource. The 'poweroff' is 
+         * an operation - not a child resource. But, it is difficult to determine, using regular expressions, whether the 'poweroff' is an operation or child resource.
+         * We could filter both and determine based on the response whether it is a child resource. While this is valid, it seems to be complex. So, a decision has been
+         * made to reject this pattern altogether and not look for child resource in this path pattern. Note: Case 5 is also rejected for the same reason.
+         *
+         * Case 4 is a valid scenario which has a child resource. Also, in this pattern, there is no ambiguity about any operation. So, in order to find the path, with 
+         * child resources, we use only this pattern. i.e. the path must have atleast one parent resource similar to '/servers/{server1}' followed by any number of child
+         * resources and end with the child resource pattern - similar to '/databases/{database1}'.
+         *
+         * Note: If in a swagger file, there are the following paths:
+         *
+         *      1: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}
+         *      2: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases
+         *
+         * and do not have the following path:
+         *
+         *      3: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{database1}
+         *
+         * then we will miss the child resource 'databases'. But, the possibility of such an occurence is extremely rare, if not impossible. It is quite possible that 
+         * 1 & 3 are present without 2 and 1-2-3 are present. So, it is fine to use this logic.
+         *
+         * Immediate Parent Resource Logic
+         * ===============================
+         * The path with the child resource has been determined and the name of the child resource has been identified. Now, in order to find the immediate parent resource,
+         * consider the following cases:
+         *
+         *      1. /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1} - Child: databases-Immediate Parent: servers
+         *      2. /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1}/disks/{disk1} - Child: disks-Immediate Parent: databases
+         *
+         *  So, we do string manipulation to determine the immediate parent. We find the last index of "/{" twice and remove after that. Then we find the last index of "/" and find the string after that.
+         *  To visualize it:
+         *
+         *      Start: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1}/disks/{disk1}
+         *      Step 1: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1}/disks
+         *      Step 2: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases
+         *      Step 3: databases
+         */
+        private static readonly Regex resourcePathPattern = new Regex("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/[^/]+/[^/]+/{[^/]+}.*/(?<childresource>\\w+)/{[^/]+}$", RegexOptions.IgnoreCase);
+
+        public static IEnumerable<string> GetParentTrackedResources(IEnumerable<string> trackedResourceModels, IEnumerable<KeyValuePair<string, string>> childTrackedResourceModels)
+            => trackedResourceModels.Where(resourceModel => !childTrackedResourceModels.Any(childModel => childModel.Key.Equals(resourceModel)));
     }
 }

--- a/src/modeler/AutoRest.Swagger/Validation/Core/RuleContext.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Core/RuleContext.cs
@@ -38,6 +38,8 @@ namespace AutoRest.Swagger.Validation.Core
             this.File = parent?.File;
             this.ResourceModels = parent?.ResourceModels;
             this.TrackedResourceModels = parent?.TrackedResourceModels;
+            this.ChildTrackedResourceModels = parent?.ChildTrackedResourceModels;
+            this.ParentTrackedResourceModels = parent?.ParentTrackedResourceModels;
             this.ProxyResourceModels = parent?.ProxyResourceModels;
         }
 
@@ -101,6 +103,16 @@ namespace AutoRest.Swagger.Validation.Core
         public IEnumerable<string> TrackedResourceModels { get; private set; }
 
         /// <summary>
+        /// List of child tracked resources in serviceDefinition
+        /// </summary>
+        public IEnumerable<KeyValuePair<string, string>> ChildTrackedResourceModels { get; private set; }
+
+        /// <summary>
+        /// List of parent tracked resources in serviceDefinition
+        /// </summary>
+        public IEnumerable<string> ParentTrackedResourceModels { get; private set; }
+
+        /// <summary>
         /// List of proxy resources in serviceDefinition
         /// </summary>
         public IEnumerable<string> ProxyResourceModels { get; private set; }
@@ -121,6 +133,8 @@ namespace AutoRest.Swagger.Validation.Core
         {
             this.ResourceModels = ValidationUtilities.GetResourceModels(serviceDefinition).ToList();
             this.TrackedResourceModels = ValidationUtilities.GetTrackedResources(this.ResourceModels, serviceDefinition.Definitions).ToList();
+            this.ChildTrackedResourceModels = ValidationUtilities.GetChildTrackedResourcesWithImmediateParent(serviceDefinition).ToList();
+            this.ParentTrackedResourceModels = ValidationUtilities.GetParentTrackedResources(this.TrackedResourceModels, this.ChildTrackedResourceModels).ToList();
             this.ProxyResourceModels = this.ResourceModels.Except(this.TrackedResourceModels).ToList();
         }
 

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceListByImmediateParent.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceListByImmediateParent.cs
@@ -35,118 +35,6 @@ namespace AutoRest.Swagger.Validation
         /// </summary>
         public override Category Severity => Category.Warning;
 
-        /*
-         * This regular expression tries to filter the paths which has child resources. Now we could take the following paths:
-         *
-         *      Case 1: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}
-         *      Case 2: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/poweroff
-         *      Case 3: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases
-         *      Case 4: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{database1}
-         *      Case 5: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{database1}/restart
-         *
-         * Case 1 does not have a child resource. So, this can be rejected.
-         *
-         * Case 2 & Case 3 are special cases. Here, Case 3 does have a child resource - 'databases'. But, Case 2 does not have a child resource. The 'poweroff' is 
-         * an operation - not a child resource. But, it is difficult to determine, using regular expressions, whether the 'poweroff' is an operation or child resource.
-         * We could filter both and determine based on the response whether it is a child resource. While this is valid, it seems to be complex. So, a decision has been
-         * made to reject this pattern altogether and not look for child resource in this path pattern. Note: Case 5 is also rejected for the same reason.
-         *
-         * Case 4 is a valid scenario which has a child resource. Also, in this pattern, there is no ambiguity about any operation. So, in order to find the path, with 
-         * child resources, we use only this pattern. i.e. the path must have atleast one parent resource similar to '/servers/{server1}' followed by any number of child
-         * resources and end with the child resource pattern - similar to '/databases/{database1}'.
-         *
-         * Note: If in a swagger file, there are the following paths:
-         *
-         *      1: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}
-         *      2: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases
-         *
-         * and do not have the following path:
-         *
-         *      3: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{database1}
-         *
-         * then we will miss the child resource 'databases'. But, the possibility of such an occurence is extremely rare, if not impossible. It is quite possible that 
-         * 1 & 3 are present without 2 and 1-2-3 are present. So, it is fine to use this logic.
-         *
-         * Immediate Parent Resource Logic
-         * ===============================
-         * The path with the child resource has been determined and the name of the child resource has been identified. Now, in order to find the immediate parent resource,
-         * consider the following cases:
-         *
-         *      1. /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1} - Child: databases-Immediate Parent: servers
-         *      2. /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1}/disks/{disk1} - Child: disks-Immediate Parent: databases
-         *
-         *  So, we do string manipulation to determine the immediate parent. We find the last index of "/{" twice and remove after that. Then we find the last index of "/" and find the string after that.
-         *  To visualize it:
-         *
-         *      Start: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1}/disks/{disk1}
-         *      Step 1: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases/{databases1}/disks
-         *      Step 2: /subscriptions/{subscriptionId}/resourceGroup/{resourceGroupName}/providers/Microsoft.Sql/servers/{server1}/databases
-         *      Step 3: databases
-         */
-        private static readonly Regex resourcePathPattern = new Regex("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/[^/]+/[^/]+/{[^/]+}.*/(?<childresource>\\w+)/{[^/]+}$", RegexOptions.IgnoreCase);
-
-        private KeyValuePair<string, string> GetChildAndImmediateParentResource(string path, Dictionary<string, Dictionary<string, Operation>> paths, Dictionary<string, Schema> definitions)
-        {
-            Match match = resourcePathPattern.Match(path);
-            KeyValuePair<string, string> result = new KeyValuePair<string, string>();
-            if (match.Success)
-            {
-                string childResourceName = match.Groups["childresource"].Value;
-                string immediateParentResourceNameInPath = GetImmediateParentResourceName(path);
-                string immediateParentResourceNameActual = GetActualParentResourceName(immediateParentResourceNameInPath, paths, definitions);
-                result = new KeyValuePair<string, string>(childResourceName, immediateParentResourceNameActual);
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the immediate parent resource name
-        /// </summary>
-        /// <param name="childResourcePaths">paths that fits the child resource criteria</param>
-        /// <returns>name of the immediate parent resource name</returns>
-        private string GetImmediateParentResourceName(string pathToEvaluate)
-        {
-            pathToEvaluate = pathToEvaluate.Substring(0, pathToEvaluate.LastIndexOf("/{"));
-            pathToEvaluate = pathToEvaluate.Substring(0, pathToEvaluate.LastIndexOf("/{"));
-            return pathToEvaluate.Substring(pathToEvaluate.LastIndexOf("/") + 1);
-        }
-
-        private string GetActualParentResourceName(string nameInPath, Dictionary<string, Dictionary<string, Operation>> paths, Dictionary<string, Schema> definitions)
-        {
-            Regex pathRegEx = new Regex("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/.*/" + nameInPath + "/{[^/]+}$", RegexOptions.IgnoreCase);
-
-            IEnumerable<KeyValuePair<string, Dictionary<string, Operation>>> matchingPaths = paths.Where((KeyValuePair<string, Dictionary<string, Operation>> pth) => pathRegEx.IsMatch(pth.Key));
-            if (!matchingPaths.Any()) return null;
-            KeyValuePair<string, Dictionary<string, Operation>> path = matchingPaths.First();
-
-            IEnumerable<KeyValuePair<string, Operation>> operations = path.Value.Where(op => op.Key.Equals("get", StringComparison.CurrentCultureIgnoreCase));
-            if (!operations.Any()) return null;
-            KeyValuePair<string, Operation>  operation = operations.First();
-
-            IEnumerable<KeyValuePair<string, OperationResponse>> responses = operation.Value.Responses.Where(resp => resp.Key.Equals("200"));
-            if (!responses.Any()) return null;
-            KeyValuePair<string, OperationResponse> response = responses.First();
-
-            return GetReferencedModel(response.Value.Schema.Reference, definitions);
-        }
-
-        private string GetReferencedModel(String schema, Dictionary<string, Schema> definitions)
-        {
-            Schema referencedSchema = Schema.FindReferencedSchema(schema, definitions);
-
-            if (referencedSchema == null) return null;
-
-            if (referencedSchema.Reference == null)
-            {
-                IEnumerable<KeyValuePair<string, Schema>> definition = definitions.Where(def => def.Value == referencedSchema);
-                if (!definition.Any()) return null;
-                return definition.First().Key;
-            }
-            
-            return GetReferencedModel(referencedSchema.Reference, definitions);
-        }
-
         /// <summary>
         /// Validates if the child tracked resources have List by immediate parent operation.
         /// </summary>
@@ -155,24 +43,19 @@ namespace AutoRest.Swagger.Validation
         /// <returns></returns>
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Dictionary<string, Operation>> paths, RuleContext context)
         {
-            foreach(KeyValuePair<string, Dictionary<string, Operation>> pathDefinition in paths)
+            foreach(KeyValuePair<string, string> childResourceMapping in context.ChildTrackedResourceModels)
             {
-                KeyValuePair<string, string> childResourceMapping = GetChildAndImmediateParentResource(pathDefinition.Key, paths, context.Root.Definitions);
-                if(childResourceMapping.Key != null && childResourceMapping.Value != null)
+                string operationIdToFind = childResourceMapping.Key + "_ListBy" + childResourceMapping.Value;
+                bool listByImmediateParent = paths.Any(filteredPath =>
+                    filteredPath.Value.Any(operationKeyValuePair => operationKeyValuePair.Value.OperationId.Equals(operationIdToFind, StringComparison.CurrentCultureIgnoreCase))
+                );
+                if (!listByImmediateParent)
                 {
-                    string operationIdToFind = childResourceMapping.Key + "_ListBy" + childResourceMapping.Value;
-                    bool listByImmediateParent = paths.Any(filteredPath =>
-                        filteredPath.Value.Any(operationKeyValuePair => operationKeyValuePair.Value.OperationId.Equals(operationIdToFind, StringComparison.CurrentCultureIgnoreCase))
-                    );
-                    if (!listByImmediateParent)
-                    {
-                        object[] formatParameters = new object[2];
-                        formatParameters[0] = childResourceMapping.Key;
-                        formatParameters[1] = childResourceMapping.Value;
+                    object[] formatParameters = new object[2];
+                    formatParameters[0] = childResourceMapping.Key;
+                    formatParameters[1] = childResourceMapping.Value;
 
-                        yield return new ValidationMessage(new FileObjectPath(context.File, context.Path.AppendProperty("#/definitions/" + childResourceMapping.Key)), this, formatParameters);
-                    }
-
+                    yield return new ValidationMessage(new FileObjectPath(context.File, context.Path.AppendProperty("#/definitions/" + childResourceMapping.Key)), this, formatParameters);
                 }
             }
         }

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceListByResourceGroup.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceListByResourceGroup.cs
@@ -47,12 +47,12 @@ namespace AutoRest.Swagger.Validation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
             // Retrieve the list of TrackedResources
-            IEnumerable<string> trackedResources = context.TrackedResourceModels;
+            IEnumerable<string> parentTrackedResources = context.ParentTrackedResourceModels;
 
             // Retrieve the list of getOperations
             IEnumerable<Operation> getOperations = ValidationUtilities.GetOperationsByRequestMethod("get", context.Root);
 
-            foreach (string trackedResource in trackedResources)
+            foreach (string trackedResource in parentTrackedResources)
             {
                 bool listByResourceGroupCheck = ValidationUtilities.ListByXCheck(getOperations, listByRgRegEx, trackedResource, definitions);
 

--- a/src/modeler/AutoRest.Swagger/Validation/TrackedResourceListBySubscription.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/TrackedResourceListBySubscription.cs
@@ -47,12 +47,12 @@ namespace AutoRest.Swagger.Validation
         public override IEnumerable<ValidationMessage> GetValidationMessages(Dictionary<string, Schema> definitions, RuleContext context)
         {
             // Retrieve the list of TrackedResources
-            IEnumerable<string> trackedResources = context.TrackedResourceModels;
+            IEnumerable<string> parentTrackedResources = context.ParentTrackedResourceModels;
 
             // Retrieve the list of getOperations
             IEnumerable<Operation> getOperations = ValidationUtilities.GetOperationsByRequestMethod("get", context.Root);
 
-            foreach (string trackedResource in trackedResources)
+            foreach (string trackedResource in parentTrackedResources)
             {
                 bool listBySubscriptionsCheck = ValidationUtilities.ListByXCheck(getOperations, listBySidRegEx, trackedResource, definitions);
 


### PR DESCRIPTION
There are atleast 3 changes suggested to Tracked Resources validation. This PR covers one of them. What does this PR do?

Currently, we apply the ListByResourceGroup and ListBySubscription rules on both parent and child resources. This is incorrect. We must apply the rules only on the parent resources. 

No regeneration changes.

@veronicagg @vishrutshah @dsgouda @salameer Please approve

Related to https://github.com/Azure/autorest/issues/2172