### PR TITLE
Code changes for Long Running Rule

### DIFF
--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -339,7 +339,7 @@ namespace AutoRest.Core.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to A long running operation must have &apos;x-ms-long-running-operation&apos; extension enabled..
+        ///   Looks up a localized string similar to A long running operation should have &apos;x-ms-long-running-operation&apos; extension enabled..
         /// </summary>
         public static string LongRunningOperationsWithLongRunningExtension {
             get {

--- a/src/core/AutoRest.Core/Properties/Resources.Designer.cs
+++ b/src/core/AutoRest.Core/Properties/Resources.Designer.cs
@@ -132,7 +132,7 @@ namespace AutoRest.Core.Properties {
                 return ResourceManager.GetString("CollectionObjectPropertiesNamingMessage", resourceCulture);
             }
         }
-
+        
         /// <summary>
         ///   Looks up a localized string similar to Plugins:
         ///  CSharp:
@@ -148,7 +148,9 @@ namespace AutoRest.Core.Properties {
         ///  Azure.Ruby:
         ///    TypeName: PluginRba, AutoRest.Ruby.Azure
         ///  NodeJS:
-        ///    TypeName: PluginJs, Au [rest of string was truncated]&quot;;.
+        ///    TypeName: PluginJs, AutoRest.NodeJS
+        ///  Azure.NodeJS:
+        ///    TypeName: PluginJsa, AutoRest.NodeJS. [rest of string was truncated]&quot;;.
         /// </summary>
         public static string ConfigurationKnownPlugins {
             get {
@@ -333,6 +335,15 @@ namespace AutoRest.Core.Properties {
         public static string ListOperationsNamingWarningMessage {
             get {
                 return ResourceManager.GetString("ListOperationsNamingWarningMessage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to A long running operation must have &apos;x-ms-long-running-operation&apos; extension enabled..
+        /// </summary>
+        public static string LongRunningOperationsWithLongRunningExtension {
+            get {
+                return ResourceManager.GetString("LongRunningOperationsWithLongRunningExtension", resourceCulture);
             }
         }
         

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -369,6 +369,6 @@ Modelers:
     <value>The summary and description values should not be same.</value>
   </data>
   <data name="LongRunningOperationsWithLongRunningExtension" xml:space="preserve">
-    <value>A long running operation must have 'x-ms-long-running-operation' extension enabled.</value>
+    <value>A long running operation should have 'x-ms-long-running-operation' extension enabled.</value>
   </data>
 </root>

--- a/src/core/AutoRest.Core/Properties/Resources.resx
+++ b/src/core/AutoRest.Core/Properties/Resources.resx
@@ -368,4 +368,7 @@ Modelers:
   <data name="SummaryDescriptionVaidationError" xml:space="preserve">
     <value>The summary and description values should not be same.</value>
   </data>
+  <data name="LongRunningOperationsWithLongRunningExtension" xml:space="preserve">
+    <value>A long running operation must have 'x-ms-long-running-operation' extension enabled.</value>
+  </data>
 </root>

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-with-extension-false.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-with-extension-false.json
@@ -1,0 +1,78 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operations schemes has non-http/https type",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "Https"
+  ],
+  "basePath": "/",
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "put": {
+        "operationId": "Redis_Create",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "create params",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": false
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  },
+  "definitions": {
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "the operation"
+          },
+          "description": "List of Operations"
+        }
+      }
+    },
+    "Model": {
+      "properties": {
+        "prop1": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-with-extension-false.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-with-extension-false.json
@@ -38,35 +38,8 @@
     }
   },
   "parameters": {
-    "SubscriptionIdParameter": {
-      "name": "subscriptionId",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "test subscription id"
-    },
-    "ApiVersion": {
-      "name": "api-version",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "test api version"
-    }
   },
   "definitions": {
-    "OperationsListResult": {
-      "description": "List of operations",
-      "properties": {
-        "value": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "the operation"
-          },
-          "description": "List of Operations"
-        }
-      }
-    },
     "Model": {
       "properties": {
         "prop1": {

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-without-extension.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-without-extension.json
@@ -37,35 +37,8 @@
     }
   },
   "parameters": {
-    "SubscriptionIdParameter": {
-      "name": "subscriptionId",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "test subscription id"
-    },
-    "ApiVersion": {
-      "name": "api-version",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "test api version"
-    }
   },
   "definitions": {
-    "OperationsListResult": {
-      "description": "List of operations",
-      "properties": {
-        "value": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "the operation"
-          },
-          "description": "List of Operations"
-        }
-      }
-    },
     "Model": {
       "properties": {
         "prop1": {

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-without-extension.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/long-running-operation-without-extension.json
@@ -1,0 +1,77 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operations schemes has non-http/https type",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "Https"
+  ],
+  "basePath": "/",
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "put": {
+        "operationId": "Redis_Create",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "create params",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  },
+  "definitions": {
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "the operation"
+          },
+          "description": "List of Operations"
+        }
+      }
+    },
+    "Model": {
+      "properties": {
+        "prop1": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/long-running-operation-extension.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/long-running-operation-extension.json
@@ -37,36 +37,9 @@
       }
     }
   },
-  "parameters": {
-    "SubscriptionIdParameter": {
-      "name": "subscriptionId",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "test subscription id"
-    },
-    "ApiVersion": {
-      "name": "api-version",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "description": "test api version"
-    }
+  "parameters": {    
   },
   "definitions": {
-    "OperationsListResult": {
-      "description": "List of operations",
-      "properties": {
-        "value": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "description": "the operation"
-          },
-          "description": "List of Operations"
-        }
-      }
-    },
     "Model": {
       "properties": {
         "prop1": {

--- a/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/long-running-operation-extension.json
+++ b/src/modeler/AutoRest.Swagger.Tests/Resource/Swagger/Validation/positive/long-running-operation-extension.json
@@ -1,0 +1,78 @@
+﻿{
+  "swagger": "2.0",
+  "info": {
+    "title": "Operations schemes has non-http/https type",
+    "description": "Some documentation.",
+    "version": "2014-04-01-preview"
+  },
+  "host": "management.azure.com",
+  "schemes": [
+    "Https"
+  ],
+  "basePath": "/",
+  "paths": {
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cache/Redis/{name}": {
+      "put": {
+        "operationId": "Redis_Create",
+        "parameters": [
+          {
+            "name": "parameters",
+            "in": "body",
+            "description": "create params",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Model"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": ""
+          },
+          "200": {
+            "description": ""
+          }
+        },
+        "x-ms-long-running-operation": true
+      }
+    }
+  },
+  "parameters": {
+    "SubscriptionIdParameter": {
+      "name": "subscriptionId",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test subscription id"
+    },
+    "ApiVersion": {
+      "name": "api-version",
+      "in": "path",
+      "required": true,
+      "type": "string",
+      "description": "test api version"
+    }
+  },
+  "definitions": {
+    "OperationsListResult": {
+      "description": "List of operations",
+      "properties": {
+        "value": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "description": "the operation"
+          },
+          "description": "List of Operations"
+        }
+      }
+    },
+    "Model": {
+      "properties": {
+        "prop1": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}

--- a/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
+++ b/src/modeler/AutoRest.Swagger.Tests/SwaggerModelerValidationTests.cs
@@ -626,7 +626,21 @@ namespace AutoRest.Swagger.Tests
             var messages = GetValidationMessagesForRule<LocationMustHaveXmsMutability>("location-with-incorrect-xms-mutability.json");
             Assert.Equal(messages.Count(), 1);
         }
-    }
+
+        [Fact]
+        public void LongRunningHasExtensionValidation()
+        {
+            var messages = GetValidationMessagesForRule<LongRunningOperationsWithLongRunningExtension>("long-running-operation-without-extension.json");
+            Assert.Equal(messages.Count(), 1);
+        }
+
+        [Fact]
+        public void LongRunningHasExtensionTrueValidation()
+        {
+            var messages = GetValidationMessagesForRule<LongRunningOperationsWithLongRunningExtension>("long-running-operation-with-extension-false.json");
+            Assert.Equal(messages.Count(), 1);
+        }
+}
 
     #region Positive tests
 
@@ -798,6 +812,15 @@ namespace AutoRest.Swagger.Tests
             Assert.Empty(messages);
         }
 
