### PR TITLE
Couldn't find a valid ICU package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:xenial
 LABEL maintainer="fearthecowboy" 
 
 # Required for install
-RUN apt-get update && apt-get install -y curl libunwind8
+RUN apt-get update && apt-get install -y curl libunwind8 libicu55
 
 # NodeJS
 RUN curl -sL https://deb.nodesource.com/setup_7.x | bash - && \


### PR DESCRIPTION
When running autorest via docker like:
```sh
docker run --rm -it -v $PWD:/src -w /src azuresdk/autorest:latest -i swagger.json -o prima-client -n RestClient
```
It did complain:
```
FailFast: Couldn't find a valid ICU package installed on the system. Set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support.
```
After adding `libicu55` it seems to work again.