### PR TITLE
Make autorest.python 3.x the new default

### DIFF
--- a/src/autorest-core/resources/default-configuration.md
+++ b/src/autorest-core/resources/default-configuration.md
@@ -100,7 +100,7 @@ try-require: ./readme.python.md
 
 ``` yaml $(python) 
 use-extension:
-  "@microsoft.azure/autorest.python": "~2.1.26"
+  "@microsoft.azure/autorest.python": "~3.0.52"
 try-require: ./readme.python.md
 ```
 


### PR DESCRIPTION
@fearthecowboy is this the good file to change default behavior of `--python`?