### PR TITLE
THE PIPELINE (and some fixes)

### DIFF
--- a/Samples/1d-common-settings/readme.md
+++ b/Samples/1d-common-settings/readme.md
@@ -60,6 +60,7 @@ Some settings are specific to plugins, such as:
 - `add-credentials` which adds a `Credentials` property to C# Azure clients
 - `sync-methods` which allows specifying whether synchronous wrappers for asynchronous methods should be generated (discouraged!)
 - `payload-flattening-threshold` which controls whether a body parameter should be passed directly (as an argument to the generated method) or whether its properties should be passed as arguments. As the latter option makes sense for body parameter types with few properties (less overhead for `new`ing), this setting is a threshold specifying when to use which option.
+- `client-side-validation` which controls whether or not client side validation of constrains such as `minLength`, `maximum` or `pattern` is desired
 
 ``` yaml
 csharp:
@@ -69,5 +70,5 @@ csharp:
     license-header: MICROSOFT_MIT # override the `license-header` defined at the top level. (see above)
     sync-methods: none # other possible values: essential, all
     payload-flattening-threshold: 3 # body parameter types with 3 or less properties cause method to expect those properties instead of an object 
-    client-side-validation: false
+    client-side-validation: false # disable client side validation
 ```

--- a/Samples/3b-custom-transformations/Client/code-model-v1.yaml
+++ b/Samples/3b-custom-transformations/Client/code-model-v1.yaml
@@ -1,0 +1,3936 @@
+---
+modelTypes:
+  - $id: '1'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '2'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - name
+        realXmlPath:
+          - name
+        collectionFormat: none
+        isRequired: true
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '3'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#name': name
+        '#serializedName': name
+      - $id: '4'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - type
+        realXmlPath:
+          - type
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '5'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#defaultValue': Microsoft.Storage/storageAccounts
+        '#name': type
+        '#serializedName': type
+    containsConstantProperties: false
+    className: StorageAccountCheckNameAvailabilityParameters
+    declarationName: StorageAccountCheckNameAvailabilityParameters
+    '#serializedName': StorageAccountCheckNameAvailabilityParameters
+    '#name': StorageAccountCheckNameAvailabilityParameters
+  - $id: '6'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '7'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - nameAvailable
+        realXmlPath:
+          - nameAvailable
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: Boolean
+        modelType:
+          $id: '8'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: boolean
+          className: Boolean
+          declarationName: Boolean
+          isConstant: false
+          '#name': Boolean
+        '#documentation': >-
+          Gets a boolean value that indicates whether the name is available for
+          you to use. If true, the name is available. If false, the name has
+          already been taken or invalid and cannot be used.
+        '#name': nameAvailable
+        '#serializedName': nameAvailable
+      - $id: '9'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - reason
+        realXmlPath:
+          - reason
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: Reason
+            modelAsString: false
+        isRequired: false
+        isConstant: false
+        modelTypeName: Reason
+        modelType:
+          $id: '10'
+          $type: 'AutoRest.Core.Model.EnumType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.EnumType
+          values:
+            - name: AccountNameInvalid
+              memberName: AccountNameInvalid
+              '#serializedName': AccountNameInvalid
+            - name: AlreadyExists
+              memberName: AlreadyExists
+              '#serializedName': AlreadyExists
+          modelAsString: false
+          declarationName: Reason
+          extendedDocumentation: 'Possible values include: ''AccountNameInvalid'', ''AlreadyExists'''
+          className: Reason
+          isConstant: false
+          '#serializedName': Reason
+          '#name': Reason
+        '#documentation': >-
+          Gets the reason that a storage account name could not be used. The
+          Reason element is only returned if NameAvailable is false.
+        '#name': reason
+        '#serializedName': reason
+      - $id: '11'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - message
+        realXmlPath:
+          - message
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '12'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets an error message explaining the Reason value in more detail.
+        '#name': message
+        '#serializedName': message
+    documentation: The CheckNameAvailability operation response.
+    containsConstantProperties: false
+    className: CheckNameAvailabilityResult
+    declarationName: CheckNameAvailabilityResult
+    '#serializedName': CheckNameAvailabilityResult
+    '#name': CheckNameAvailabilityResult
+  - $id: '13'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '14'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - accountType
+        realXmlPath:
+          - accountType
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: AccountType
+            modelAsString: false
+        isRequired: true
+        isConstant: false
+        modelTypeName: AccountType
+        modelType:
+          $id: '15'
+          $type: 'AutoRest.Core.Model.EnumType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.EnumType
+          values:
+            - name: Standard_LRS
+              memberName: StandardLRS
+              '#serializedName': Standard_LRS
+            - name: Standard_ZRS
+              memberName: StandardZRS
+              '#serializedName': Standard_ZRS
+            - name: Standard_GRS
+              memberName: StandardGRS
+              '#serializedName': Standard_GRS
+            - name: Standard_RAGRS
+              memberName: StandardRAGRS
+              '#serializedName': Standard_RAGRS
+            - name: Premium_LRS
+              memberName: PremiumLRS
+              '#serializedName': Premium_LRS
+          modelAsString: false
+          declarationName: AccountType
+          extendedDocumentation: >-
+            Possible values include: 'Standard_LRS', 'Standard_ZRS',
+            'Standard_GRS', 'Standard_RAGRS', 'Premium_LRS'
+          className: AccountType
+          isConstant: false
+          '#serializedName': AccountType
+          '#name': AccountType
+        '#documentation': Gets or sets the account type.
+        '#name': accountType
+        '#serializedName': accountType
+    containsConstantProperties: false
+    className: StorageAccountPropertiesCreateParameters
+    declarationName: StorageAccountPropertiesCreateParameters
+    '#serializedName': StorageAccountPropertiesCreateParameters
+    '#name': StorageAccountPropertiesCreateParameters
+  - $id: '16'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '17'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - location
+        realXmlPath:
+          - location
+        collectionFormat: none
+        isRequired: true
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '18'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Resource location
+        '#name': location
+        '#serializedName': location
+      - $id: '19'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - tags
+        realXmlPath:
+          - tags
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: 'Dictionary<string,String>'
+        modelType:
+          $id: '20'
+          $type: 'AutoRest.Core.Model.DictionaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.DictionaryType
+          valueType:
+            $id: '21'
+            $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+            $actualType: AutoRest.Core.Model.PrimaryType
+            knownFormat: none
+            knownPrimaryType: string
+            className: String
+            declarationName: String
+            isConstant: false
+            '#name': String
+          supportsAdditionalProperties: false
+          className: 'Dictionary<string,String>'
+          declarationName: 'Dictionary<string,String>'
+          isConstant: false
+        '#documentation': Resource tags
+        '#name': tags
+        '#serializedName': tags
+      - $id: '22'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - properties
+        realXmlPath:
+          - properties
+        collectionFormat: none
+        extensions:
+          x-ms-client-flatten: true
+        isRequired: false
+        isConstant: false
+        modelTypeName: StorageAccountPropertiesCreateParameters
+        modelType:
+          $ref: '13'
+        '#name': properties
+        '#serializedName': properties
+    documentation: The parameters to provide for the account.
+    containsConstantProperties: false
+    className: StorageAccountCreateParameters
+    declarationName: StorageAccountCreateParameters
+    extensions:
+      x-ms-azure-resource: true
+    '#serializedName': StorageAccountCreateParameters
+    '#name': StorageAccountCreateParameters
+  - $id: '23'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '24'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - blob
+        realXmlPath:
+          - blob
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '25'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets the blob endpoint.
+        '#name': blob
+        '#serializedName': blob
+      - $id: '26'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - queue
+        realXmlPath:
+          - queue
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '27'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets the queue endpoint.
+        '#name': queue
+        '#serializedName': queue
+      - $id: '28'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - table
+        realXmlPath:
+          - table
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '29'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets the table endpoint.
+        '#name': table
+        '#serializedName': table
+      - $id: '30'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - file
+        realXmlPath:
+          - file
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '31'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets the file endpoint.
+        '#name': file
+        '#serializedName': file
+    documentation: >-
+      The URIs that are used to perform a retrieval of a public blob, queue or
+      table object.
+    containsConstantProperties: false
+    className: Endpoints
+    declarationName: Endpoints
+    '#serializedName': Endpoints
+    '#name': Endpoints
+  - $id: '32'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '33'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - name
+        realXmlPath:
+          - name
+        collectionFormat: none
+        isRequired: true
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '34'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets or sets the custom domain name. Name is the CNAME source.
+        '#name': name
+        '#serializedName': name
+      - $id: '35'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - useSubDomain
+        realXmlPath:
+          - useSubDomain
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: Boolean
+        modelType:
+          $id: '36'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: boolean
+          className: Boolean
+          declarationName: Boolean
+          isConstant: false
+          '#name': Boolean
+        '#documentation': >-
+          Indicates whether indirect CName validation is enabled. Default value
+          is false. This should only be set on updates
+        '#name': useSubDomain
+        '#serializedName': useSubDomain
+    documentation: >-
+      The custom domain assigned to this storage account. This can be set via
+      Update.
+    containsConstantProperties: false
+    className: CustomDomain
+    declarationName: CustomDomain
+    '#serializedName': CustomDomain
+    '#name': CustomDomain
+  - $id: '37'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '38'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - provisioningState
+        realXmlPath:
+          - provisioningState
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: ProvisioningState
+            modelAsString: false
+        isRequired: false
+        isConstant: false
+        modelTypeName: ProvisioningState
+        modelType:
+          $id: '39'
+          $type: 'AutoRest.Core.Model.EnumType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.EnumType
+          values:
+            - name: Creating
+              memberName: Creating
+              '#serializedName': Creating
+            - name: ResolvingDNS
+              memberName: ResolvingDNS
+              '#serializedName': ResolvingDNS
+            - name: Succeeded
+              memberName: Succeeded
+              '#serializedName': Succeeded
+          modelAsString: false
+          declarationName: ProvisioningState
+          extendedDocumentation: 'Possible values include: ''Creating'', ''ResolvingDNS'', ''Succeeded'''
+          className: ProvisioningState
+          isConstant: false
+          '#serializedName': ProvisioningState
+          '#name': ProvisioningState
+        '#documentation': >-
+          Gets the status of the storage account at the time the operation was
+          called.
+        '#name': provisioningState
+        '#serializedName': provisioningState
+      - $id: '40'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - accountType
+        realXmlPath:
+          - accountType
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: AccountType
+            modelAsString: false
+        isRequired: false
+        isConstant: false
+        modelTypeName: AccountType
+        modelType:
+          $ref: '15'
+        '#documentation': Gets the type of the storage account.
+        '#name': accountType
+        '#serializedName': accountType
+      - $id: '41'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - primaryEndpoints
+        realXmlPath:
+          - primaryEndpoints
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: Endpoints
+        modelType:
+          $ref: '23'
+        '#documentation': >-
+          Gets the URLs that are used to perform a retrieval of a public blob,
+          queue or table object.Note that StandardZRS and PremiumLRS accounts
+          only return the blob endpoint.
+        '#name': primaryEndpoints
+        '#serializedName': primaryEndpoints
+      - $id: '42'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - primaryLocation
+        realXmlPath:
+          - primaryLocation
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '43'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets the location of the primary for the storage account.
+        '#name': primaryLocation
+        '#serializedName': primaryLocation
+      - $id: '44'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - statusOfPrimary
+        realXmlPath:
+          - statusOfPrimary
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: AccountStatus
+            modelAsString: false
+        isRequired: false
+        isConstant: false
+        modelTypeName: AccountStatus
+        modelType:
+          $id: '45'
+          $type: 'AutoRest.Core.Model.EnumType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.EnumType
+          values:
+            - name: Available
+              memberName: Available
+              '#serializedName': Available
+            - name: Unavailable
+              memberName: Unavailable
+              '#serializedName': Unavailable
+          modelAsString: false
+          declarationName: AccountStatus
+          extendedDocumentation: 'Possible values include: ''Available'', ''Unavailable'''
+          className: AccountStatus
+          isConstant: false
+          '#serializedName': AccountStatus
+          '#name': AccountStatus
+        '#documentation': >-
+          Gets the status indicating whether the primary location of the storage
+          account is available or unavailable.
+        '#name': statusOfPrimary
+        '#serializedName': statusOfPrimary
+      - $id: '46'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - lastGeoFailoverTime
+        realXmlPath:
+          - lastGeoFailoverTime
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: DateTime
+        modelType:
+          $id: '47'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          format: date-time
+          knownFormat: date_time
+          knownPrimaryType: dateTime
+          className: DateTime
+          declarationName: DateTime
+          isConstant: false
+          '#name': DateTime
+        '#documentation': >-
+          Gets the timestamp of the most recent instance of a failover to the
+          secondary location. Only the most recent timestamp is retained. This
+          element is not returned if there has never been a failover instance.
+          Only available if the accountType is StandardGRS or StandardRAGRS.
+        '#name': lastGeoFailoverTime
+        '#serializedName': lastGeoFailoverTime
+      - $id: '48'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - secondaryLocation
+        realXmlPath:
+          - secondaryLocation
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '49'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': >-
+          Gets the location of the geo replicated secondary for the storage
+          account. Only available if the accountType is StandardGRS or
+          StandardRAGRS.
+        '#name': secondaryLocation
+        '#serializedName': secondaryLocation
+      - $id: '50'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - statusOfSecondary
+        realXmlPath:
+          - statusOfSecondary
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: AccountStatus
+            modelAsString: false
+        isRequired: false
+        isConstant: false
+        modelTypeName: AccountStatus
+        modelType:
+          $ref: '45'
+        '#documentation': >-
+          Gets the status indicating whether the secondary location of the
+          storage account is available or unavailable. Only available if the
+          accountType is StandardGRS or StandardRAGRS.
+        '#name': statusOfSecondary
+        '#serializedName': statusOfSecondary
+      - $id: '51'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - creationTime
+        realXmlPath:
+          - creationTime
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: DateTime
+        modelType:
+          $id: '52'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          format: date-time
+          knownFormat: date_time
+          knownPrimaryType: dateTime
+          className: DateTime
+          declarationName: DateTime
+          isConstant: false
+          '#name': DateTime
+        '#documentation': Gets the creation date and time of the storage account in UTC.
+        '#name': creationTime
+        '#serializedName': creationTime
+      - $id: '53'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - customDomain
+        realXmlPath:
+          - customDomain
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: CustomDomain
+        modelType:
+          $ref: '32'
+        '#documentation': Gets the user assigned custom domain assigned to this storage account.
+        '#name': customDomain
+        '#serializedName': customDomain
+      - $id: '54'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - secondaryEndpoints
+        realXmlPath:
+          - secondaryEndpoints
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: Endpoints
+        modelType:
+          $ref: '23'
+        '#documentation': >-
+          Gets the URLs that are used to perform a retrieval of a public blob,
+          queue or table object from the secondary location of the storage
+          account. Only available if the accountType is StandardRAGRS.
+        '#name': secondaryEndpoints
+        '#serializedName': secondaryEndpoints
+    containsConstantProperties: false
+    className: StorageAccountProperties
+    declarationName: StorageAccountProperties
+    '#serializedName': StorageAccountProperties
+    '#name': StorageAccountProperties
+  - $id: '55'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '56'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - properties
+        realXmlPath:
+          - properties
+        collectionFormat: none
+        extensions:
+          x-ms-client-flatten: true
+        isRequired: false
+        isConstant: false
+        modelTypeName: StorageAccountProperties
+        modelType:
+          $ref: '37'
+        '#name': properties
+        '#serializedName': properties
+    baseModelType:
+      $id: '57'
+      $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+      $actualType: AutoRest.Core.Model.CompositeType
+      properties:
+        - $id: '58'
+          $actualType: AutoRest.Core.Model.Property
+          isReadOnly: true
+          isPolymorphicDiscriminator: false
+          realPath:
+            - id
+          realXmlPath:
+            - id
+          collectionFormat: none
+          isRequired: false
+          isConstant: false
+          modelTypeName: String
+          modelType:
+            $id: '59'
+            $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+            $actualType: AutoRest.Core.Model.PrimaryType
+            knownFormat: none
+            knownPrimaryType: string
+            className: String
+            declarationName: String
+            isConstant: false
+            '#name': String
+          '#documentation': Resource Id
+          '#name': id
+          '#serializedName': id
+        - $id: '60'
+          $actualType: AutoRest.Core.Model.Property
+          isReadOnly: true
+          isPolymorphicDiscriminator: false
+          realPath:
+            - name
+          realXmlPath:
+            - name
+          collectionFormat: none
+          isRequired: false
+          isConstant: false
+          modelTypeName: String
+          modelType:
+            $id: '61'
+            $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+            $actualType: AutoRest.Core.Model.PrimaryType
+            knownFormat: none
+            knownPrimaryType: string
+            className: String
+            declarationName: String
+            isConstant: false
+            '#name': String
+          '#documentation': Resource name
+          '#name': name
+          '#serializedName': name
+        - $id: '62'
+          $actualType: AutoRest.Core.Model.Property
+          isReadOnly: true
+          isPolymorphicDiscriminator: false
+          realPath:
+            - type
+          realXmlPath:
+            - type
+          collectionFormat: none
+          isRequired: false
+          isConstant: false
+          modelTypeName: String
+          modelType:
+            $id: '63'
+            $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+            $actualType: AutoRest.Core.Model.PrimaryType
+            knownFormat: none
+            knownPrimaryType: string
+            className: String
+            declarationName: String
+            isConstant: false
+            '#name': String
+          '#documentation': Resource type
+          '#name': type
+          '#serializedName': type
+        - $id: '64'
+          $actualType: AutoRest.Core.Model.Property
+          isReadOnly: false
+          isPolymorphicDiscriminator: false
+          realPath:
+            - location
+          realXmlPath:
+            - location
+          collectionFormat: none
+          isRequired: false
+          isConstant: false
+          modelTypeName: String
+          modelType:
+            $id: '65'
+            $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+            $actualType: AutoRest.Core.Model.PrimaryType
+            knownFormat: none
+            knownPrimaryType: string
+            className: String
+            declarationName: String
+            isConstant: false
+            '#name': String
+          '#documentation': Resource location
+          '#name': location
+          '#serializedName': location
+        - $id: '66'
+          $actualType: AutoRest.Core.Model.Property
+          isReadOnly: false
+          isPolymorphicDiscriminator: false
+          realPath:
+            - tags
+          realXmlPath:
+            - tags
+          collectionFormat: none
+          isRequired: false
+          isConstant: false
+          modelTypeName: 'Dictionary<string,String>'
+          modelType:
+            $id: '67'
+            $type: 'AutoRest.Core.Model.DictionaryType, AutoRest.Core'
+            $actualType: AutoRest.Core.Model.DictionaryType
+            valueType:
+              $id: '68'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            supportsAdditionalProperties: false
+            className: 'Dictionary<string,String>'
+            declarationName: 'Dictionary<string,String>'
+            isConstant: false
+          '#documentation': Resource tags
+          '#name': tags
+          '#serializedName': tags
+      containsConstantProperties: false
+      className: Resource
+      declarationName: Resource
+      extensions:
+        x-ms-azure-resource: true
+      '#serializedName': Resource
+      '#name': Resource
+    documentation: The storage account.
+    containsConstantProperties: false
+    className: StorageAccount
+    declarationName: StorageAccount
+    '#serializedName': StorageAccount
+    '#name': StorageAccount
+  - $id: '69'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '70'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - key1
+        realXmlPath:
+          - key1
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '71'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets the value of key 1.
+        '#name': key1
+        '#serializedName': key1
+      - $id: '72'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - key2
+        realXmlPath:
+          - key2
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '73'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets the value of key 2.
+        '#name': key2
+        '#serializedName': key2
+    documentation: The access keys for the storage account.
+    containsConstantProperties: false
+    className: StorageAccountKeys
+    declarationName: StorageAccountKeys
+    '#serializedName': StorageAccountKeys
+    '#name': StorageAccountKeys
+  - $id: '74'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '75'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - value
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: IList<StorageAccount>
+        modelType:
+          $id: '76'
+          $type: 'AutoRest.Core.Model.SequenceType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.SequenceType
+          elementType:
+            $ref: '55'
+          className: IList<StorageAccount>
+          declarationName: IList<StorageAccount>
+          isConstant: false
+        '#documentation': Gets the list of storage accounts and their properties.
+        '#name': value
+        '#serializedName': value
+    documentation: The list storage accounts operation response.
+    containsConstantProperties: false
+    className: StorageAccountListResult
+    declarationName: StorageAccountListResult
+    '#serializedName': StorageAccountListResult
+    '#name': StorageAccountListResult
+  - $id: '77'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '78'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - accountType
+        realXmlPath:
+          - accountType
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: AccountType
+            modelAsString: false
+        isRequired: false
+        isConstant: false
+        modelTypeName: AccountType
+        modelType:
+          $ref: '15'
+        '#documentation': >-
+          Gets or sets the account type. Note that StandardZRS and PremiumLRS
+          accounts cannot be changed to other account types, and other account
+          types cannot be changed to StandardZRS or PremiumLRS.
+        '#name': accountType
+        '#serializedName': accountType
+      - $id: '79'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - customDomain
+        realXmlPath:
+          - customDomain
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: CustomDomain
+        modelType:
+          $ref: '32'
+        '#documentation': >-
+          User domain assigned to the storage account. Name is the CNAME source.
+          Only one custom domain is supported per storage account at this time.
+          To clear the existing custom domain, use an empty string for the
+          custom domain name property.
+        '#name': customDomain
+        '#serializedName': customDomain
+    containsConstantProperties: false
+    className: StorageAccountPropertiesUpdateParameters
+    declarationName: StorageAccountPropertiesUpdateParameters
+    '#serializedName': StorageAccountPropertiesUpdateParameters
+    '#name': StorageAccountPropertiesUpdateParameters
+  - $id: '80'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '81'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - tags
+        realXmlPath:
+          - tags
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: 'Dictionary<string,String>'
+        modelType:
+          $id: '82'
+          $type: 'AutoRest.Core.Model.DictionaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.DictionaryType
+          valueType:
+            $id: '83'
+            $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+            $actualType: AutoRest.Core.Model.PrimaryType
+            knownFormat: none
+            knownPrimaryType: string
+            className: String
+            declarationName: String
+            isConstant: false
+            '#name': String
+          supportsAdditionalProperties: false
+          className: 'Dictionary<string,String>'
+          declarationName: 'Dictionary<string,String>'
+          isConstant: false
+        '#documentation': Resource tags
+        '#name': tags
+        '#serializedName': tags
+      - $id: '84'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - properties
+        realXmlPath:
+          - properties
+        collectionFormat: none
+        extensions:
+          x-ms-client-flatten: true
+        isRequired: false
+        isConstant: false
+        modelTypeName: StorageAccountPropertiesUpdateParameters
+        modelType:
+          $ref: '77'
+        '#name': properties
+        '#serializedName': properties
+    documentation: The parameters to update on the account.
+    containsConstantProperties: false
+    className: StorageAccountUpdateParameters
+    declarationName: StorageAccountUpdateParameters
+    extensions:
+      x-ms-azure-resource: true
+    '#serializedName': StorageAccountUpdateParameters
+    '#name': StorageAccountUpdateParameters
+  - $id: '85'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '86'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - keyName
+        realXmlPath:
+          - keyName
+        collectionFormat: none
+        isRequired: true
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '87'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#name': keyName
+        '#serializedName': keyName
+    containsConstantProperties: false
+    className: StorageAccountRegenerateKeyParameters
+    declarationName: StorageAccountRegenerateKeyParameters
+    '#serializedName': StorageAccountRegenerateKeyParameters
+    '#name': StorageAccountRegenerateKeyParameters
+  - $id: '88'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '89'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - value
+        realXmlPath:
+          - value
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '90'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets a string describing the resource name.
+        '#name': value
+        '#serializedName': value
+      - $id: '91'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - localizedValue
+        realXmlPath:
+          - localizedValue
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: String
+        modelType:
+          $id: '92'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          knownFormat: none
+          knownPrimaryType: string
+          className: String
+          declarationName: String
+          isConstant: false
+          '#name': String
+        '#documentation': Gets a localized string describing the resource name.
+        '#name': localizedValue
+        '#serializedName': localizedValue
+    documentation: The Usage Names.
+    containsConstantProperties: false
+    className: UsageName
+    declarationName: UsageName
+    '#serializedName': UsageName
+    '#name': UsageName
+  - $id: '93'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '94'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - unit
+        realXmlPath:
+          - unit
+        collectionFormat: none
+        extensions:
+          x-ms-enum:
+            name: UsageUnit
+            modelAsString: false
+        isRequired: true
+        isConstant: false
+        modelTypeName: UsageUnit
+        modelType:
+          $id: '95'
+          $type: 'AutoRest.Core.Model.EnumType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.EnumType
+          values:
+            - name: Count
+              memberName: Count
+              '#serializedName': Count
+            - name: Bytes
+              memberName: Bytes
+              '#serializedName': Bytes
+            - name: Seconds
+              memberName: Seconds
+              '#serializedName': Seconds
+            - name: Percent
+              memberName: Percent
+              '#serializedName': Percent
+            - name: CountsPerSecond
+              memberName: CountsPerSecond
+              '#serializedName': CountsPerSecond
+            - name: BytesPerSecond
+              memberName: BytesPerSecond
+              '#serializedName': BytesPerSecond
+          modelAsString: false
+          declarationName: UsageUnit
+          extendedDocumentation: >-
+            Possible values include: 'Count', 'Bytes', 'Seconds', 'Percent',
+            'CountsPerSecond', 'BytesPerSecond'
+          className: UsageUnit
+          isConstant: false
+          '#serializedName': UsageUnit
+          '#name': UsageUnit
+        '#documentation': Gets the unit of measurement.
+        '#name': unit
+        '#serializedName': unit
+      - $id: '96'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - currentValue
+        realXmlPath:
+          - currentValue
+        collectionFormat: none
+        isRequired: true
+        isConstant: false
+        modelTypeName: Int
+        modelType:
+          $id: '97'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          format: int32
+          knownFormat: int32
+          knownPrimaryType: int
+          className: Int
+          declarationName: Int
+          isConstant: false
+          '#name': Int
+        '#documentation': Gets the current count of the allocated resources in the subscription.
+        '#name': currentValue
+        '#serializedName': currentValue
+      - $id: '98'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - limit
+        realXmlPath:
+          - limit
+        collectionFormat: none
+        isRequired: true
+        isConstant: false
+        modelTypeName: Int
+        modelType:
+          $id: '99'
+          $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.PrimaryType
+          format: int32
+          knownFormat: int32
+          knownPrimaryType: int
+          className: Int
+          declarationName: Int
+          isConstant: false
+          '#name': Int
+        '#documentation': >-
+          Gets the maximum count of the resources that can be allocated in the
+          subscription.
+        '#name': limit
+        '#serializedName': limit
+      - $id: '100'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - name
+        realXmlPath:
+          - name
+        collectionFormat: none
+        isRequired: true
+        isConstant: false
+        modelTypeName: UsageName
+        modelType:
+          $ref: '88'
+        '#documentation': Gets the name of the type of usage.
+        '#name': name
+        '#serializedName': name
+    documentation: DESCRIBES STORAGE RESOURCE USAGE.
+    containsConstantProperties: false
+    className: Usage
+    declarationName: Usage
+    '#serializedName': Usage
+    '#name': Usage
+  - $id: '101'
+    $type: 'AutoRest.Core.Model.CompositeType, AutoRest.Core'
+    $actualType: AutoRest.Core.Model.CompositeType
+    properties:
+      - $id: '102'
+        $actualType: AutoRest.Core.Model.Property
+        isReadOnly: false
+        isPolymorphicDiscriminator: false
+        realPath:
+          - value
+        collectionFormat: none
+        isRequired: false
+        isConstant: false
+        modelTypeName: IList<Usage>
+        modelType:
+          $id: '103'
+          $type: 'AutoRest.Core.Model.SequenceType, AutoRest.Core'
+          $actualType: AutoRest.Core.Model.SequenceType
+          elementType:
+            $ref: '93'
+          className: IList<Usage>
+          declarationName: IList<Usage>
+          isConstant: false
+        '#documentation': Gets or sets the list Storage Resource Usages.
+        '#name': value
+        '#serializedName': value
+    documentation: The List Usages operation response.
+    containsConstantProperties: false
+    className: UsageListResult
+    declarationName: UsageListResult
+    '#serializedName': UsageListResult
+    '#name': UsageListResult
+  - $ref: '57'
+enumTypes:
+  - $ref: '10'
+  - $ref: '15'
+  - $ref: '39'
+  - $ref: '45'
+  - $ref: '95'
+namespace: ''
+modelsName: Models
+apiVersion: '2015-06-15'
+baseUrl: 'https://management.azure.com'
+methodGroupNames:
+  - StorageAccounts
+  - Usage
+documentation: The Storage Management Client.
+shouldGenerateXmlSerialization: false
+properties:
+  - $id: '104'
+    $actualType: AutoRest.Core.Model.Property
+    isReadOnly: false
+    isPolymorphicDiscriminator: false
+    realPath:
+      - subscriptionId
+    realXmlPath:
+      - subscriptionId
+    collectionFormat: none
+    isRequired: true
+    isConstant: false
+    modelTypeName: String
+    modelType:
+      $id: '105'
+      $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+      $actualType: AutoRest.Core.Model.PrimaryType
+      knownFormat: none
+      knownPrimaryType: string
+      className: String
+      declarationName: String
+      isConstant: false
+      '#name': String
+    '#documentation': >-
+      Gets subscription credentials which uniquely identify Microsoft Azure
+      subscription. The subscription ID forms part of the URI for every service
+      call.
+    '#name': subscriptionId
+    '#serializedName': subscriptionId
+  - $id: '106'
+    $actualType: AutoRest.Core.Model.Property
+    isReadOnly: false
+    isPolymorphicDiscriminator: false
+    realPath:
+      - api-version
+    realXmlPath:
+      - api-version
+    collectionFormat: none
+    isRequired: true
+    isConstant: false
+    modelTypeName: String
+    modelType:
+      $id: '107'
+      $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+      $actualType: AutoRest.Core.Model.PrimaryType
+      knownFormat: none
+      knownPrimaryType: string
+      className: String
+      declarationName: String
+      isConstant: false
+      '#name': String
+    '#documentation': Client Api Version.
+    '#name': api-version
+    '#serializedName': api-version
+operations:
+  - methods:
+      - parameters:
+          - $id: '108'
+            isClientProperty: false
+            location: body
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: StorageAccountCheckNameAvailabilityParameters
+            modelType:
+              $ref: '1'
+            '#documentation': >-
+              The name of the storage account within the specified resource
+              group. Storage account names must be between 3 and 24 characters
+              in length and use numbers and lower-case letters only.
+            '#name': accountName
+            '#serializedName': accountName
+          - $id: '109'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '110'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '111'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '112'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: post
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '6'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '6'
+          isNullable: true
+        description: >-
+          Checks that the account name has sufficient cowbell (in order to
+          prevent fevers).
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        deprecated: false
+        '#name': CheckNameAvailability
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_CheckNameAvailability
+        '#url': >-
+          /subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability
+      - parameters:
+          - $id: '113'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '114'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the resource group within the user's subscription.
+            '#name': resourceGroupName
+            '#serializedName': resourceGroupName
+          - $id: '115'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            constraints:
+              MaxLength: '24'
+              MinLength: '3'
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '116'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              The name of the storage account within the specified resource
+              group. Storage account names must be between 3 and 24 characters
+              in length and use numbers and lower-case letters only.  
+            '#name': accountName
+            '#serializedName': accountName
+          - $id: '117'
+            isClientProperty: false
+            location: body
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: StorageAccountCreateParameters
+            modelType:
+              $ref: '16'
+            '#documentation': The parameters to provide for the created account.
+            '#name': parameters
+            '#serializedName': parameters
+          - $id: '118'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '119'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '120'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '121'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: put
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '55'
+            isNullable: true
+          Accepted:
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '55'
+          isNullable: true
+        description: >-
+          Asynchronously creates a new storage account with the specified
+          parameters. Existing accounts cannot be updated with this API and
+          should instead use the Update Storage Account API. If an account is
+          already created and subsequent PUT request is issued with exact same
+          set of properties, then HTTP 200 would be returned.  Make sure you add
+          that extra cowbell.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        extensions:
+          x-ms-long-running-operation: true
+        deprecated: false
+        '#name': Create
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_Create
+        '#url': >-
+          /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}
+      - parameters:
+          - $id: '122'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '123'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the resource group within the user's subscription.
+            '#name': resourceGroupName
+            '#serializedName': resourceGroupName
+          - $id: '124'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            constraints:
+              MaxLength: '24'
+              MinLength: '3'
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '125'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              The name of the storage account within the specified resource
+              group. Storage account names must be between 3 and 24 characters
+              in length and use numbers and lower-case letters only.  
+            '#name': accountName
+            '#serializedName': accountName
+          - $id: '126'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '127'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '128'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '129'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: delete
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            isNullable: true
+          NoContent:
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          isNullable: true
+        description: Deletes a storage account in Microsoft Azure.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        deprecated: false
+        '#name': Delete
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_Delete
+        '#url': >-
+          /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}
+      - parameters:
+          - $id: '130'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '131'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the resource group within the user's subscription.
+            '#name': resourceGroupName
+            '#serializedName': resourceGroupName
+          - $id: '132'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            constraints:
+              MaxLength: '24'
+              MinLength: '3'
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '133'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              The name of the storage account within the specified resource
+              group. Storage account names must be between 3 and 24 characters
+              in length and use numbers and lower-case letters only.  
+            '#name': accountName
+            '#serializedName': accountName
+          - $id: '134'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '135'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '136'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '137'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: get
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '55'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '55'
+          isNullable: true
+        description: >-
+          Returns the properties for the specified storage account including but
+          not limited to name, account type, location, and account status. The
+          ListKeys operation should be used to retrieve storage keys.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        deprecated: false
+        '#name': GetProperty
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_GetProperty
+        '#url': >-
+          /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}
+      - parameters:
+          - $id: '138'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '139'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the resource group within the user's subscription.
+            '#name': resourceGroupName
+            '#serializedName': resourceGroupName
+          - $id: '140'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            constraints:
+              MaxLength: '24'
+              MinLength: '3'
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '141'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              The name of the storage account within the specified resource
+              group. Storage account names must be between 3 and 24 characters
+              in length and use numbers and lower-case letters only.  
+            '#name': accountName
+            '#serializedName': accountName
+          - $id: '142'
+            isClientProperty: false
+            location: body
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: StorageAccountUpdateParameters
+            modelType:
+              $ref: '80'
+            '#documentation': >-
+              The parameters to update on the account. Note that only one
+              property can be changed at a time using this API. 
+            '#name': parameters
+            '#serializedName': parameters
+          - $id: '143'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '144'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '145'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '146'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: patch
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '55'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '55'
+          isNullable: true
+        description: >-
+          Updates the account type or tags for a storage account. It can also be
+          used to add a custom domain (note that custom domains cannot be added
+          via the Create operation). Only one custom domain is supported per
+          storage account. In order to replace a custom domain, the old value
+          must be cleared before a new value may be set. To clear a custom
+          domain, simply update the custom domain with empty string. Then call
+          update again with the new cutsom domain name. The update API can only
+          be used to update one of tags, accountType, or customDomain per call.
+          To update multiple of these properties, call the API multiple times
+          with one change per call. This call does not change the storage keys
+          for the account. If you want to change storage account keys, use the
+          RegenerateKey operation. The location and name of the storage account
+          cannot be changed after creation.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        deprecated: false
+        '#name': Update
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_Update
+        '#url': >-
+          /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}
+      - parameters:
+          - $id: '147'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '148'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the resource group.
+            '#name': resourceGroupName
+            '#serializedName': resourceGroupName
+          - $id: '149'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            constraints:
+              MaxLength: '24'
+              MinLength: '3'
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '150'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the storage account.
+            '#name': accountName
+            '#serializedName': accountName
+          - $id: '151'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '152'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '153'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '154'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: post
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '69'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '69'
+          isNullable: true
+        description: Lists the access keys for the specified storage account.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        deprecated: false
+        '#name': ListKeys
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_ListKeys
+        '#url': >-
+          /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys
+      - parameters:
+          - $id: '155'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '156'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '157'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '158'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: get
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '74'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '74'
+          isNullable: true
+        description: >-
+          Lists all the storage accounts available under the subscription. Note
+          that storage keys are not returned; use the ListKeys operation for
+          this.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        extensions:
+          x-ms-pageable:
+            nextLinkName: null
+        deprecated: false
+        '#name': List
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_List
+        '#url': >-
+          /subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts
+      - parameters:
+          - $id: '159'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '160'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the resource group within the user's subscription.
+            '#name': resourceGroupName
+            '#serializedName': resourceGroupName
+          - $id: '161'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '162'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '163'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '164'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: get
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '74'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '74'
+          isNullable: true
+        description: >-
+          Lists all the storage accounts available under the given resource
+          group. Note that storage keys are not returned; use the ListKeys
+          operation for this.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        extensions:
+          x-ms-pageable:
+            nextLinkName: null
+        deprecated: false
+        '#name': ListByResourceGroup
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_ListByResourceGroup
+        '#url': >-
+          /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts
+      - parameters:
+          - $id: '165'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '166'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': The name of the resource group within the user's subscription.
+            '#name': resourceGroupName
+            '#serializedName': resourceGroupName
+          - $id: '167'
+            isClientProperty: false
+            location: path
+            collectionFormat: none
+            constraints:
+              MaxLength: '24'
+              MinLength: '3'
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '168'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              The name of the storage account within the specified resource
+              group. Storage account names must be between 3 and 24 characters
+              in length and use numbers and lower-case letters only.  
+            '#name': accountName
+            '#serializedName': accountName
+          - $id: '169'
+            isClientProperty: false
+            location: body
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: StorageAccountRegenerateKeyParameters
+            modelType:
+              $ref: '85'
+            '#documentation': >-
+              Specifies name of the key which should be regenerated. key1 or
+              key2 for the default keys
+            '#name': regenerateKey
+            '#serializedName': regenerateKey
+          - $id: '170'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '171'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '172'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '173'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: post
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '69'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '69'
+          isNullable: true
+        description: Regenerates the access keys for the specified storage account.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        deprecated: false
+        '#name': RegenerateKey
+        '#group': StorageAccounts
+        '#serializedName': StorageAccounts_RegenerateKey
+        '#url': >-
+          /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey
+    isCodeModelMethodGroup: false
+    usings:
+      - Models
+    '#name': checkNameAvailability
+    summary: |-
+      {
+        "methods": [
+          {
+            "parameters": [
+              {
+                "$id": "108",
+                "isClientProperty": false,
+                "location": "body",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "StorageAccountCheckNameAvailabilityParameters",
+                "modelType": {
+                  "$ref": "1"
+                },
+                "#documentation": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.",
+                "#name": "accountName",
+                "#serializedName": "accountName"
+              },
+              {
+                "$id": "109",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "110",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "111",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "112",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "post",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "6"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "6"
+              },
+              "isNullable": true
+            },
+            "description": "Checks that the account name has sufficient cowbell (in order to prevent fevers).",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "deprecated": false,
+            "#name": "CheckNameAvailability",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_CheckNameAvailability",
+            "#url": "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/checkNameAvailability"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "113",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "114",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the resource group within the user's subscription.",
+                "#name": "resourceGroupName",
+                "#serializedName": "resourceGroupName"
+              },
+              {
+                "$id": "115",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "constraints": {
+                  "MaxLength": "24",
+                  "MinLength": "3"
+                },
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "116",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
+                "#name": "accountName",
+                "#serializedName": "accountName"
+              },
+              {
+                "$id": "117",
+                "isClientProperty": false,
+                "location": "body",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "StorageAccountCreateParameters",
+                "modelType": {
+                  "$ref": "16"
+                },
+                "#documentation": "The parameters to provide for the created account.",
+                "#name": "parameters",
+                "#serializedName": "parameters"
+              },
+              {
+                "$id": "118",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "119",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "120",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "121",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "put",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "55"
+                },
+                "isNullable": true
+              },
+              "Accepted": {
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "55"
+              },
+              "isNullable": true
+            },
+            "description": "Asynchronously creates a new storage account with the specified parameters. Existing accounts cannot be updated with this API and should instead use the Update Storage Account API. If an account is already created and subsequent PUT request is issued with exact same set of properties, then HTTP 200 would be returned.  Make sure you add that extra cowbell.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "extensions": {
+              "x-ms-long-running-operation": true
+            },
+            "deprecated": false,
+            "#name": "Create",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_Create",
+            "#url": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "122",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "123",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the resource group within the user's subscription.",
+                "#name": "resourceGroupName",
+                "#serializedName": "resourceGroupName"
+              },
+              {
+                "$id": "124",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "constraints": {
+                  "MaxLength": "24",
+                  "MinLength": "3"
+                },
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "125",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
+                "#name": "accountName",
+                "#serializedName": "accountName"
+              },
+              {
+                "$id": "126",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "127",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "128",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "129",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "delete",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "isNullable": true
+              },
+              "NoContent": {
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "isNullable": true
+            },
+            "description": "Deletes a storage account in Microsoft Azure.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "deprecated": false,
+            "#name": "Delete",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_Delete",
+            "#url": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "130",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "131",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the resource group within the user's subscription.",
+                "#name": "resourceGroupName",
+                "#serializedName": "resourceGroupName"
+              },
+              {
+                "$id": "132",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "constraints": {
+                  "MaxLength": "24",
+                  "MinLength": "3"
+                },
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "133",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
+                "#name": "accountName",
+                "#serializedName": "accountName"
+              },
+              {
+                "$id": "134",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "135",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "136",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "137",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "get",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "55"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "55"
+              },
+              "isNullable": true
+            },
+            "description": "Returns the properties for the specified storage account including but not limited to name, account type, location, and account status. The ListKeys operation should be used to retrieve storage keys.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "deprecated": false,
+            "#name": "GetProperty",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_GetProperty",
+            "#url": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "138",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "139",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the resource group within the user's subscription.",
+                "#name": "resourceGroupName",
+                "#serializedName": "resourceGroupName"
+              },
+              {
+                "$id": "140",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "constraints": {
+                  "MaxLength": "24",
+                  "MinLength": "3"
+                },
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "141",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
+                "#name": "accountName",
+                "#serializedName": "accountName"
+              },
+              {
+                "$id": "142",
+                "isClientProperty": false,
+                "location": "body",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "StorageAccountUpdateParameters",
+                "modelType": {
+                  "$ref": "80"
+                },
+                "#documentation": "The parameters to update on the account. Note that only one property can be changed at a time using this API. ",
+                "#name": "parameters",
+                "#serializedName": "parameters"
+              },
+              {
+                "$id": "143",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "144",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "145",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "146",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "patch",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "55"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "55"
+              },
+              "isNullable": true
+            },
+            "description": "Updates the account type or tags for a storage account. It can also be used to add a custom domain (note that custom domains cannot be added via the Create operation). Only one custom domain is supported per storage account. In order to replace a custom domain, the old value must be cleared before a new value may be set. To clear a custom domain, simply update the custom domain with empty string. Then call update again with the new cutsom domain name. The update API can only be used to update one of tags, accountType, or customDomain per call. To update multiple of these properties, call the API multiple times with one change per call. This call does not change the storage keys for the account. If you want to change storage account keys, use the RegenerateKey operation. The location and name of the storage account cannot be changed after creation.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "deprecated": false,
+            "#name": "Update",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_Update",
+            "#url": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "147",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "148",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the resource group.",
+                "#name": "resourceGroupName",
+                "#serializedName": "resourceGroupName"
+              },
+              {
+                "$id": "149",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "constraints": {
+                  "MaxLength": "24",
+                  "MinLength": "3"
+                },
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "150",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the storage account.",
+                "#name": "accountName",
+                "#serializedName": "accountName"
+              },
+              {
+                "$id": "151",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "152",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "153",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "154",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "post",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "69"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "69"
+              },
+              "isNullable": true
+            },
+            "description": "Lists the access keys for the specified storage account.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "deprecated": false,
+            "#name": "ListKeys",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_ListKeys",
+            "#url": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/listKeys"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "155",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "156",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "157",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "158",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "get",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "74"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "74"
+              },
+              "isNullable": true
+            },
+            "description": "Lists all the storage accounts available under the subscription. Note that storage keys are not returned; use the ListKeys operation for this.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "extensions": {
+              "x-ms-pageable": {
+                "nextLinkName": null
+              }
+            },
+            "deprecated": false,
+            "#name": "List",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_List",
+            "#url": "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/storageAccounts"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "159",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "160",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the resource group within the user's subscription.",
+                "#name": "resourceGroupName",
+                "#serializedName": "resourceGroupName"
+              },
+              {
+                "$id": "161",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "162",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "163",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "164",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "get",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "74"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "74"
+              },
+              "isNullable": true
+            },
+            "description": "Lists all the storage accounts available under the given resource group. Note that storage keys are not returned; use the ListKeys operation for this.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "extensions": {
+              "x-ms-pageable": {
+                "nextLinkName": null
+              }
+            },
+            "deprecated": false,
+            "#name": "ListByResourceGroup",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_ListByResourceGroup",
+            "#url": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts"
+          },
+          {
+            "parameters": [
+              {
+                "$id": "165",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "166",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the resource group within the user's subscription.",
+                "#name": "resourceGroupName",
+                "#serializedName": "resourceGroupName"
+              },
+              {
+                "$id": "167",
+                "isClientProperty": false,
+                "location": "path",
+                "collectionFormat": "none",
+                "constraints": {
+                  "MaxLength": "24",
+                  "MinLength": "3"
+                },
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "168",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "The name of the storage account within the specified resource group. Storage account names must be between 3 and 24 characters in length and use numbers and lower-case letters only.  ",
+                "#name": "accountName",
+                "#serializedName": "accountName"
+              },
+              {
+                "$id": "169",
+                "isClientProperty": false,
+                "location": "body",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "StorageAccountRegenerateKeyParameters",
+                "modelType": {
+                  "$ref": "85"
+                },
+                "#documentation": "Specifies name of the key which should be regenerated. key1 or key2 for the default keys",
+                "#name": "regenerateKey",
+                "#serializedName": "regenerateKey"
+              },
+              {
+                "$id": "170",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "171",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "172",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "173",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "post",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "69"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "69"
+              },
+              "isNullable": true
+            },
+            "description": "Regenerates the access keys for the specified storage account.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "deprecated": false,
+            "#name": "RegenerateKey",
+            "#group": "StorageAccounts",
+            "#serializedName": "StorageAccounts_RegenerateKey",
+            "#url": "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Storage/storageAccounts/{accountName}/regenerateKey"
+          }
+        ],
+        "isCodeModelMethodGroup": false,
+        "usings": [
+          "Models"
+        ],
+        "#name": "checkNameAvailability"
+      }
+  - methods:
+      - parameters:
+          - $id: '174'
+            isClientProperty: true
+            clientProperty:
+              $ref: '106'
+            location: query
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '175'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': Client Api Version.
+            '#name': api-version
+            '#serializedName': api-version
+          - $id: '176'
+            isClientProperty: true
+            clientProperty:
+              $ref: '104'
+            location: path
+            collectionFormat: none
+            isRequired: true
+            isConstant: false
+            modelTypeName: String
+            modelType:
+              $id: '177'
+              $type: 'AutoRest.Core.Model.PrimaryType, AutoRest.Core'
+              $actualType: AutoRest.Core.Model.PrimaryType
+              knownFormat: none
+              knownPrimaryType: string
+              className: String
+              declarationName: String
+              isConstant: false
+              '#name': String
+            '#documentation': >-
+              Gets subscription credentials which uniquely identify Microsoft
+              Azure subscription. The subscription ID forms part of the URI for
+              every service call.
+            '#name': subscriptionId
+            '#serializedName': subscriptionId
+        isAbsoluteUrl: false
+        httpMethod: get
+        requestSerializationFormat: none
+        responseSerializationFormat: none
+        responses:
+          OK:
+            body:
+              $ref: '101'
+            isNullable: true
+        defaultResponse:
+          isNullable: true
+        returnType:
+          body:
+            $ref: '101'
+          isNullable: true
+        description: >-
+          Gets the current usage count and the limit for the resources under the
+          subscription.
+        requestContentType: application/json; charset=utf-8
+        responseContentTypes:
+          - application/json
+          - text/json
+        extensions:
+          x-ms-pageable:
+            nextLinkName: null
+        deprecated: false
+        '#name': List
+        '#group': Usage
+        '#serializedName': Usage_List
+        '#url': '/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages'
+    isCodeModelMethodGroup: false
+    usings:
+      - Models
+    '#name': usages
+    summary: |-
+      {
+        "methods": [
+          {
+            "parameters": [
+              {
+                "$id": "174",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "106"
+                },
+                "location": "query",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "175",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Client Api Version.",
+                "#name": "api-version",
+                "#serializedName": "api-version"
+              },
+              {
+                "$id": "176",
+                "isClientProperty": true,
+                "clientProperty": {
+                  "$ref": "104"
+                },
+                "location": "path",
+                "collectionFormat": "none",
+                "isRequired": true,
+                "isConstant": false,
+                "modelTypeName": "String",
+                "modelType": {
+                  "$id": "177",
+                  "$type": "AutoRest.Core.Model.PrimaryType, AutoRest.Core",
+                  "$actualType": "AutoRest.Core.Model.PrimaryType",
+                  "knownFormat": "none",
+                  "knownPrimaryType": "string",
+                  "className": "String",
+                  "declarationName": "String",
+                  "isConstant": false,
+                  "#name": "String"
+                },
+                "#documentation": "Gets subscription credentials which uniquely identify Microsoft Azure subscription. The subscription ID forms part of the URI for every service call.",
+                "#name": "subscriptionId",
+                "#serializedName": "subscriptionId"
+              }
+            ],
+            "isAbsoluteUrl": false,
+            "httpMethod": "get",
+            "requestSerializationFormat": "none",
+            "responseSerializationFormat": "none",
+            "responses": {
+              "OK": {
+                "body": {
+                  "$ref": "101"
+                },
+                "isNullable": true
+              }
+            },
+            "defaultResponse": {
+              "isNullable": true
+            },
+            "returnType": {
+              "body": {
+                "$ref": "101"
+              },
+              "isNullable": true
+            },
+            "description": "Gets the current usage count and the limit for the resources under the subscription.",
+            "requestContentType": "application/json; charset=utf-8",
+            "responseContentTypes": [
+              "application/json",
+              "text/json"
+            ],
+            "extensions": {
+              "x-ms-pageable": {
+                "nextLinkName": null
+              }
+            },
+            "deprecated": false,
+            "#name": "List",
+            "#group": "Usage",
+            "#serializedName": "Usage_List",
+            "#url": "/subscriptions/{subscriptionId}/providers/Microsoft.Storage/usages"
+          }
+        ],
+        "isCodeModelMethodGroup": false,
+        "usings": [
+          "Models"
+        ],
+        "#name": "usages"
+      }
+'#name': StorageManagementClient

