### PR TITLE
Powershell config: folder update

### DIFF
--- a/src/autorest-core/resources/plugin-powershell.md
+++ b/src/autorest-core/resources/plugin-powershell.md
@@ -2,17 +2,24 @@
 
 The beta version of the PowerShell Generator.
 
-Note: if the --powershell is mentioned, but they are using autorest.powershell, don't try to load the autorest.powershell from npm.
+``` yaml $(powershell)
 
-``` yaml $(powershell) && ( "$(requesting-extensions)".indexOf('autorest.powershell') === -1 ) 
 # requires multi-api merger
 enable-multi-api: true
+api-folder: generated/api
+runtime-folder: generated/runtime
+
+# probe from readme.powershell.md file 
+try-require: ./readme.powershell.md
+
+```
+
+Note: if the --powershell is mentioned, but they are using autorest.incubator, don't try to load the autorest.powershell from npm.
+
+``` yaml $(powershell) && ( "$(requesting-extensions)".indexOf('autorest.powershell') === -1 )
 
 # load the extension 
 use-extension:
   "@microsoft.azure/autorest.powershell": "beta"
-
-# probe from readme.powershell.md file 
-try-require: ./readme.powershell.md
 
 ```


### PR DESCRIPTION
This is for: https://github.com/Azure/autorest.powershell/pull/48

- Adds api-folder and runtime-folder for use with the cshaper generator when ran when the powershell generator is loaded
- Only uses the autorest.powershell online version when the local version is not present