### PR TITLE
Reintroducing modelAsExtensible for syntax validator

### DIFF
--- a/schema/swagger-extensions.json
+++ b/schema/swagger-extensions.json
@@ -1587,6 +1587,10 @@
           "type": "boolean",
           "default": false
         },
+        "modelAsExtensible": {
+          "type": "boolean",
+          "default": false
+        },
         "values": {
           "type": "array",
           "items": {


### PR DESCRIPTION
This is to mitigate the CI issues [here](https://github.com/Azure/azure-rest-api-specs/pull/2630)