### PR TITLE
[Go] Simpler names for clients

### DIFF
--- a/src/generator/AutoRest.Go/CodeNamerGo.cs
+++ b/src/generator/AutoRest.Go/CodeNamerGo.cs
@@ -319,7 +319,7 @@ namespace AutoRest.Go
 
             // we use the base implementation here as it uses a case-insensitive comparison.
             // this is a bit of a hacky work-around for some naming changes introduced in core...
-            return EnsureNameCase(PascalCase(RemoveInvalidCharacters(base.GetEscapedReservedName(name, "Group"))));
+            return EnsureNameCase(PascalCase(RemoveInvalidCharacters(name)));
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes one of the issues @colemickens mentions here https://github.com/Azure/azure-sdk-for-go/issues/616
Renaming the very confusing `GroupClient` to `Client`

PTAL
@jhendrixMSFT @marstr