### PR TITLE
Update literate-configuration.md

### DIFF
--- a/docs/proposals/generator-specific-settings/literate-configuration.md
+++ b/docs/proposals/generator-specific-settings/literate-configuration.md
@@ -421,7 +421,7 @@ Then, once you've installed AutoRest, you can use any arbitrary version by just 
 |disable-simplifier| `disable-simplfier:true` | Disables c# post-codegeneration simplifier|
 |internal-constructors| `internal-constructors: true` | Indicates whether ctor needs to be generated with internal protection level. |
 |sync-methods| `sync-methods: true `| Specifies mode for generating sync wrappers. |
-|use-date-time-offset| `use-date-time-offset: true` | Indicates whether to use DateTimeOffset instead of DateTime to model date-time types |
+|use-datetimeoffset| `use-datetimeoffset: true` | Indicates whether to use DateTimeOffset instead of DateTime to model date-time types |
 
 #### NodeJS Settings:
 |Setting|Example|Purpose|


### PR DESCRIPTION
use-datetimeoffset is not correct and doesn't work. New variant is using in autorest command line