### PR TITLE
[ReadMe] Fix header

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,4 +1,4 @@
-#AutoRest Documentation
+# AutoRest Documentation
 
 1. Installing AutoRest. 
     - You can [install AutoRest](./installing-autorest.md) on Windows, Mac, or Linux.


### PR DESCRIPTION
Adds a space between "#" and "AutoRest Documentation" so this displays with large font