+        /// <summary>
+        /// Verifies extension for long running operation
+        /// </summary>
+        [Fact]
+        public void ValidExtensionForLongRunningOperation()
+        {
+            var messages = GetValidationMessagesForRule<LongRunningOperationsWithLongRunningExtension>(Path.Combine("positive", "long-running-operation-extension.json"));
+            Assert.Empty(messages);
+        }
     }
 
     #endregion

--- a/src/modeler/AutoRest.Swagger/Model/Operation.cs
+++ b/src/modeler/AutoRest.Swagger/Model/Operation.cs
@@ -14,6 +14,7 @@ namespace AutoRest.Swagger.Model
     /// </summary>
     [Rule(typeof(OperationDescriptionOrSummaryRequired))]
     [Rule(typeof(SummaryAndDescriptionMustNotBeSame))]
+    [Rule(typeof(LongRunningOperationsWithLongRunningExtension))]
     public class Operation : SwaggerBase
     {
         private string _description;

--- a/src/modeler/AutoRest.Swagger/Validation/LongRunningOperationsWithLongRunningExtension.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/LongRunningOperationsWithLongRunningExtension.cs
@@ -16,7 +16,7 @@ namespace AutoRest.Swagger.Validation
         /// <summary>
         /// Id of the Rule.
         /// </summary>
-        public override string Id => "M2004";
+        public override string Id => "R2007";
 
         /// <summary>
         /// Violation category of the Rule.

--- a/src/modeler/AutoRest.Swagger/Validation/LongRunningOperationsWithLongRunningExtension.cs
+++ b/src/modeler/AutoRest.Swagger/Validation/LongRunningOperationsWithLongRunningExtension.cs
@@ -1,0 +1,70 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+using AutoRest.Core.Logging;
+using AutoRest.Core.Properties;
+using AutoRest.Swagger.Model;
+using AutoRest.Swagger.Validation.Core;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace AutoRest.Swagger.Validation
+{
+    public class LongRunningOperationsWithLongRunningExtension : TypedRule<Operation>
+    {
+        /// <summary>
+        /// Id of the Rule.
+        /// </summary>
+        public override string Id => "M2004";
+
+        /// <summary>
+        /// Violation category of the Rule.
+        /// </summary>
+        public override ValidationCategory ValidationCategory => ValidationCategory.SDKViolation;
+
+        /// <summary>
+        /// The template message for this Rule. 
+        /// </summary>
+        /// <remarks>
+        /// This may contain placeholders '{0}' for parameterized messages.
+        /// </remarks>
+        public override string MessageTemplate => Resources.LongRunningOperationsWithLongRunningExtension;
+
+        /// <summary>
+        /// The severity of this message (ie, debug/info/warning/error/fatal, etc)
+        /// </summary>
+        public override Category Severity => Category.Warning;
+
+        /// <summary>
+        /// What kind of open api document type this rule should be applied to
+        /// </summary>
+        public override ServiceDefinitionDocumentType ServiceDefinitionDocumentType => ServiceDefinitionDocumentType.ARM;
+
+        /// <summary>
+        /// What kind of change implementing this rule can cause.
+        /// </summary>
+        public override ValidationChangesImpact ValidationChangesImpact => ValidationChangesImpact.SDKImpactingChanges;
+
+        /// <summary>
+        /// The rule could be violated by a model referenced by many jsons belonging to the same
+        /// composed state, to reduce duplicate messages, run validation rule in composed state
+        /// </summary>
+        public override ServiceDefinitionDocumentState ValidationRuleMergeState => ServiceDefinitionDocumentState.Individual;
+
+        /// <summary>
+        /// Validates if the long running operation has long running extension enabled.
+        /// </summary>
+        /// <param name="operation"></param>
+        /// <param name="context"></param>
+        /// <returns>true if the long running operation has long running extension enabled. false otherwise.</returns>
+        public override IEnumerable<ValidationMessage> GetValidationMessages(Operation operation, RuleContext context)
+        {
+            if (operation.Responses?.Any(response => response.Key.Equals("202")) == true &&
+              operation.Extensions?.Any(extension => extension.Key.Equals("x-ms-long-running-operation") && (bool)extension.Value) == false)
+            {
+                yield return new ValidationMessage(new FileObjectPath(context.File, context.Path), this, new object[0]);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Related to https://github.com/Azure/autorest/issues/1960

What does this rule do?
For an Operation with response 202,
1. It must have x-ms-long-running extension
2. The extension must be set to true.

Error Message: "A long running operation must have 'x-ms-long-running-operation' extension enabled."
Sample Path: "file:///C:/workspace/autorest/src/modeler/AutoRest.Swagger.Tests/bin/Debug/netcoreapp1.0/Resource/Swagger/Validation/long-running-operation-without-extension.json#/paths/~1subscriptions~1{subscriptionId}~1resourceGroups~1{resourceGroupName}~1providers~1Microsoft.Cache~1Redis~1{name}/put"
Severity: Warning
