### PR TITLE
swallow leading $

### DIFF
--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -406,7 +406,15 @@ export class ConfigurationView {
                   if (path.length === 0) {
                     throw e;
                   }
-                  path.pop();
+                  // adjustment
+                  // 1) skip leading `$`
+                  if (path[0] === "$") {
+                    path.shift();
+                  }
+                  // 2) drop last part
+                  else {
+                    path.pop();
+                  }
                 } else {
                   throw e;
                 }


### PR DESCRIPTION
...because a certain `oav` emits paths like that which led to all paths getting reported as `$`...