### PR TITLE
communicate bootstrapper failure to the outside

### DIFF
--- a/src/autorest/app.ts
+++ b/src/autorest/app.ts
@@ -236,7 +236,8 @@ async function main() {
   } catch (exception) {
     console.log("Failure:");
     console.error(exception);
-    console.error((<Error>exception).stack)
+    console.error((<Error>exception).stack);
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
...or stuff like `regenerate` will just silently succeed (also swallowing the stuff that is written out to STDERR here) since the exit code is 0