### PR TITLE
Moving base-image of Dockerfile to use ubuntu:xenial

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:trusty
+FROM ubuntu:xenial 
 
 LABEL maintainer="fearthecowboy" 
 
 # Required for install
-RUN apt-get update && apt-get install -y curl libunwind8 libicu52
+RUN apt-get update && apt-get install -y curl libunwind8
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM ubuntu:17.04
+FROM ubuntu:trusty
 
 LABEL maintainer="fearthecowboy" 
 
 # Required for install
-RUN apt-get update && apt-get install -y curl libunwind8 libicu57
+RUN apt-get update && apt-get install -y curl libunwind8 libicu52
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \


### PR DESCRIPTION
This also required picking a compatible version of `libicu`
https://packages.ubuntu.com/trusty/libicu52