### PR TITLE
bring joy to: single cores, AAAL message consumers, Ruby people, CLI users

### DIFF
--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -143,15 +143,15 @@ function subscribeMessages(api: AutoRest, errorCounter: () => void) {
       case Channel.Debug:
       case Channel.Verbose:
       case Channel.Information:
-        console.log(m.FormattedMessage);
+        console.log(m.FormattedMessage || m.Text);
         break;
       case Channel.Warning:
-        console.warn(m.FormattedMessage);
+        console.warn(m.FormattedMessage || m.Text);
         break;
       case Channel.Error:
       case Channel.Fatal:
         errorCounter();
-        console.error(m.FormattedMessage);
+        console.error(m.FormattedMessage || m.Text);
         break;
     }
   });

--- a/src/autorest-core/app.ts
+++ b/src/autorest-core/app.ts
@@ -140,25 +140,18 @@ function parseArgs(autorestArgs: string[]): CommandLineArgs {
 function subscribeMessages(api: AutoRest, errorCounter: () => void) {
   api.Message.Subscribe((_, m) => {
     switch (m.Channel) {
+      case Channel.Debug:
+      case Channel.Verbose:
       case Channel.Information:
-        console.log(m.Text);
+        console.log(m.FormattedMessage);
         break;
       case Channel.Warning:
-        console.warn(m.Text);
+        console.warn(m.FormattedMessage);
         break;
       case Channel.Error:
-        errorCounter();
-        console.error(m.Text);
-        break;
-      case Channel.Debug:
-        console.log(m.Text);
-        break;
-      case Channel.Verbose:
-        console.log(m.Text);
-        break;
       case Channel.Fatal:
         errorCounter();
-        console.error(m.Text);
+        console.error(m.FormattedMessage);
         break;
     }
   });

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -393,7 +393,7 @@ export class ConfigurationView {
                 mx.Details["json-path"] = mx.Details[0];
               }
             }
-            mx.Text = JSON.stringify(mx.Details || mx, null, 2);
+            mx.FormattedMessage = JSON.stringify(mx.Details || mx, null, 2);
             break;
           default:
             let text = `${(mx.Channel || Channel.Information).toString().toUpperCase()}${mx.Key ? ` (${[...mx.Key].join("/")})` : ""}: ${mx.Text}`;
@@ -411,7 +411,7 @@ export class ConfigurationView {
                 }
               }
             }
-            mx.Text = text;
+            mx.FormattedMessage = text;
             break;
         }
 

--- a/src/autorest-core/lib/message.ts
+++ b/src/autorest-core/lib/message.ts
@@ -30,7 +30,10 @@ export interface Message {
   Key?: Iterable<string>;
   Details?: any;
   Text: string;
+
+  // injected or modified by core
   Source?: Array<SourceLocation>;
   Range?: Iterable<Range>;
   Plugin?: string;
+  FormattedMessage?: string;
 };

--- a/src/autorest-core/lib/ref/uri.ts
+++ b/src/autorest-core/lib/ref/uri.ts
@@ -63,11 +63,23 @@ import { dirname } from "path";
 const URI = require("urijs");
 const fileUri: (path: string, options: { resolve: boolean }) => string = require("file-url");
 