--- a/Samples/3b-custom-transformations/generated/pipeline.yaml
+++ b/Samples/3b-custom-transformations/generated/pipeline.yaml
@@ -1,0 +1,88 @@
+---
+pipeline-emitter:
+  pluginName: pipeline-emitter
+  configScope:
+    - scope-pipeline-emitter
+  inputs: []
+swagger-document/loader:
+  pluginName: loader
+  configScope: []
+  inputs: []
+swagger-document/individual/transform:
+  pluginName: transform
+  configScope: []
+  inputs:
+    - swagger-document/loader
+swagger-document/compose:
+  pluginName: compose
+  configScope: []
+  inputs:
+    - swagger-document/individual/transform
+swagger-document/transform:
+  pluginName: transform
+  configScope: []
+  inputs:
+    - swagger-document/compose
+swagger-document/emitter:
+  pluginName: emitter
+  configScope:
+    - scope-swagger-document/emitter
+  inputs:
+    - swagger-document/transform
+swagger-document/azure-validator:
+  pluginName: azure-validator
+  configScope:
+    - azure-validator
+  inputs:
+    - swagger-document/transform
+csharp/modeler:
+  pluginName: modeler
+  configScope:
+    - csharp
+  inputs:
+    - swagger-document/transform
+csharp/commonmarker:
+  pluginName: commonmarker
+  configScope:
+    - csharp
+  inputs:
+    - csharp/modeler
+csharp/cm/transform:
+  pluginName: transform
+  configScope:
+    - csharp
+  inputs:
+    - csharp/commonmarker
+csharp/cm/emitter:
+  pluginName: emitter
+  configScope:
+    - csharp
+    - scope-cm/emitter
+  inputs:
+    - csharp/cm/transform
+csharp/generate:
+  pluginName: csharp
+  configScope:
+    - csharp
+  inputs:
+    - swagger-document/transform
+    - csharp/cm/transform
+csharp/simplifier:
+  pluginName: csharp-simplifier
+  configScope:
+    - csharp
+  inputs:
+    - csharp/generate
+csharp/transform:
+  pluginName: transform
+  configScope:
+    - csharp
+  inputs:
+    - csharp/simplifier
+csharp/emitter:
+  pluginName: emitter
+  configScope:
+    - csharp
+    - scope-csharp/emitter
+  inputs:
+    - csharp/transform

