### PR TITLE
nested style fix

### DIFF
--- a/src/autorest/app.ts
+++ b/src/autorest/app.ts
@@ -24,6 +24,7 @@ function compileStyledText(text: string): string {
   let result = "";
   let consumedUpTo = 0;
   const appendPart = (end: number) => {
+    const CHALK = chalk;
     result += eval(styleStack[styleStack.length - 1])(text.slice(consumedUpTo, end));
     consumedUpTo = end;
   };
@@ -42,7 +43,7 @@ function compileStyledText(text: string): string {
     consumedUpTo += length;
     switch (command[0]) {
       case "PUSH":
-        styleStack.push(command[1]);
+        styleStack.push("CHALK." + command[1]);
         break;
       case "POP":
         styleStack.pop();
@@ -54,20 +55,20 @@ function compileStyledText(text: string): string {
 }
 function color(text: string): string {
   return compileStyledText(text.
-    replace(/\*\*(.*?)\*\*/gm, addStyle("chalk.bold", `$1`)).
-    replace(/^# (.*)/gm, addStyle("chalk.green.bold", '$1')).
-    replace(/^## (.*)/gm, addStyle("chalk.green", '$1')).
-    replace(/^### (.*)/gm, addStyle("chalk.cyan.bold", '$1')).
-    replace(/(https?:\/\/\S*)/gm, addStyle("chalk.blue.bold.underline", '$1')).
-    replace(/__(.*)__/gm, addStyle("chalk.italic", '$1')).
-    replace(/^>(.*)/gm, addStyle("chalk.cyan", '  $1')).
-    replace(/^!(.*)/gm, addStyle("chalk.red.bold", '  $1')).
-    replace(/^(ERROR) (.*?):(.*)/gm, `\n${addStyle("chalk.red.bold", '$1')} ${addStyle("chalk.green", '$2')}:$3`).
-    replace(/^(WARNING) (.*?):(.*)/gm, `\n${addStyle("chalk.yellow.bold", '$1')} ${addStyle("chalk.green", '$2')}:$3`).
-    replace(/^(\s* - \w*:\/\/\S*):(\d*):(\d*) (.*)/gm, `${addStyle("chalk.cyan", '$1')}:${addStyle("chalk.cyan.bold", '$2')}:${addStyle("chalk.cyan.bold", '$3')} $4`).
-    replace(/`(.+?)`/gm, addStyle("chalk.gray", '$1')).
-    replace(/"(.*?)"/gm, addStyle("chalk.gray", '"$1"')).
-    replace(/'(.*?)'/gm, addStyle("chalk.gray", "'$1'")));
+    replace(/\*\*(.*?)\*\*/gm, addStyle("bold", `$1`)).
+    replace(/^# (.*)/gm, addStyle("greenBright", '$1')).
+    replace(/^## (.*)/gm, addStyle("green", '$1')).
+    replace(/^### (.*)/gm, addStyle("cyanBright", '$1')).
+    replace(/(https?:\/\/\S*)/gm, addStyle("blue.bold.underline", '$1')).
+    replace(/__(.*)__/gm, addStyle("italic", '$1')).
+    replace(/^>(.*)/gm, addStyle("cyan", '  $1')).
+    replace(/^!(.*)/gm, addStyle("red.bold", '  $1')).
+    replace(/^(ERROR) (.*?):(.*)/gm, `\n${addStyle("red.bold", '$1')} ${addStyle("green", '$2')}:$3`).
+    replace(/^(WARNING) (.*?):(.*)/gm, `\n${addStyle("yellow.bold", '$1')} ${addStyle("green", '$2')}:$3`).
+    replace(/^(\s* - \w*:\/\/\S*):(\d*):(\d*) (.*)/gm, `${addStyle("cyan", '$1')}:${addStyle("cyan.bold", '$2')}:${addStyle("cyan.bold", '$3')} $4`).
+    replace(/`(.+?)`/gm, addStyle("gray", '$1')).
+    replace(/"(.*?)"/gm, addStyle("gray", '"$1"')).
+    replace(/'(.*?)'/gm, addStyle("gray", "'$1'")));
 }
 
 (<any>global).color = color;


### PR DESCRIPTION
nested styles were rendered incorrectly, e.g.
```
`asd "qwe" rty`
```
would be rendered as if it was
```
`asd "qwe"` rty
```
for the simple reason that the ANSI codes injected by `color` are not stack-like, i.e. the "end of `"`-style" ANSI code will actually reset the color to whatever it was before the backtick style started.

I've changed the function to first inject PUSH/POP style instructions into the text and then in the very end compile that into a *flat* sequence of styled text segments.