### PR TITLE
Fixing issue 2226

### DIFF
--- a/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameParameter.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/Extensions/XmsClientNameParameter.cs
@@ -50,7 +50,7 @@ namespace AutoRest.Swagger.Validation
         {
             if (parameter?.Extensions?.ContainsKey(extensionToCheck) == true)
             {
-                if (parameter.Extensions[extensionToCheck].ToString().EqualsIgnoreCase(parameter.Name))
+                if (parameter.Extensions[extensionToCheck].ToString().Equals(parameter.Name))
                 {
                     yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, parameter.Name);
                 }


### PR DESCRIPTION
Relaxes condition that compares x-ms-client-name appropriate properties to allow case insensitive naming