### PR TITLE
Improve Python 3.5 reliability on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ addons:
     sources:
     - deadsnakes
     packages:
-    # packages for python
+    # packages for python (including cryptography)
     - python3.6
+    - python3.6-dev
+    - libssl-dev
+    - libffi-dev
 env:
   matrix:
   - MODE=main

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ addons:
     - deadsnakes
     packages:
     # packages for python (including cryptography)
-    - python3.6
-    - python3.6-dev
+    - python3.5
+    - python3.5-dev
     - libssl-dev
     - libffi-dev
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ addons:
     - deadsnakes
     packages:
     # packages for python
-    - python3.5
+    - python3.6
 env:
   matrix:
   - MODE=main

--- a/src/generator/AutoRest.Python.Azure.Tests/tox.ini
+++ b/src/generator/AutoRest.Python.Azure.Tests/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27, py36
+envlist=py27, py35
 skipsdist=True
 
 [testenv]

--- a/src/generator/AutoRest.Python.Azure.Tests/tox.ini
+++ b/src/generator/AutoRest.Python.Azure.Tests/tox.ini
@@ -1,8 +1,12 @@
 [tox]
-envlist=py27, py35
+envlist=py27, py36
 skipsdist=True
 
 [testenv]
+deps=
+    -rrequirements.txt 
+    coverage
+    flake8
 commands=
     coverage run ./AcceptanceTests/__init__.py
     coverage report --fail-under=60 --omit=*AutoRest.Python.Tests*,AcceptanceTests*.py,*.tox*.py
@@ -14,15 +18,3 @@ setenv =
 [flake8]
 ignore = E501,F401
 max-line-length = 100
-
-[testenv:py27]
-deps=
-    -rrequirements.txt 
-    coverage
-    flake8
-
-[testenv:py35]
-deps=
-    -rrequirements.txt 
-    coverage
-    flake8

--- a/src/generator/AutoRest.Python.Tests/tox.ini
+++ b/src/generator/AutoRest.Python.Tests/tox.ini
@@ -1,8 +1,13 @@
 [tox]
-envlist=py27, py35
+envlist=py27, py36
 skipsdist=True
 
 [testenv]
+deps=
+    -rrequirements.txt 
+    coverage
+    flake8
+
 commands=
     coverage run ./AcceptanceTests/__init__.py
     coverage report --fail-under=60 --omit=AcceptanceTests*.py,*.tox*.py
@@ -14,15 +19,3 @@ setenv =
 [flake8]
 ignore = E501
 max-line-length = 100
-
-[testenv:py27]
-deps=
-    -rrequirements.txt 
-    coverage
-    flake8
-
-[testenv:py35]
-deps=
-    -rrequirements.txt 
-    coverage
-    flake8

--- a/src/generator/AutoRest.Python.Tests/tox.ini
+++ b/src/generator/AutoRest.Python.Tests/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27, py36
+envlist=py27, py35
 skipsdist=True
 
 [testenv]


### PR DESCRIPTION
@olydis This should fix your Travis build. Might require Python 3.6 installation on Jenkins.