--- a/Samples/3b-custom-transformations/readme.md
+++ b/Samples/3b-custom-transformations/readme.md
@@ -10,6 +10,7 @@ azure-arm: true
 output-artifact:
  - swagger-document.json
  - code-model-v1.yaml
+ - pipeline.yaml
 csharp:
   output-folder: Client
 ```

--- a/Samples/3b-custom-transformations/readme.md
+++ b/Samples/3b-custom-transformations/readme.md
@@ -7,7 +7,9 @@
 ``` yaml 
 input-file: https://github.com/Azure/azure-rest-api-specs/blob/master/arm-storage/2015-06-15/swagger/storage.json
 azure-arm: true
-output-artifact: swagger-document.json
+output-artifact:
+ - swagger-document.json
+ - code-model-v1.yaml
 csharp:
   output-folder: Client
 ```

--- a/docs/user/literate-file-formats/configuration.md
+++ b/docs/user/literate-file-formats/configuration.md
@@ -6,7 +6,7 @@ blocks for machine readable sections. This encourages easy-to-author documentati
 desired when authoring and processing instructions.
 
 ### Notable Features
-- All the relavent settings for generating code for any langugage can be unified into a single location
+- All the relavent settings for generating code for any language can be unified into a single location
 - Choose a specific version (or a valid range?) of AutoRest to run (discovery/acquring when necessary.)
 - Specify the OpenAPI files that it applies to.
 - Apply code generation tweaks without having to mark up the OpenAPI 

--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -130,7 +130,7 @@ function parseArgs(autorestArgs: string[]): CommandLineArgs {
   };
 
   for (const arg of autorestArgs) {
-    const match = /^--([^=]+)(=([^=]+))?$/g.exec(arg);
+    const match = /^--([^=]+)(=(.+))?$/g.exec(arg);
 
     // configuration file?
     if (match === null) {

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -219,7 +219,9 @@ export class ConfigurationView {
 
   public * GetPluginViews(pluginName: string): Iterable<ConfigurationView> {
     for (const section of ValuesOf<any>((this.config as any)[pluginName])) {
-      yield new ConfigurationView(this.messageEmitter, this.configFileFolderUri, section, this.config);
+      if (section) {
+        yield new ConfigurationView(this.messageEmitter, this.configFileFolderUri, section === true ? {} : section, this.config);
+      }
     }
   }
 

--- a/src/autorest-core/lib/pipeline/artifact-emitter.ts
+++ b/src/autorest-core/lib/pipeline/artifact-emitter.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { Lazy, LazyPromise } from '../lazy';
+import { Lazy } from "../lazy";
 import { Stringify, YAMLNode } from "../ref/yaml";
 import { IdentitySourceMapping } from "../source-map/merging";
 import { Channel } from "../message";

--- a/src/autorest-core/lib/pipeline/artifact-emitter.ts
+++ b/src/autorest-core/lib/pipeline/artifact-emitter.ts
@@ -13,11 +13,6 @@ import { DataHandleRead, DataStoreViewReadonly } from "../data-store/data-store"
 function IsOutputArtifactOrMapRequested(config: ConfigurationView, artifactType: string) {
   return config.IsOutputArtifactRequested(artifactType) || config.IsOutputArtifactRequested(artifactType + ".map");
 }
-function IsOutputArtifactVariantRequested(config: ConfigurationView, artifactType: string) {
-  return IsOutputArtifactOrMapRequested(config, artifactType)
-    || IsOutputArtifactOrMapRequested(config, artifactType + ".yaml")
-    || IsOutputArtifactOrMapRequested(config, artifactType + ".json");
-}
 
 async function EmitArtifactInternal(config: ConfigurationView, artifactType: string, uri: string, handle: DataHandleRead): Promise<void> {
   config.Message({ Channel: Channel.Debug, Text: `Emitting '${artifactType}' at ${uri}` });
@@ -58,12 +53,9 @@ async function EmitArtifact(config: ConfigurationView, artifactType: string, uri
   }
 }
 
-export async function EmitArtifacts(config: ConfigurationView, artifactType: string, uriResolver: (key: string) => string, lazyScope: LazyPromise<DataStoreViewReadonly>, isObject: boolean): Promise<void> {
-  if (IsOutputArtifactVariantRequested(config, artifactType)) {
-    const scope = await lazyScope;
-    for (const key of await scope.Enum()) {
-      const file = await scope.ReadStrict(key);
-      await EmitArtifact(config, artifactType, uriResolver(file.key), file, isObject);
-    }
+export async function EmitArtifacts(config: ConfigurationView, artifactType: string, uriResolver: (key: string) => string, scope: DataStoreViewReadonly, isObject: boolean): Promise<void> {
+  for (const key of await scope.Enum()) {
+    const file = await scope.ReadStrict(key);
+    await EmitArtifact(config, artifactType, uriResolver(file.key), file, isObject);
   }
 }

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -162,7 +162,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
     const relPath =
       config.GetEntry("output-file") || // TODO: overthink
       (config.GetEntry("namespace") ? config.GetEntry("namespace") : GetFilename(config.InputFileUris[0]).replace(/\.json$/, ""));
-    barrier.Await(EmitArtifacts(config, "swagger-document", _ => ResolveUri(config.OutputFolderUri, relPath), new LazyPromise(async () => scopeComposedSwaggerTransformed), true));
+    barrier.Await(EmitArtifacts(config, "swagger-document", _ => ResolveUri(config.OutputFolderUri, relPath), scopeComposedSwaggerTransformed, true));
   }
 
   if (config.GetEntry("model-validator")) {
@@ -185,7 +185,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
         const scopeCodeModelCommonmark = await RunPlugin(genConfig, "commonmarker", scopeCodeModel);
         const scopeCodeModelTransformed = await RunPlugin(genConfig, "transform", scopeCodeModelCommonmark);
 
-        await EmitArtifacts(genConfig, "code-model-v1", _ => ResolveUri(genConfig.OutputFolderUri, "code-model.yaml"), new LazyPromise(async () => scopeCodeModelTransformed), false);
+        await EmitArtifacts(genConfig, "code-model-v1", _ => ResolveUri(genConfig.OutputFolderUri, "code-model.yaml"), scopeCodeModelTransformed, false);
 
         const inputScope = new QuickScope([
           await scopeComposedSwaggerTransformed.ReadStrict((await scopeComposedSwaggerTransformed.Enum())[0]),
@@ -199,7 +199,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
         }
 
         generatedFileScope = await RunPlugin(genConfig, "transform", generatedFileScope);
-        await EmitArtifacts(genConfig, `source-file-${codeGenerator}`, key => ResolveUri(genConfig.OutputFolderUri, key.split("/output/")[1]), new LazyPromise(async () => generatedFileScope), false);
+        await EmitArtifacts(genConfig, `source-file-${codeGenerator}`, key => ResolveUri(genConfig.OutputFolderUri, key.split("/output/")[1]), generatedFileScope, false);
       })());
     }
   }

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -24,7 +24,6 @@ export type DataPromise = MultiPromise<DataHandleRead>;
 
 type PipelinePlugin = (config: ConfigurationView, input: DataStoreViewReadonly, working: DataStoreView, output: DataStoreView) => Promise<void>;
 interface PipelineNode {
-  // id: string;
   outputArtifact?: string;
   pluginName: string;
   configScope: JsonPath;
@@ -257,7 +256,7 @@ export async function RunPipeline(configView: ConfigurationView, fileSystem: IFi
 
   // TODO: think about adding "number of files in scope" kind of validation in between pipeline steps
 
-  const RunPlugin: (nodeName: string) => Promise<DataStoreViewReadonly> =
+  const ScheduleNode: (nodeName: string) => Promise<DataStoreViewReadonly> =
     async (nodeName) => {
       const node = pipeline.pipeline[nodeName];
 
@@ -312,7 +311,7 @@ export async function RunPipeline(configView: ConfigurationView, fileSystem: IFi
   const tasks: { [name: string]: Promise<DataStoreViewReadonly> } = {};
   const getTask = (name: string) => name in tasks ?
     tasks[name] :
-    tasks[name] = (async () => RunPlugin(name))();
+    tasks[name] = (async () => ScheduleNode(name))();
 
   // execute pipeline
   const barrier = new OutstandingTaskAwaiter();

--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -99,7 +99,7 @@ function CreateArtifactEmitter(): PipelinePlugin {
   return async (config, input, working, output) => {
     return EmitArtifacts(
       config,
-      config.GetEntry("artifact" as any),
+      config.GetEntry("input-artifact" as any),
       key => ResolveUri(
         config.OutputFolderUri,
         safeEval<string>(config.GetEntry("output-uri-expr" as any), { $key: key, $config: config.Raw })),
@@ -175,7 +175,7 @@ export async function RunPipeline(config: ConfigurationView, fileSystem: IFileSy
   const scopeComposedSwagger = await RunPlugin(config, "compose", scopeLoadedSwaggersTransformed);
   const scopeComposedSwaggerTransformed = await RunPlugin(config, "transform", scopeComposedSwagger);
 
-  await RunPlugin([...config.GetPluginViews("emit-swagger-document")][0], "emitter", scopeComposedSwaggerTransformed);
+  barrier.Await(RunPlugin([...config.GetPluginViews("emit-swagger-document")][0], "emitter", scopeComposedSwaggerTransformed));
 
   if (config.GetEntry("model-validator")) {
     barrier.Await(RunPlugin(config, "model-validator", scopeComposedSwaggerTransformed));

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -29,6 +29,14 @@ plugins:
 
 ### Graph
 
+#### Reflection
+
+``` yaml
+pipeline:
+  pipeline-emitter: # emits the pipeline graph
+    scope: scope-pipeline-emitter
+```
+
 #### Loading
 
 ``` yaml
