### PR TITLE
typos in docs

### DIFF
--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -570,7 +570,7 @@ parameters | [Array of Parameter Objects](https://github.com/OAI/OpenAPI-Specifi
     }
 ```
 - Using explicit parameters and specifying the positionInOperation and schemePrefix.
-   - This means that accountName will be the first required parameter in all the methods and the user is expected to provide a url (protocol + accountName), since "useSchemePrfix" is set to false.
+   - This means that accountName will be the first required parameter in all the methods and the user is expected to provide a url (protocol + accountName), since "useSchemePrefix" is set to false.
 ```json5
 "x-ms-parameterized-host": {
     "hostTemplate": "{accountName}.mystaticsuffix.com",

--- a/docs/how-autorest-generates-code-from-swagger.md
+++ b/docs/how-autorest-generates-code-from-swagger.md
@@ -74,7 +74,7 @@ To represent `byte` arrays in the generated code, the property of the OpenAPI de
 AutoRest generates `DateTime` typed properties in generated C# code for OpenAPI properties that have `string` as the type and `date-time` as the format. Note: it's possible to generate these properties as `DateTimeOffset` in C# when `-useDateTimeOffset` parameter is passed via command line. 
 
 - **`int` / `long`**
-Both `int` and `long` proeprties in the generated code correspond to `integer` types in OpenAPI properties. If the format of the OpenAPI property is `int32`, `int` will be generated; if the format is `int64`, `long` will be generated. If the format field of the OpenAPI property is not set, AutoRest use  format `int32`.
+Both `int` and `long` properties in the generated code correspond to `integer` types in OpenAPI properties. If the format of the OpenAPI property is `int32`, `int` will be generated; if the format is `int64`, `long` will be generated. If the format field of the OpenAPI property is not set, AutoRest use  format `int32`.
 
 **Example:**
 ```json
@@ -625,7 +625,7 @@ public async Task<HttpOperationResponse<Product>> ListWithOperationResponseAsync
 
 > Note that parameters that have field `in` as path are always required and the `required` field will be ignored.
 
-Properties in OpenAPI Schema do not contain a required field. Instead, Each definition schema can provide a `'required'` array that specifies which proeprties are required. An example is shown below.
+Properties in OpenAPI Schema do not contain a required field. Instead, Each definition schema can provide a `'required'` array that specifies which properties are required. An example is shown below.
 ```json
 "Product": {
   "required": [

--- a/docs/how-autorest-generates-code-from-swagger.md
+++ b/docs/how-autorest-generates-code-from-swagger.md
@@ -167,7 +167,7 @@ public partial class Pet
 ```
 
 ### Dictionaries
-AutoRest generates dictionaries (or hash maps in some contexts) using `additionalProperites` from [JSON-Schema Draft 4][JSON-schema-validation-properties]. The additionalProperties element should specify the OpenAPI schema of the values in the dictionary . The keys of the generated dictionary will be of type `string`.
+AutoRest generates dictionaries (or hash maps in some contexts) using `additionalProperties` from [JSON-Schema Draft 4][JSON-schema-validation-properties]. The additionalProperties element should specify the OpenAPI schema of the values in the dictionary . The keys of the generated dictionary will be of type `string`.
 
 There are two basic patterns when generating dictionaries in AutoRest. 
 

--- a/docs/how-autorest-generates-code-from-swagger.md
+++ b/docs/how-autorest-generates-code-from-swagger.md
@@ -535,7 +535,7 @@ The following example will generate a type `PetStyle`.
 ```
 
 - **Schemas in sequences and dictionaries**
-*A schema defined in the 'items' proeprty of a sequence or the 'additionalProperties' value of a dictionary.* Model types corresponding to Items of a sequence are named using the parent class's name concatenated with "Item". Model types corresponding to the 'additinalPropeties' value of a dictionary are named using the parent class's name concatenated with "Value".
+*A schema defined in the 'items' property of a sequence or the 'additionalProperties' value of a dictionary.* Model types corresponding to Items of a sequence are named using the parent class's name concatenated with "Item". Model types corresponding to the 'additinalPropeties' value of a dictionary are named using the parent class's name concatenated with "Value".
 The following example will generate types `PetFavFoodItem` and `PetFavFoodBrandValue`.
 ```json
 "Pet": {

--- a/docs/how-autorest-generates-code-from-swagger.md
+++ b/docs/how-autorest-generates-code-from-swagger.md
@@ -535,7 +535,7 @@ The following example will generate a type `PetStyle`.
 ```
 
 - **Schemas in sequences and dictionaries**
-*A schema defined in the 'items' property of a sequence or the 'additionalProperties' value of a dictionary.* Model types corresponding to Items of a sequence are named using the parent class's name concatenated with "Item". Model types corresponding to the 'additinalPropeties' value of a dictionary are named using the parent class's name concatenated with "Value".
+*A schema defined in the 'items' property of a sequence or the 'additionalProperties' value of a dictionary.* Model types corresponding to Items of a sequence are named using the parent class's name concatenated with "Item". Model types corresponding to the 'additionalProperties' value of a dictionary are named using the parent class's name concatenated with "Value".
 The following example will generate types `PetFavFoodItem` and `PetFavFoodBrandValue`.
 ```json
 "Pet": {

--- a/docs/powershell/default-directory-layout.md
+++ b/docs/powershell/default-directory-layout.md
@@ -48,7 +48,7 @@ Contains customized cmdlets.
 
 ### /docs
 
-Contains miscellanous documents from the code. For example, cmdlet documentation, code generation instructions, breaking-changes, etc.
+Contains miscellaneous documents from the code. For example, cmdlet documentation, code generation instructions, breaking-changes, etc.
 
 ### /exports
 

--- a/docs/powershell/default-directory-layout.md
+++ b/docs/powershell/default-directory-layout.md
@@ -14,7 +14,7 @@ By default, AutoRest's PowerShell Generator will place all the generated files u
   - /runtime
 - [/obj](#obj)
 - [/test](#test)
-- [/node-modules](#node-modules) (comming soon)
+- [/node-modules](#node-modules) (coming soon)
 - [.gitignore](#gitignore) 
 - [\<format-file>.format.ps1xml](#format-fileformatps1xml)
 - [\<cs-project-file>.csproj](#cs-project-filecsproj)
@@ -22,12 +22,12 @@ By default, AutoRest's PowerShell Generator will place all the generated files u
 - [\<module-file>.psm1](#module-filepsm1)
 - [build-module.ps1](#build-moduleps1)
 - [generate-help.ps1](#generate-helpps1)
-- how-to<span></span>.md (#how-tpmd) (comming soon)
+- how-to<span></span>.md (#how-tpmd) (coming soon)
 - [license.txt](#licensetxt)
 - [pack-module.ps1](#pack-moduleps1) 
 - [readme.md](#readmemd)
 - [test-module.ps1](#test-moduleps1)
-- [regen-module.ps1](#regen-moduleps1) (comming soon)
+- [regen-module.ps1](#regen-moduleps1) (coming soon)
 - [types.ps1xml](#typesps1xml) (coming soon)
 - [dll-help.ps1xml](#dll-helpps1xml) (coming soon)
 

--- a/docs/powershell/readme.md
+++ b/docs/powershell/readme.md
@@ -69,7 +69,7 @@ The output will be in the `./generated` folder by default
 - [Samples](./samples/readme.md) demonstrate some example usage for generating cmdlets. 
 - [Options](./options.md) details about some of the configuration options for manipulating the cmdlet generation process.
 - [Release Notes](./release-notes.md) information about the current build.
-- [Fileing Bugs](https://githunb.com/azure/autorest) make sure that you tag it with the 'powershell' label.
+- [Filing Bugs](https://githunb.com/azure/autorest) make sure that you tag it with the 'powershell' label.
 - [Command-line-interface](../user/command-line-interface.md) - about the autorest command line
 - [Configuration Files](../user/configuration.md)
 - **Coming Soon**: [Debugging](./debugging-modules.md) modules with VSCode made easy.

--- a/docs/user/configuration.md
+++ b/docs/user/configuration.md
@@ -65,7 +65,7 @@ AutoRest identifies a markdown file as a literate configuration file when it con
 ~~~ markdown
 # My API 
 
-This file contains the configuratuion for generating My API from the OpenAPI specification.
+This file contains the configuration for generating My API from the OpenAPI specification.
 
 > see https://aka.ms/autorest
 

--- a/docs/user/literate-file-formats/configuration.md
+++ b/docs/user/literate-file-formats/configuration.md
@@ -197,7 +197,7 @@ input-file:
   - ./2015-01-02/foo.json   # referenced documents can be JSON, YAML or Markdown.
   - ./2016-02-03/bar.md
 ```
-Once a file is loaded, it can beereferred to in configuration by it's file name or instead by it's OpenAPI `title` value. (You can think of this as the `namespace` for the OpenAPI document)
+Once a file is loaded, it can be referred to in configuration by it's file name or instead by it's OpenAPI `title` value. (You can think of this as the `namespace` for the OpenAPI document)
 
 ## Configuration sections
 

--- a/src/autorest-core/lib/autorest-core.ts
+++ b/src/autorest-core/lib/autorest-core.ts
@@ -172,7 +172,7 @@ export class AutoRest extends EventEmitter {
 export async function IdentifyDocument(content: string): Promise<DocumentType> {
   if (content) {
 
-    // check for configuratuion 
+    // check for configuration 
     if (await IsConfigurationDocument(content)) {
       return DocumentType.LiterateConfiguration;
     }


### PR DESCRIPTION
Batched these together, but I can split it out to separate PRs if preferred