### PR TITLE
Fix indents in x-ms-client-flatten example

### DIFF
--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -449,13 +449,13 @@ by using the following OpenAPI definition:
 "definitions": {
   "template": {
     "properties": {
-	    "name": {
-	      "type": "string"
-        },
-	    "properties": {
-	      "x-ms-client-flatten": true,
-	      "$ref": "#/definitions/templateProperties"
-	    } 
+      "name": {
+        "type": "string"
+      },
+      "properties": {
+        "x-ms-client-flatten": true,
+        "$ref": "#/definitions/templateProperties"
+      } 
     }
   }
 }
@@ -491,12 +491,12 @@ by using the following OpenAPI definition:
 "definitions": {
   "template": {
     "properties": {
-	    "name": {
-	      "type": "string"
-        },
-	    "properties": {
-	      "x-ms-client-flatten": true,
-	      "$ref": "#/definitions/templateProperties"
+      "name": {
+        "type": "string"
+      },
+      "properties": {
+        "x-ms-client-flatten": true,
+        "$ref": "#/definitions/templateProperties"
 	    } 
     }
   }


### PR DESCRIPTION
I think there were some tabs in the examples which rendered differently on GitHub than in the author's editor.