@@ -49,6 +57,11 @@ pipeline:
     input: transform
     scope: scope-swagger-document/emitter
 
+scope-pipeline-emitter:
+  input-artifact: pipeline
+  is-object: true
+  output-uri-expr: |
+    "pipeline"
 scope-swagger-document/emitter:
   input-artifact: swagger-document
   is-object: true

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -31,7 +31,7 @@ plugins:
 
 ``` yaml
 emit-swagger-document:
-  artifact: swagger-document
+  input-artifact: swagger-document
   is-object: true
   # rethink that output-file part
   output-uri-expr: |
@@ -39,30 +39,30 @@ emit-swagger-document:
     $config.namespace || 
     $config["input-file"][0].split('/').reverse()[0].split('\\').reverse()[0].replace(/\.json$/, "")
 emit-code-model-v1:
-  artifact: code-model-v1
+  input-artifact: code-model-v1
   is-object: true
   output-uri-expr: |
     "code-model-v1"
 emit-source-file-csharp:
-  artifact: source-file-csharp
+  input-artifact: source-file-csharp
   output-uri-expr: $key.split("/output/")[1]
 emit-source-file-ruby:
-  artifact: source-file-ruby
+  input-artifact: source-file-ruby
   output-uri-expr: $key.split("/output/")[1]
 emit-source-file-nodejs:
-  artifact: source-file-nodejs
+  input-artifact: source-file-nodejs
   output-uri-expr: $key.split("/output/")[1]
 emit-source-file-python:
-  artifact: source-file-python
+  input-artifact: source-file-python
   output-uri-expr: $key.split("/output/")[1]
 emit-source-file-go:
-  artifact: source-file-go
+  input-artifact: source-file-go
   output-uri-expr: $key.split("/output/")[1]
 emit-source-file-java:
-  artifact: source-file-java
+  input-artifact: source-file-java
   output-uri-expr: $key.split("/output/")[1]
 emit-source-file-azureresourceschema:
-  artifact: source-file-azureresourceschema
+  input-artifact: source-file-azureresourceschema
   output-uri-expr: $key.split("/output/")[1]
 ```
 

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -47,9 +47,9 @@ pipeline:
     output-artifact: swagger-document
   swagger-document/emitter:
     input: transform
