### PR TITLE
Debugging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,15 +84,12 @@ Start by reading the documentation for using AutoRest:
 Get yourself up and coding in AutoRest
 
 - [Developer Workstation Requirements](./docs/developer/workstation.md) - what do you need to install to start working with the AutoRest code
-- [Compiling AutoRest](./docs/developer/compiling-autorest.md) - compiling/testing AutoRest using the build scripts 
+- [Compiling AutoRest](./docs/developer/compiling-autorest.md) - compiling/testing AutoRest using the build scripts
+- [Debugging AutoRest](./docs/developer/debugging-autorest.md) - debugging AutoRest and its components
 
-Some information about the internal AutoRest architecture (may need updating!):
+Some information about the internal architecture:
+- [Architecture Overview](./docs/developer/architecture/) - Components that make up AutoRest itself, extension model, client runtimes, etc.
 - [Developer Guide](./docs/developer/guide/) - Notes on developing with AutoRest
-- [AutoRest and ClientRuntimes](./docs/developer/architecture/Autorest-and-Clientruntimes.md) - about the client runtime requirements for AutoRest
-- [The `CodeModel` data model](./docs/developer/architecture/CodeModel-and-the-Language-specific-Generator-Transformer-Namer.md) and the Language-specific Generator/Transformer/Namer
-- [`Fixable<T>` implementation](./docs/developer/architecture/Fixable-T----When-a-value-is-both-calculated-and-or-fixed.md) - When a value is both calculated and/or fixed
-- [LODIS](./docs/developer/architecture/Least-Offensive-Dependency-Injection-System.md) - The Least Offensive Dependency Injection System
-- [Name Disambiguation](./docs/developer/architecture/Name-Disambiguation.md) - how names don't collide in code generation.
 - [Validation Rules & Linting](./docs/developer/validation-rules/readme.md) - about the validation rules in AutoRest
 
 ---

--- a/docs/developer/debugging-autorest.md
+++ b/docs/developer/debugging-autorest.md
@@ -1,0 +1,38 @@
+# Debugging AutoRest
+
+Since AutoRest is a combination of multiple components that work together, it is important to distinguish between them in order to choose the correct debugging strategy.
+See [AutoRest Fundamentals](./architecture/AutoRest-fundamentals.md) for information about the architecture.
+
+## Debugging the core
+
+The core is written in TypeScript, is the main entry point (`src/autorest-core/app.ts`) and can hence be debugged regularly using VS Code, corresponding launch scripts are predefined.
+
+## Debugging a classic generator
+
+The first generation of AutoRest generators were written in C#, resulting in the `AutoRest.dll` which now merely serves as one of many [extensions](./architecture/AutoRest-extension.md) to the AutoRest core.
+This extension is not usable or invokable as a stand-alone since it relies on previous processing steps either done by other extensions or by the AutoRest core.
+
+As a result, debugging the extension also requires it to be launched *through the core* like in a regular invocation of AutoRest (on the bright side, one can stay on the CLI and run exactly the command that exposes the problem to debug).
+One can then attach to the running extension process (`dotnet AutoRest.dll --server`) through VS Code, there is a launch configuration for that.
+The biggest problem is timing, i.e. attaching and having breakpoints in place before execution has passed the critical point.
+
+For this purpose, we introduced the `--debugger` flag which will cause any call to `AutoRest.dll` to *sit and wait* until a debugger is attached.
+
+### Example
+
+Assume there is a bug in C# code generation when running:
+
+```haskell
+autorest foo\readme.md --azure-validator --fancy-setting=3 --csharp.azure-arm
+```
+
+Simply call:
+
+```haskell
+autorest foo\readme.md --azure-validator --fancy-setting=3 --csharp.azure-arm --debugger
+```
+
+In this case, the modeler and the C# generator exposed by `AutoRest.dll` are called.
+Both of these calls will be suspended until a debugger is attached to the `dotnet` process.
+It will print something like `Waiting for debugger to attach.......` to the console.
+Happy debugging!

--- a/src/autorest-core/test/blaming.ts
+++ b/src/autorest-core/test/blaming.ts
@@ -13,7 +13,7 @@ import { parse } from "../lib/ref/jsonpath";
 
 @suite class Blaming {
 
-  @test @skip @timeout(0) async "end to end blaming with literate swagger"() {
+  @test @timeout(0) async "end to end blaming with literate swagger"() {
     const autoRest = new AutoRest(new RealFileSystem(), ResolveUri(CreateFolderUri(__dirname), "../../test/resources/literate-example/readme-composite.md"));
 
     autoRest.AddConfiguration({ "use-extension": { "@microsoft.azure/autorest-classic-generators": `${__dirname}/../../../core/AutoRest` } })
@@ -21,22 +21,24 @@ import { parse } from "../lib/ref/jsonpath";
     const view = await autoRest.view;
     assert.equal(await autoRest.Process().finish, true);
 
+    const keys = Object.keys((view.DataStore as any).store);
+    const composed = keys.filter(x => x.endsWith("swagger-document"))[0];
 
     // regular description
     {
       const blameTree = await view.DataStore.Blame(
-        "mem:///swagger-document/transform-immediate/output/swagger-document",
+        composed,
         { path: parse("$.securityDefinitions.azure_auth.description") });
-      const blameInputs = [...blameTree.BlameLeafs()];
+      const blameInputs = blameTree.BlameLeafs();
       assert.equal(blameInputs.length, 1);
     }
 
     // markdown description (blames both the swagger's json path and the markdown source of the description)
     {
       const blameTree = await view.DataStore.Blame(
-        "mem:///swagger-document/transform-immediate/output/swagger-document",
+        composed,
         { path: parse("$.definitions.SearchServiceListResult.description") });
-      const blameInputs = [...blameTree.BlameLeafs()];
+      const blameInputs = blameTree.BlameLeafs();
       assert.equal(blameInputs.length, 1);
       // assert.equal(blameInputs.length, 2); // TODO: blame configuration file segments!
     }
@@ -46,7 +48,7 @@ import { parse } from "../lib/ref/jsonpath";
       let msg = {
         Text: 'Phoney message to test', Channel: Channel.Warning, Source: [<SourceLocation>
           {
-            document: "mem:///compose/swagger.yaml",
+            document: composed,
             Position: <EnhancedPosition>{ path: parse('$.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{serviceName}"]') }
           }]
       };
@@ -59,7 +61,7 @@ import { parse } from "../lib/ref/jsonpath";
       let msg = {
         Text: 'Phoney message to test', Channel: Channel.Warning, Source: [<SourceLocation>
           {
-            document: "mem:///compose/swagger.yaml",
+            document: composed,
             Position: <EnhancedPosition>{ path: parse('$.paths["/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Search/searchServices/{serviceName}"].get') }
           }]
       };


### PR DESCRIPTION
...and refactored main README.md: It called out some things from the "architecture" folder, but not all, and arguably not the most important ones. Instead, now just references the architecture overview as a whole. Essentially we listed the same documents in 2 places but then failed to keep both up to date.