### PR TITLE
preserve object graph

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,6 +3,12 @@
   "configurations": [
     {
       "type": "node",
+      "request": "attach",
+      "name": "Node.js Attach",
+      "port": 9229
+    },
+    {
+      "type": "node",
       "protocol": "inspector",
       "request": "launch",
       "name": "run tests",

--- a/src/autorest-core/lib/ref/yaml.ts
+++ b/src/autorest-core/lib/ref/yaml.ts
@@ -104,10 +104,10 @@ function ParseNodeInternal(yamlRootNode: YAMLNode, yamlNode: YAMLNode, onError: 
   }
 
   // important for anchors!
-  const memoize = (factory: (cache: WeakMap<YAMLNode, any>) => any): ((cache: WeakMap<YAMLNode, any>) => any) =>
+  const memoize = (factory: (cache: WeakMap<YAMLNode, any>, set: (o: any) => void) => any): ((cache: WeakMap<YAMLNode, any>) => any) =>
     cache => {
       if (cache.has(yamlNode)) return cache.get(yamlNode);
-      const result = factory(cache);
+      const result = factory(cache, o => cache.set(yamlNode, o));
       cache.set(yamlNode, result);
       return result;
     };
@@ -124,8 +124,9 @@ function ParseNodeInternal(yamlRootNode: YAMLNode, yamlNode: YAMLNode, onError: 
       return (yamlNode as any).valueFunc = () => null;
     case Kind.MAP: {
       const yamlNodeMapping = yamlNode as YAMLMap;
-      return (yamlNode as any).valueFunc = memoize(cache => {
+      return (yamlNode as any).valueFunc = memoize((cache, set) => {
         const result = NewEmptyObject();
+        set(result);
         for (const mapping of yamlNodeMapping.mappings) {
           if (mapping.key.kind !== Kind.SCALAR) {
             onError("Syntax error: Only scalar keys are allowed as mapping keys.", mapping.key.startPosition);
@@ -140,9 +141,13 @@ function ParseNodeInternal(yamlRootNode: YAMLNode, yamlNode: YAMLNode, onError: 
     }
     case Kind.SEQ: {
       const yamlNodeSequence = yamlNode as YAMLSequence;
-      return (yamlNode as any).valueFunc = memoize(cache => {
-        if (cache.has(yamlNode)) return cache.get(yamlNode);
-        return yamlNodeSequence.items.map(item => ParseNodeInternal(yamlRootNode, item, onError)(cache));
+      return (yamlNode as any).valueFunc = memoize((cache, set) => {
+        const result: any[] = [];
+        set(result);
+        for (const item of yamlNodeSequence.items) {
+          result.push(ParseNodeInternal(yamlRootNode, item, onError)(cache));
+        }
+        return result;
       });
     }
     case Kind.ANCHOR_REF: {
@@ -215,7 +220,7 @@ export function FastStringify<T>(obj: T): string {
   // has duplicate objects?
   const seen = new WeakSet();
   const losslessJsonSerializable = (o: any): boolean => {
-    if (typeof o == "object") {
+    if (o && typeof o == "object") {
       if (seen.has(o)) return false;
       seen.add(o);
     }

--- a/src/autorest-core/lib/ref/yaml.ts
+++ b/src/autorest-core/lib/ref/yaml.ts
@@ -184,11 +184,16 @@ export function Clone<T>(object: T): T {
  * Normalizes the order of given object's keys (sorts recursively)
  */
 export function Normalize<T>(object: T): T {
+  const seen = new WeakSet();
   const clone = Clone<T>(object);
   const norm = (o: any) => {
     if (Array.isArray(o)) {
       o.forEach(norm);
     } else if (o && typeof o == "object") {
+      if (seen.has(o)) {
+        return;
+      }
+      seen.add(o);
       const keys = Object.keys(o).sort();
       const oo = { ...o };
       for (const k of keys) {


### PR DESCRIPTION
### serialization

We would use JSON as long as there are no circular data structures - but that's too agressive and can still impose data loss compared to YAML! If the object graph contains multiple instances of the same object, each of those instances would be serialized out - so the information about object identity is lost.

### deserialization

When hitting a YAML anchor, we emitted a clone of the referenced object instead of literally returning the same reference.