-    scope: emit-swagger-document
+    scope: scope-swagger-document/emitter
 
-emit-swagger-document:
+scope-swagger-document/emitter:
   input-artifact: swagger-document
   is-object: true
   # rethink that output-file part
@@ -57,7 +57,7 @@ emit-swagger-document:
     $config["output-file"] || 
     $config.namespace || 
     $config["input-file"][0].split('/').reverse()[0].split('\\').reverse()[0].replace(/\.json$/, "")
-emit-code-model-v1:
+scope-cm/emitter:
   input-artifact: code-model-v1
   is-object: true
   output-uri-expr: |
@@ -97,7 +97,7 @@ pipeline:
     output-artifact: code-model-v1
   csharp/cm/emitter:
     input: transform
-    scope: emit-code-model-v1
+    scope: scope-cm/emitter
   csharp/generate:
     plugin: csharp
     input: 
@@ -113,9 +113,9 @@ pipeline:
     output-artifact: source-file-csharp
   csharp/emitter:
     input: transform
-    scope: emit-source-file-csharp
+    scope: scope-csharp/emitter
 
-emit-source-file-csharp:
+scope-csharp/emitter:
   input-artifact: source-file-csharp
   output-uri-expr: $key.split("/output/")[1]
 
@@ -139,7 +139,7 @@ pipeline:
     output-artifact: code-model-v1
   go/cm/emitter:
     input: transform
