### PR TITLE
Extension and modeler fixes.

### DIFF
--- a/src/core/AutoRest.Extensions/ParameterGroupExtensionHelper.cs
+++ b/src/core/AutoRest.Extensions/ParameterGroupExtensionHelper.cs
@@ -69,7 +69,7 @@ namespace AutoRest.Extensions
                     string parameterGroupName;
                     if (specifiedGroupName == null)
                     {
-                        string postfix = extensionObject.Value<string>("postfix").Capitalize() ?? "Parameters";
+                        string postfix = extensionObject.Value<string>("postfix")?.Capitalize() ?? "Parameters";
                         parameterGroupName = $"{methodGroupName}{methodName.Capitalize()}{postfix}";
                     }
                     else

--- a/src/core/AutoRest.Extensions/ParameterGroupExtensionHelper.cs
+++ b/src/core/AutoRest.Extensions/ParameterGroupExtensionHelper.cs
@@ -69,8 +69,8 @@ namespace AutoRest.Extensions
                     string parameterGroupName;
                     if (specifiedGroupName == null)
                     {
-                        string postfix = extensionObject.Value<string>("postfix") ?? "Parameters";
-                        parameterGroupName = methodGroupName + "-" + methodName + "-" + postfix;
+                        string postfix = extensionObject.Value<string>("postfix").Capitalize() ?? "Parameters";
+                        parameterGroupName = $"{methodGroupName}{methodName.Capitalize()}{postfix}";
                     }
                     else
                     {

--- a/src/modeler/AutoRest.Swagger/OperationBuilder.cs
+++ b/src/modeler/AutoRest.Swagger/OperationBuilder.cs
@@ -146,6 +146,7 @@ namespace AutoRest.Swagger
                             Name = h.Key,
                             SerializedName = h.Key,
                             RealPath = new[] {h.Key},
+                            Extensions = h.Value.Extensions,
                             ModelType = h.Value.GetBuilder(this._swaggerModeler).BuildServiceType(h.Key),
                             Documentation = h.Value.Description
                         });


### PR DESCRIPTION
Generate parameter group postfix names according to the spec.
Preserve extensions when building header types.