### PR TITLE
wat

### DIFF
--- a/.gulp/gulpfile.iced
+++ b/.gulp/gulpfile.iced
@@ -23,9 +23,7 @@ Import
     source ["src/autorest-core", "src/autorest" ]
 
   npminstalls: ()->
-    source ["src/autorest-core", 
-      "src/autorest"
-    ]
+    source ["src/autorest-core", "src/autorest" ]
 
   typescriptProjects: () -> 
     typescriptProjectFolders()

--- a/Samples/3b-custom-transformations/Client/code-model-v1.yaml
+++ b/Samples/3b-custom-transformations/Client/code-model-v1.yaml
@@ -8,6 +8,10 @@ enumTypes:
   - $ref: '41'
   - $ref: '48'
   - $ref: '99'
+extensions:
+  security:
+    - azure_auth:
+        - user_impersonation
 modelTypes:
   - $id: '1'
     $type: CompositeType

--- a/Samples/3b-custom-transformations/generated/configuration.yaml
+++ b/Samples/3b-custom-transformations/generated/configuration.yaml
@@ -259,6 +259,11 @@ pipeline:
     suffixes:
       - ''
 require: []
+scope-cm-yaml/emitter:
+  input-artifact: code-model-v1-yaml
+  is-object: true
+  output-uri-expr: |
+    "code-model-v1-yaml"
 scope-cm/emitter:
   input-artifact: code-model-v1
   is-object: true
@@ -306,13 +311,13 @@ skip-upgrade-check: {}
 use: []
 use-extension:
   '@microsoft.azure/autorest.csharp': ~2.2.0
-  '@microsoft.azure/autorest.modeler': 2.3.31
+  '@microsoft.azure/autorest.modeler': 2.3.38
   '@microsoft.azure/classic-openapi-validator': ~1.0.3
   '@microsoft.azure/openapi-validator': ~1.0.0
 used-extension:
   - '["@microsoft.azure/autorest.csharp","~2.2.0"]'
   - '["@microsoft.azure/classic-openapi-validator","~1.0.3"]'
   - '["@microsoft.azure/openapi-validator","~1.0.0"]'
-  - '["@microsoft.azure/autorest.modeler","2.3.31"]'
+  - '["@microsoft.azure/autorest.modeler","2.3.38"]'
 verbose: false
 

--- a/src/autorest/app.ts
+++ b/src/autorest/app.ts
@@ -140,44 +140,21 @@ async function showInstalledExtensions(): Promise<number> {
 
 /** Main Entrypoint for AutoRest Bootstrapper */
 async function main() {
-
-  if (args.json) {
-    process.argv.push("--message-format=json");
-  }
-
-  // did they ask for what is available?
-  if (listAvailable) {
-    process.exit(await showAvailableCores());
-  }
-
-  // show what we have.
-  if (args.info) {
-    process.exit(await showInstalledExtensions());
-  }
-
-  // check to see if local installed core is available.
-  const localVersion = resolvePathForLocalVersion(args.version && args.version !== '' ? requestedVersion : null);
-
-  // try to use a specified folder or one in node_modules if it is there.
-  if (await tryRequire(localVersion, "app.js")) {
-    return;
-  }
-
-  // if the resolved local version is actually a file, we'll try that as a package when we get there.
-  if (await isFile(localVersion)) {
-    // this should try to install the file.
-    if (args.debug) {
-      console.log(`Found local core package file: '${localVersion}'`);
-    }
-    requestedVersion = localVersion;
-  }
-
-  // failing that, we'll continue on and see if NPM can do something with the version.
-  if (args.debug) {
-    console.log(`Network Enabled: ${await networkEnabled}`);
-  }
-
   try {
+    if (args.json) {
+      process.argv.push("--message-format=json");
+    }
+
+    // did they ask for what is available?
+    if (listAvailable) {
+      process.exit(await showAvailableCores());
+    }
+
+    // show what we have.
+    if (args.info) {
+      process.exit(await showInstalledExtensions());
+    }
+
     /* make sure we have a .autorest folder */
     await ensureAutorestHome();
 
@@ -193,9 +170,30 @@ async function main() {
       }
     }
 
+    // check to see if local installed core is available.
+    const localVersion = resolvePathForLocalVersion(args.version && args.version !== '' ? requestedVersion : null);
+
+    // try to use a specified folder or one in node_modules if it is there.
+    if (await tryRequire(localVersion, "app.js")) {
+      return;
+    }
+
+    // if the resolved local version is actually a file, we'll try that as a package when we get there.
+    if (await isFile(localVersion)) {
+      // this should try to install the file.
+      if (args.debug) {
+        console.log(`Found local core package file: '${localVersion}'`);
+      }
+      requestedVersion = localVersion;
+    }
+
+    // failing that, we'll continue on and see if NPM can do something with the version.
+    if (args.debug) {
+      console.log(`Network Enabled: ${await networkEnabled}`);
+    }
+
     // wait for the bootstrapper check to finish.
     await checkBootstrapper;
-
 
     // logic to resolve and optionally install a autorest core package.
     // will throw if it's not doable.


### PR DESCRIPTION
@fearthecowboy what's the idea of this?

This happens before things like `--reset` and effectively prevents 
```
node #{basefolder}/src/autorest/dist/app.js --reset --no-upgrade-check --allow-no-input --version=#{basefolder}/src/autorest-core --verbose --debug
                                            ^^^^^^^                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```
(in `regeneration.iced`) from doing anything right now!