-    scope: emit-code-model-v1
+    scope: scope-cm/emitter
   go/generate:
     plugin: go
     input: 
@@ -151,9 +151,9 @@ pipeline:
     output-artifact: source-file-go
   go/emitter:
     input: transform
-    scope: emit-source-file-go
+    scope: scope-go/emitter
 
-emit-source-file-go:
+scope-go/emitter:
   input-artifact: source-file-go
   output-uri-expr: $key.split("/output/")[1]
 
@@ -177,7 +177,7 @@ pipeline:
     output-artifact: code-model-v1
   java/cm/emitter:
     input: transform
-    scope: emit-code-model-v1
+    scope: scope-cm/emitter
   java/generate:
     plugin: java
     input: 
@@ -189,9 +189,9 @@ pipeline:
     output-artifact: source-file-java
   java/emitter:
     input: transform
-    scope: emit-source-file-java
+    scope: scope-java/emitter
 
-emit-source-file-java:
+scope-java/emitter:
   input-artifact: source-file-java
   output-uri-expr: $key.split("/output/")[1]
 
@@ -215,7 +215,7 @@ pipeline:
     output-artifact: code-model-v1
   python/cm/emitter:
     input: transform
-    scope: emit-code-model-v1
+    scope: scope-cm/emitter
   python/generate:
     plugin: python
     input: 
