### PR TITLE
Fix LRO tests to support exceptions at creation

### DIFF
--- a/src/generator/AutoRest.Python.Azure.Tests/AcceptanceTests/lro_tests.py
+++ b/src/generator/AutoRest.Python.Azure.Tests/AcceptanceTests/lro_tests.py
@@ -67,7 +67,7 @@ class LroTests(unittest.TestCase):
 
     def assertRaisesWithMessage(self, msg, func, *args, **kwargs):
         try:
-            func(*args, **kwargs)
+            func(*args, **kwargs).result()
             self.fail("CloudError wasn't raised as expected")
 
         except CloudError as err:
@@ -86,13 +86,13 @@ class LroTests(unittest.TestCase):
         self.assertEqual("Succeeded", process.result().provisioning_state)
 
         self.assertRaisesWithMessage("Operation failed with status: 200. Details: Resource state Failed",
-            self.client.lr_os.put201_creating_failed200(product).result)
+            self.client.lr_os.put201_creating_failed200, product)
 
         process = self.client.lr_os.put200_updating_succeeded204(product)
         self.assertEqual("Succeeded", process.result().provisioning_state)
 
         self.assertRaisesWithMessage("Operation failed with status: 200. Details: Resource state Canceled",
-            self.client.lr_os.put200_acceptedcanceled200(product).result)
+            self.client.lr_os.put200_acceptedcanceled200, product)
 
         # Testing raw
         process = self.client.lr_os.put201_creating_succeeded200(product, raw=True)
@@ -144,10 +144,10 @@ class LroTests(unittest.TestCase):
         self.assertEqual("Succeeded", process.result().provisioning_state)
 
         self.assertRaisesWithMessage("Operation failed with status: 200. Details: Resource state Failed",
-            self.client.lr_os.put_async_retry_failed(product).result)
+            self.client.lr_os.put_async_retry_failed, product)
 
         self.assertRaisesWithMessage("Operation failed with status: 200. Details: Resource state Canceled",
-            self.client.lr_os.put_async_no_retrycanceled(product).result)
+            self.client.lr_os.put_async_no_retrycanceled, product)
 
         self.assertIsNone(self.client.lr_os.delete204_succeeded().result())
         self.assertIsNone(self.client.lr_os.delete202_retry200().result())
@@ -159,10 +159,10 @@ class LroTests(unittest.TestCase):
         self.assertIsNone(self.client.lr_os.delete_async_no_header_in_retry().result())
 
         self.assertRaisesWithMessage("Operation failed with status: 200. Details: Resource state Canceled",
-            self.client.lr_os.delete_async_retrycanceled().result)
+            self.client.lr_os.delete_async_retrycanceled)
 
         self.assertRaisesWithMessage("Operation failed with status: 200. Details: Resource state Failed",
-            self.client.lr_os.delete_async_retry_failed().result)
+            self.client.lr_os.delete_async_retry_failed)
 
         self.assertIsNone(self.client.lr_os.delete_async_retry_succeeded().result())
 
@@ -178,10 +178,10 @@ class LroTests(unittest.TestCase):
         self.assertIsNone(self.client.lr_os.post202_no_retry204(product).result())
 
         self.assertRaisesWithMessage("Internal Server Error",
-            self.client.lr_os.post_async_retry_failed().result)
+            self.client.lr_os.post_async_retry_failed)
 
         self.assertRaisesWithMessage("Operation failed with status: 200. Details: Resource state Canceled",
-            self.client.lr_os.post_async_retrycanceled().result)
+            self.client.lr_os.post_async_retrycanceled)
 
         prod = self.client.lr_os.post_async_retry_succeeded().result()
         self.assertEqual(prod.id, "100")