-// remake of path.isAbsolute... because it's platform dependent:
-// Windows: C:\\... -> true    /... -> true
-// Linux:   C:\\... -> false   /... -> true
+
+/**
+ *  remake of path.isAbsolute... because it's platform dependent:
+ * Windows: C:\\... -> true    /... -> true
+ * Linux:   C:\\... -> false   /... -> true
+ */
 function isAbsolute(path: string): boolean {
   return !!path.match(/^([a-zA-Z]:)?(\/|\\)/);
+}
+
+/**
+ * determines what an absolute URI is for our purposes, consider:
+ * - we had Ruby try to use "Azure::ARM::SQL" as a file name, so that should not be considered absolute
+ * - we want simple, easily predictable semantics
+ */
+function isUriAbsolute(url: string): boolean {
+  return /^[a-z]+:\/\//.test(url);
 }
 
 /**
@@ -117,9 +129,18 @@ export function ResolveUri(baseUri: string, pathOrUri: string): string {
   if (isAbsolute(pathOrUri)) {
     return CreateFileOrFolderUri(pathOrUri);
   }
+  // known here: `pathOrUri` is eiher URI (relative or absolute) or relative path - which we can normalize to a relative URI
   pathOrUri = pathOrUri.replace(/\\/g, "/");
+  // known here: `pathOrUri` is a URI (relative or absolute)
+  if (isUriAbsolute(pathOrUri)) {
+    return pathOrUri;
+  }
+  // known here: `pathOrUri` is a relative URI
   if (!baseUri) {
     throw new Error("'pathOrUri' was detected to be relative so 'baseUri' is required");
+  }
+  if (pathOrUri.indexOf(":") !== -1) {
+    throw new Error(`Invalid character ':' in relative URI ${pathOrUri}`);
   }
   return new URI(pathOrUri).absoluteTo(baseUri).toString();
 }

--- a/src/autorest-core/lib/ref/uri.ts
+++ b/src/autorest-core/lib/ref/uri.ts
@@ -139,10 +139,11 @@ export function ResolveUri(baseUri: string, pathOrUri: string): string {
   if (!baseUri) {
     throw new Error("'pathOrUri' was detected to be relative so 'baseUri' is required");
   }
-  if (pathOrUri.indexOf(":") !== -1) {
-    throw new Error(`Invalid character ':' in relative URI ${pathOrUri}`);
+  try {
+    return new URI(pathOrUri).absoluteTo(baseUri).toString();
+  } catch (e) {
+    throw new Error(`Failed resolving '${pathOrUri}' against '${baseUri}'.`);
   }
-  return new URI(pathOrUri).absoluteTo(baseUri).toString();
 }
 
 export function ParentFolderUri(uri: string): string | null {

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -78,7 +78,7 @@ scope-swagger-document/emitter:
   # rethink that output-file part
   output-uri-expr: |
     $config["output-file"] || 
-    $config.namespace || 
+    $config.namespace.replace(/:/g,'_') || 
     $config["input-file"][0].split('/').reverse()[0].split('\\').reverse()[0].replace(/\.json$/, "")
 scope-cm/emitter:
   input-artifact: code-model-v1

--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -78,7 +78,7 @@ scope-swagger-document/emitter:
   # rethink that output-file part
   output-uri-expr: |
     $config["output-file"] || 
-    $config.namespace.replace(/:/g,'_') || 
+    ($config.namespace ? $config.namespace.replace(/:/g,'_') : undefined) || 
     $config["input-file"][0].split('/').reverse()[0].split('\\').reverse()[0].replace(/\.json$/, "")
 scope-cm/emitter:
   input-artifact: code-model-v1

--- a/src/gulp_modules/gulp.iced
+++ b/src/gulp_modules/gulp.iced
@@ -86,7 +86,7 @@ Import
   today: moment().format('YYYYMMDD')
   now: moment().format('YYYYMMDD-HHmm')
   force: argv.force or false
-  threshold: argv.threshold or ((os.cpus().length)-1 )
+  threshold: argv.threshold or ((os.cpus().length)-1) or 1
   verbose: argv.verbose or null
   workdir: "#{process.env.tmp}/gulp/#{guid()}"
   watch: argv.watch or false


### PR DESCRIPTION
- give single cores a chance to run gulp stuff
- fixes #2332 
- fixes a bug (saw it affect Ruby CI) where a namespace like "A::B::C" is used during URI resolution (it was the default path to emit some artifacts), which got URI resolution very confused (is this relative or absolute?)
- emit a warning if both `-` and `--` arguments are mixed