### PR TITLE
GO: Minor tweak to long-running operations.

### DIFF
--- a/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
+++ b/src/generator/AutoRest.Go/Templates/MethodTemplate.cshtml
@@ -70,8 +70,10 @@ func (client @(Model.Owner)) @(Model.MethodSignature) (@Model.MethodReturnSignat
         @:var result @(Model.MethodReturnType)
 
         @:defer func() {
+            @:if err != nil {
+                @:errChan <- err
+            @:}
             @:resultChan <- result
-            @:errChan <- err
             @:close(resultChan)
             @:close(errChan)
         @:}()


### PR DESCRIPTION
If error is nil don't write it to error channel just close it.