### PR TITLE
Fixed bug: tree-shaking collision for things that had dash characters…

### DIFF
--- a/src/autorest-core/lib/pipeline/plugins/tree-shaker.ts
+++ b/src/autorest-core/lib/pipeline/plugins/tree-shaker.ts
@@ -441,7 +441,8 @@ export class OAI3Shaker extends Transformer<AnyObject, AnyObject> {
         nameHint = undefined;
       }
     }
-    const id = nameHint || `${parseJsonPointer(pointer).map(each => `${each}`.toLowerCase().replace(/\W+/g, '-').split('-').filter(each => each).join('-')).filter(each => each).join('·')}`.replace(/\·+/g, '·');
+
+    const id = nameHint || `${parseJsonPointer(pointer).map(each => `${each}`.toLowerCase().replace(/-+/g, '_').replace(/\W+/g, '-').split('-').filter(each => each).join('-')).filter(each => each).join('·')}`.replace(/\·+/g, '·');
 
     // set the current location's object to be a $ref
     targetParent[key] = {


### PR DESCRIPTION
… as part of their original json-path.

Fixes: https://github.com/Azure/autorest.powershell/issues/176

- https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-number.json
- https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/url.json
- https://raw.githubusercontent.com/Azure/autorest.testserver/master/swagger/body-number.quirks.json