@@ -227,9 +227,9 @@ pipeline:
     output-artifact: source-file-python
   python/emitter:
     input: transform
-    scope: emit-source-file-python
+    scope: scope-python/emitter
 
-emit-source-file-python:
+scope-python/emitter:
   input-artifact: source-file-python
   output-uri-expr: $key.split("/output/")[1]
 
@@ -253,7 +253,7 @@ pipeline:
     output-artifact: code-model-v1
   nodejs/cm/emitter:
     input: transform
-    scope: emit-code-model-v1
+    scope: scope-cm/emitter
   nodejs/generate:
     plugin: nodejs
     input: 
@@ -265,9 +265,9 @@ pipeline:
     output-artifact: source-file-nodejs
   nodejs/emitter:
     input: transform
-    scope: emit-source-file-nodejs
+    scope: scope-nodejs/emitter
 
-emit-source-file-nodejs:
+scope-nodejs/emitter:
   input-artifact: source-file-nodejs
   output-uri-expr: $key.split("/output/")[1]
 
@@ -291,7 +291,7 @@ pipeline:
     output-artifact: code-model-v1
   ruby/cm/emitter:
     input: transform
-    scope: emit-code-model-v1
+    scope: scope-cm/emitter
   ruby/generate:
     plugin: ruby
     input: 
@@ -303,9 +303,9 @@ pipeline:
     output-artifact: source-file-ruby
   ruby/emitter:
     input: transform
-    scope: emit-source-file-ruby
+    scope: scope-ruby/emitter
 
-emit-source-file-ruby:
+scope-ruby/emitter:
   input-artifact: source-file-ruby
   output-uri-expr: $key.split("/output/")[1]
 
@@ -329,7 +329,7 @@ pipeline:
     output-artifact: code-model-v1
   azureresourceschema/cm/emitter:
     input: transform
-    scope: emit-code-model-v1
+    scope: scope-cm/emitter
   azureresourceschema/generate:
     plugin: azureresourceschema
     input: 
@@ -341,9 +341,9 @@ pipeline:
     output-artifact: source-file-azureresourceschema
   azureresourceschema/emitter:
     input: transform
-    scope: emit-source-file-azureresourceschema
+    scope: scope-azureresourceschema/emitter
 
-emit-source-file-azureresourceschema:
+scope-azureresourceschema/emitter:
   input-artifact: source-file-azureresourceschema
   output-uri-expr: $key.split("/output/")[1]
 output-artifact:

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -27,9 +27,28 @@ plugins:
   swagger-loader: 42
 ```
 
-### Emitters
+### Graph
+
+#### Loading
 
 ``` yaml
+pipeline:
+  swagger-document/loader:
+    # plugin: loader # IMPLICIT: default to last item if split by '/'
+    output-artifact: swagger-document
+  swagger-document/individual/transform:
+    input: loader
+    output-artifact: swagger-document
+  swagger-document/compose:
+    input: individual/transform
+    output-artifact: swagger-document
+  swagger-document/transform:
+    input: compose
+    output-artifact: swagger-document
+  swagger-document/emitter:
+    input: transform
+    scope: emit-swagger-document
+
 emit-swagger-document:
   input-artifact: swagger-document
   is-object: true
@@ -43,41 +62,291 @@ emit-code-model-v1:
   is-object: true
   output-uri-expr: |
     "code-model-v1"
+```
+
+#### Validation
+
+``` yaml
+pipeline:
+  swagger-document/model-validator:
+    input: transform
+    scope: model-validator
+  swagger-document/semantic-validator:
+    input: transform
+    scope: semantic-validator
+  swagger-document/azure-validator:
+    input: transform
+    scope: azure-validator
+```
+
+#### Generation
+
+##### C#
+
+``` yaml
+pipeline:
+  csharp/modeler:
+    input: swagger-document/transform
+    output-artifact: code-model-v1
+    scope: csharp
+  csharp/commonmarker:
+    input: modeler
+    output-artifact: code-model-v1
+  csharp/cm/transform:
+    input: commonmarker
+    output-artifact: code-model-v1
+  csharp/cm/emitter:
+    input: transform
+    scope: emit-code-model-v1
+  csharp/generate:
+    plugin: csharp
+    input: 
+      - swagger-document/transform
+      - cm/transform
+    output-artifact: source-file-csharp
+  csharp/simplifier:
+    plugin: csharp-simplifier
+    input: generate
+    output-artifact: source-file-csharp
+  csharp/transform:
+    input: simplifier
+    output-artifact: source-file-csharp
+  csharp/emitter:
+    input: transform
+    scope: emit-source-file-csharp
+
 emit-source-file-csharp:
   input-artifact: source-file-csharp
   output-uri-expr: $key.split("/output/")[1]
-emit-source-file-ruby:
-  input-artifact: source-file-ruby
-  output-uri-expr: $key.split("/output/")[1]
-emit-source-file-nodejs:
-  input-artifact: source-file-nodejs
-  output-uri-expr: $key.split("/output/")[1]
-emit-source-file-python:
-  input-artifact: source-file-python
-  output-uri-expr: $key.split("/output/")[1]
+
+output-artifact:
+- source-file-csharp
+```
+
+##### Go
+
+``` yaml
+pipeline:
+  go/modeler:
+    input: swagger-document/transform
+    output-artifact: code-model-v1
+    scope: go
+  go/commonmarker:
+    input: modeler
+    output-artifact: code-model-v1
+  go/cm/transform:
+    input: commonmarker
+    output-artifact: code-model-v1
+  go/cm/emitter:
+    input: transform
+    scope: emit-code-model-v1
+  go/generate:
+    plugin: go
+    input: 
+      - swagger-document/transform
+      - cm/transform
+    output-artifact: source-file-go
+  go/transform:
+    input: generate
+    output-artifact: source-file-go
+  go/emitter:
+    input: transform
+    scope: emit-source-file-go
+
 emit-source-file-go:
   input-artifact: source-file-go
   output-uri-expr: $key.split("/output/")[1]
+
+output-artifact:
+- source-file-go
+```
+
+##### Java
+
+``` yaml
+pipeline:
+  java/modeler:
+    input: swagger-document/transform
+    output-artifact: code-model-v1
+    scope: java
+  java/commonmarker:
+    input: modeler
+    output-artifact: code-model-v1
+  java/cm/transform:
+    input: commonmarker
+    output-artifact: code-model-v1
+  java/cm/emitter:
+    input: transform
+    scope: emit-code-model-v1
+  java/generate:
+    plugin: java
+    input: 
+      - swagger-document/transform
+      - cm/transform
+    output-artifact: source-file-java
+  java/transform:
+    input: generate
+    output-artifact: source-file-java
+  java/emitter:
+    input: transform
+    scope: emit-source-file-java
+
 emit-source-file-java:
   input-artifact: source-file-java
   output-uri-expr: $key.split("/output/")[1]