@@ -225,40 +225,40 @@ class LroTests(unittest.TestCase):
         product = Product(location="West US")
 
         self.assertRaisesWithMessage("Expected bad request message",
-            self.client.lrosa_ds.put_non_retry400(product).result)
+            self.client.lrosa_ds.put_non_retry400, product)
 
         self.assertRaisesWithMessage("Error from the server",
-            self.client.lrosa_ds.put_non_retry201_creating400(product).result)
+            self.client.lrosa_ds.put_non_retry201_creating400, product)
 
         self.assertRaisesWithMessage("Operation failed with status: 'Bad Request'",
-            self.client.lrosa_ds.put_async_relative_retry400(product).result)
+            self.client.lrosa_ds.put_async_relative_retry400, product)
 
         self.assertRaisesWithMessage("Expected bad request message",
-            self.client.lrosa_ds.delete_non_retry400().result)
+            self.client.lrosa_ds.delete_non_retry400)
 
         self.assertRaisesWithMessage("Expected bad request message",
-            self.client.lrosa_ds.delete202_non_retry400().result)
+            self.client.lrosa_ds.delete202_non_retry400)
 
         self.assertRaisesWithMessage("Expected bad request message",
-            self.client.lrosa_ds.delete_async_relative_retry400().result)
+            self.client.lrosa_ds.delete_async_relative_retry400)
 
         self.assertRaisesWithMessage("Expected bad request message",
-            self.client.lrosa_ds.post_non_retry400(product).result)
+            self.client.lrosa_ds.post_non_retry400, product)
 
         self.assertRaisesWithMessage("Expected bad request message",
-            self.client.lrosa_ds.post202_non_retry400(product).result)
+            self.client.lrosa_ds.post202_non_retry400, product)
 
         self.assertRaisesWithMessage("Expected bad request message",
-            self.client.lrosa_ds.post_async_relative_retry400(product).result)
+            self.client.lrosa_ds.post_async_relative_retry400, product)
 
         self.assertRaisesWithMessage("The response from long running operation does not contain a body.",
-            self.client.lrosa_ds.put_error201_no_provisioning_state_payload(product).result)
+            self.client.lrosa_ds.put_error201_no_provisioning_state_payload, product)
 
         self.assertRaisesWithMessage("The response from long running operation does not contain a body.",
-            self.client.lrosa_ds.put_async_relative_retry_no_status(product).result)
+            self.client.lrosa_ds.put_async_relative_retry_no_status, product)
 
         self.assertRaisesWithMessage("The response from long running operation does not contain a body.",
-            self.client.lrosa_ds.put_async_relative_retry_no_status_payload(product).result)
+            self.client.lrosa_ds.put_async_relative_retry_no_status_payload, product)
 
         with self.assertRaises(DeserializationError):
             self.client.lrosa_ds.put200_invalid_json(product).result()
@@ -290,13 +290,13 @@ class LroTests(unittest.TestCase):
         self.client.lrosa_ds.delete204_succeeded().result()
 
         self.assertRaisesWithMessage("The response from long running operation does not contain a body.",
-            self.client.lrosa_ds.delete_async_relative_retry_no_status().result)
+            self.client.lrosa_ds.delete_async_relative_retry_no_status)
 
         self.assertRaisesWithMessage("Location header is missing from long running operation.",
-            self.client.lrosa_ds.post202_no_location().result)
+            self.client.lrosa_ds.post202_no_location)
 
         self.assertRaisesWithMessage("The response from long running operation does not contain a body.",
-            self.client.lrosa_ds.post_async_relative_retry_no_payload().result)
+            self.client.lrosa_ds.post_async_relative_retry_no_payload)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Current testsuite wrongly assume that only the `result` method can raise an exception, but the creation of the object can also.
Saw it by fixing this bug, https://github.com/Azure/msrestazure-for-python/issues/21

This PR just changes the assumption "only result() can raise" to "result() and constructor can raise". This means this is backward compatible and this PR should be green right now. This will allow me to release a new version of msrestazure without breaking Autorest CI

@olydis @fearthecowboy 