+
+output-artifact:
+- source-file-java
+```
+
+##### Python
+
+``` yaml
+pipeline:
+  python/modeler:
+    input: swagger-document/transform
+    output-artifact: code-model-v1
+    scope: python
+  python/commonmarker:
+    input: modeler
+    output-artifact: code-model-v1
+  python/cm/transform:
+    input: commonmarker
+    output-artifact: code-model-v1
+  python/cm/emitter:
+    input: transform
+    scope: emit-code-model-v1
+  python/generate:
+    plugin: python
+    input: 
+      - swagger-document/transform
+      - cm/transform
+    output-artifact: source-file-python
+  python/transform:
+    input: generate
+    output-artifact: source-file-python
+  python/emitter:
+    input: transform
+    scope: emit-source-file-python
+
+emit-source-file-python:
+  input-artifact: source-file-python
+  output-uri-expr: $key.split("/output/")[1]
+
+output-artifact:
+- source-file-python
+```
+
+##### Node JS
+
+``` yaml
+pipeline:
+  nodejs/modeler:
+    input: swagger-document/transform
+    output-artifact: code-model-v1
+    scope: nodejs
+  nodejs/commonmarker:
+    input: modeler
+    output-artifact: code-model-v1
+  nodejs/cm/transform:
+    input: commonmarker
+    output-artifact: code-model-v1
+  nodejs/cm/emitter:
+    input: transform
+    scope: emit-code-model-v1
+  nodejs/generate:
+    plugin: nodejs
+    input: 
+      - swagger-document/transform
+      - cm/transform
+    output-artifact: source-file-nodejs
+  nodejs/transform:
+    input: generate
+    output-artifact: source-file-nodejs
+  nodejs/emitter:
+    input: transform
+    scope: emit-source-file-nodejs
+
+emit-source-file-nodejs:
+  input-artifact: source-file-nodejs
+  output-uri-expr: $key.split("/output/")[1]
+
+output-artifact:
+- source-file-nodejs
+```
+
+##### Ruby
+
+``` yaml
+pipeline:
+  ruby/modeler:
+    input: swagger-document/transform
+    output-artifact: code-model-v1
+    scope: ruby
+  ruby/commonmarker:
+    input: modeler
+    output-artifact: code-model-v1
+  ruby/cm/transform:
+    input: commonmarker
+    output-artifact: code-model-v1
+  ruby/cm/emitter:
+    input: transform
+    scope: emit-code-model-v1
+  ruby/generate:
+    plugin: ruby
+    input: 
+      - swagger-document/transform
+      - cm/transform
+    output-artifact: source-file-ruby
+  ruby/transform:
+    input: generate
+    output-artifact: source-file-ruby
+  ruby/emitter:
+    input: transform
+    scope: emit-source-file-ruby
+
+emit-source-file-ruby:
+  input-artifact: source-file-ruby
+  output-uri-expr: $key.split("/output/")[1]
+
+output-artifact:
+- source-file-ruby
+```
+
+##### Azure Resource Schema
+
+``` yaml
+pipeline:
+  azureresourceschema/modeler:
+    input: swagger-document/transform
+    output-artifact: code-model-v1
+    scope: azureresourceschema
+  azureresourceschema/commonmarker:
+    input: modeler
+    output-artifact: code-model-v1
+  azureresourceschema/cm/transform:
+    input: commonmarker
+    output-artifact: code-model-v1
+  azureresourceschema/cm/emitter:
+    input: transform
+    scope: emit-code-model-v1
+  azureresourceschema/generate:
+    plugin: azureresourceschema
+    input: 
+      - swagger-document/transform
+      - cm/transform
+    output-artifact: source-file-azureresourceschema
+  azureresourceschema/transform:
+    input: generate
+    output-artifact: source-file-azureresourceschema
+  azureresourceschema/emitter:
+    input: transform
+    scope: emit-source-file-azureresourceschema
+
 emit-source-file-azureresourceschema:
   input-artifact: source-file-azureresourceschema
   output-uri-expr: $key.split("/output/")[1]
-```
-
-### Output Artifacts
-
-What to write out.
-
-``` yaml
 output-artifact:
-- source-file-csharp
-- source-file-ruby
-- source-file-nodejs
-- source-file-python
-- source-file-go
-- source-file-java
 - source-file-azureresourceschema
 ```
 

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -40,9 +40,9 @@ emit-swagger-document:
     $config["input-file"][0].split('/').reverse()[0].split('\\').reverse()[0].replace(/\.json$/, "")
 emit-code-model-v1:
   artifact: code-model-v1
-  is-object: false
+  is-object: true
   output-uri-expr: |
-    "code-model-v1.yaml"
+    "code-model-v1"
 emit-source-file-csharp:
   artifact: source-file-csharp
   output-uri-expr: $key.split("/output/")[1]

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -27,7 +27,46 @@ plugins:
   swagger-loader: 42
 ```
 
-## Output Artifacts
+### Emitters
+
+``` yaml
+emit-swagger-document:
+  artifact: swagger-document
+  is-object: true
+  # rethink that output-file part
+  output-uri-expr: |
+    $config["output-file"] || 
+    $config.namespace || 
+    $config["input-file"][0].split('/').reverse()[0].split('\\').reverse()[0].replace(/\.json$/, "")
+emit-code-model-v1:
+  artifact: code-model-v1
+  is-object: false
+  output-uri-expr: |
+    "code-model-v1.yaml"
+emit-source-file-csharp:
+  artifact: source-file-csharp
+  output-uri-expr: $key.split("/output/")[1]
+emit-source-file-ruby:
+  artifact: source-file-ruby
+  output-uri-expr: $key.split("/output/")[1]
+emit-source-file-nodejs:
+  artifact: source-file-nodejs
+  output-uri-expr: $key.split("/output/")[1]
+emit-source-file-python:
+  artifact: source-file-python
+  output-uri-expr: $key.split("/output/")[1]
+emit-source-file-go:
+  artifact: source-file-go
+  output-uri-expr: $key.split("/output/")[1]
+emit-source-file-java:
+  artifact: source-file-java
+  output-uri-expr: $key.split("/output/")[1]
+emit-source-file-azureresourceschema:
+  artifact: source-file-azureresourceschema
+  output-uri-expr: $key.split("/output/")[1]
+```
+
+### Output Artifacts
 
 What to write out.
 

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -385,12 +385,6 @@ Licensed under the MIT License. See License.txt in the project root for license 
                 }
             }
 
-            // opt into client side validation by default
-            if (!autoRestSettings.CustomSettings.ContainsKey("ClientSideValidation"))
-            {
-                autoRestSettings.CustomSettings.Add("ClientSideValidation", true);
-            }
-
             return autoRestSettings;
         }
 

--- a/src/core/AutoRest.Core/Settings.cs
+++ b/src/core/AutoRest.Core/Settings.cs
@@ -73,8 +73,6 @@ Licensed under the MIT License. See License.txt in the project root for license 
             ValidationLevel = Category.Error;
             ModelsName = "Models";
             CodeGenerationMode = "rest-client";
-
-            CustomSettings.Add("ClientSideValidation", true);
         }
 
         /// <summary>
@@ -386,6 +384,13 @@ Licensed under the MIT License. See License.txt in the project root for license 
                     autoRestSettings.CustomSettings[pair.Key] = pair.Value;
                 }
             }
+
+            // opt into client side validation by default
+            if (!autoRestSettings.CustomSettings.ContainsKey("ClientSideValidation"))
+            {
+                autoRestSettings.CustomSettings.Add("ClientSideValidation", true);
+            }
+
             return autoRestSettings;
         }
 

--- a/src/core/AutoRest.Extensions/ParameterGroupExtensionHelper.cs
+++ b/src/core/AutoRest.Extensions/ParameterGroupExtensionHelper.cs
@@ -35,6 +35,7 @@ namespace AutoRest.Extensions
                 //Constraints = parameter.Constraints, Omit these since we don't want to perform parameter validation
                 Documentation = parameter.Documentation,
                 ModelType = parameter.ModelType,
+                RealPath = new string[] { },
                 SerializedName = default(string) //Parameter is never serialized directly
             });
 

--- a/src/core/AutoRest/Program.cs
+++ b/src/core/AutoRest/Program.cs
@@ -40,6 +40,12 @@ namespace AutoRest
                     {
                         settings = Settings.Create(args);
 
+                        // opt into client side validation by default
+                        if (!settings.CustomSettings.ContainsKey("ClientSideValidation"))
+                        {
+                            settings.CustomSettings.Add("ClientSideValidation", true);
+                        }
+
                         // set up logging
                         if (settings.JsonValidationMessages)
                         {

--- a/src/gulp_modules/regeneration.iced
+++ b/src/gulp_modules/regeneration.iced
@@ -14,7 +14,6 @@ regenExpected = (opts,done) ->
     
     swaggerFiles = (if optsMappingsValue instanceof Array then optsMappingsValue[0] else optsMappingsValue).split(";")
     args = [
-      '--skip-validation=true',
       "--#{opts.language}",
       "--output-folder=#{outputDir}/#{key}",
       "--license-header=#{if !!opts.header then opts.header else 'MICROSOFT_MIT_NO_VERSION'}"
@@ -24,25 +23,25 @@ regenExpected = (opts,done) ->
       args.push("--input-file=#{if !!opts.inputBaseDir then "#{opts.inputBaseDir}/#{swaggerFile}" else swaggerFile}")
 
     if (opts.addCredentials)
-      args.push('--add-credentials=true')
+      args.push('--#{opts.language}.add-credentials=true')
 
     if (opts.azureArm)
-      args.push('--azure-arm=true')
+      args.push('--#{opts.language}.azure-arm=true')
 
     if (opts.fluent)
-      args.push('--fluent=true')
+      args.push('--#{opts.language}.fluent=true')
     
     if (opts.syncMethods)
-      args.push("--sync-methods=#{opts.syncMethods}")
+      args.push("--#{opts.language}.sync-methods=#{opts.syncMethods}")
     
     if (opts.flatteningThreshold)
-      args.push("--payload-flattening-threshold=#{opts.flatteningThreshold}")
+      args.push("--#{opts.language}.payload-flattening-threshold=#{opts.flatteningThreshold}")
 
     if (!!opts.nsPrefix)
       if (optsMappingsValue instanceof Array && optsMappingsValue[1] != undefined)
-        args.push("--namespace=#{optsMappingsValue[1]}")
+        args.push("--#{opts.language}.namespace=#{optsMappingsValue[1]}")
       else
-        args.push("--namespace=#{[opts.nsPrefix, key.replace(/\/|\./, '')].join('.')}")
+        args.push("--#{opts.language}.namespace=#{[opts.nsPrefix, key.replace(/\/|\./, '')].join('.')}")
 
     if (opts['override-info.version'])
       args.push("--override-info.version=#{opts['override-info.version']}")

--- a/src/gulp_modules/regeneration.iced
+++ b/src/gulp_modules/regeneration.iced
@@ -23,13 +23,13 @@ regenExpected = (opts,done) ->
       args.push("--input-file=#{if !!opts.inputBaseDir then "#{opts.inputBaseDir}/#{swaggerFile}" else swaggerFile}")
 
     if (opts.addCredentials)
-      args.push('--#{opts.language}.add-credentials=true')
+      args.push("--#{opts.language}.add-credentials=true")
 
     if (opts.azureArm)
-      args.push('--#{opts.language}.azure-arm=true')
+      args.push("--#{opts.language}.azure-arm=true")
 
     if (opts.fluent)
-      args.push('--#{opts.language}.fluent=true')
+      args.push("--#{opts.language}.fluent=true")
     
     if (opts.syncMethods)
       args.push("--#{opts.language}.sync-methods=#{opts.syncMethods}")


### PR DESCRIPTION
- fully abstract, configurable pipeline
- fixes #2236 (`application/xml` + `x-ms-parameter-grouping` = crash)
- legacy CLI: opt out client-side-validation by default
- allow `=` in value part of CLI param
