### PR TITLE
profile-filter-log and --exclude-file 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -29,10 +29,10 @@
         "--version=${workspaceRoot}/src/autorest-core",
         "--verbose",
         "--debug",
-        "--output-artifact=specs-used",
+        "--output-artifact=profile-filter-log",
         "--interactive"
       ],
-      "cwd": "c:/work/2019/azure-powershell/src/network"
+      "cwd": "c:/work/2019/azure-powershell/src/compute"
     },
     {
       "type": "node",

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -29,6 +29,7 @@ export interface AutoRestConfigurationImpl {
   __info?: string | null;
   'allow-no-input'?: boolean;
   'input-file'?: Array<string> | string;
+  'exclude-file'?: Array<string> | string;
   'base-folder'?: string;
   'directive'?: Array<Directive> | Directive;
   'declare-directive'?: { [name: string]: string };
@@ -281,6 +282,7 @@ export class ConfigurationView {
     this.rawConfig = <any>{
       'directive': [],
       'input-file': [],
+      'exclude-file': [],
       'profile': [],
       'output-artifact': [],
       'require': [],
@@ -491,9 +493,14 @@ export class ConfigurationView {
   }
 
   public get InputFileUris(): Array<string> {
-    return From<string>(valuesOf<string>(this.config['input-file']))
+    const inputFiles = From<string>(valuesOf<string>(this.config['input-file']))
       .Select(each => this.ResolveAsPath(each))
       .ToArray();
+    const filesToExclude = From<string>(valuesOf<string>(this.config['exclude-file']))
+      .Select(each => this.ResolveAsPath(each))
+      .ToArray();
+
+    return inputFiles.filter(x => !filesToExclude.includes(x));
   }
 
   public get OutputFolderUri(): string {

--- a/src/autorest-core/lib/pipeline/plugins/deduplicator.ts
+++ b/src/autorest-core/lib/pipeline/plugins/deduplicator.ts
@@ -12,7 +12,7 @@ import { Dictionary, values, keys, items } from '@microsoft.azure/linq';
 async function deduplicate(config: ConfigurationView, input: DataSource, sink: DataSink) {
   const inputs = await Promise.all((await input.Enum()).map(async x => input.ReadStrict(x)));
   const result: Array<DataHandle> = [];
-  for (const each of values(inputs).linq.where(input => input.artifactType !== 'specs-used')) {
+  for (const each of values(inputs).linq.where(input => input.artifactType !== 'profile-filter-log')) {
     const deduplicator = new Deduplicator(await each.ReadObject());
 
     result.push(await sink.WriteObject('model-deduplicated-oai3-doc', deduplicator.output, each.identity, 'deduplicated-oai3', [/* fix-me: Construct source map from the mappings returned by the deduplicator.s*/]));

--- a/src/autorest-core/lib/pipeline/plugins/profile-filter.ts
+++ b/src/autorest-core/lib/pipeline/plugins/profile-filter.ts
@@ -412,9 +412,11 @@ async function filter(config: ConfigurationView, input: DataSource, sink: DataSi
 
       const processor = new ProfileFilter(each, allProfileDefinitions, profilesRequested, apiVersions);
       const output = await processor.getOutput();
-      const specsUsed = [...getLatestFiles(visit(output))];
-      if ((Array.isArray(config.GetEntry('output-artifact')) && config.GetEntry('output-artifact').includes('specs-used')) || config.GetEntry('output-artifact') === 'specs-used') {
-        result.push(await sink.WriteData('specs-used.yaml', serialize({ count: specsUsed.length, specsUsed }), [], 'specs-used'));
+      const specsReferencedBeforeFiltering = getFilesUsed(visit(await each.ReadObject<AnyObject>()));
+      const specsReferencedAfterFiltering = getFilesUsed(visit(output));
+      const specsNotUsed = [...specsReferencedBeforeFiltering].filter(x => !specsReferencedAfterFiltering.has(x));
+      if ((Array.isArray(config.GetEntry('output-artifact')) && config.GetEntry('output-artifact').includes('profile-filter-log')) || config.GetEntry('output-artifact') === 'profile-filter-log') {
+        result.push(await sink.WriteData('profile-filter-log.yaml', serialize({ 'file-used': [...specsReferencedAfterFiltering], 'files-not-used': [...specsNotUsed] }), [], 'profile-filter-log'));
       }
 
       result.push(await sink.WriteObject('profile-filtered-oai-doc...', output, each.identity, 'profile-filtered-oai3', await processor.getSourceMappings()));
@@ -426,7 +428,7 @@ async function filter(config: ConfigurationView, input: DataSource, sink: DataSi
   return new QuickDataSource(result, input.skip);
 }
 
-function getLatestFiles(nodes: Iterable<Node>) {
+function getFilesUsed(nodes: Iterable<Node>) {
   const filesUsed = new Set<string>();
   for (const field of nodes) {
     switch (field.key) {

--- a/src/autorest-core/lib/pipeline/plugins/profile-filter.ts
+++ b/src/autorest-core/lib/pipeline/plugins/profile-filter.ts
@@ -416,7 +416,7 @@ async function filter(config: ConfigurationView, input: DataSource, sink: DataSi
       const specsReferencedAfterFiltering = getFilesUsed(visit(output));
       const specsNotUsed = [...specsReferencedBeforeFiltering].filter(x => !specsReferencedAfterFiltering.has(x));
       if ((Array.isArray(config.GetEntry('output-artifact')) && config.GetEntry('output-artifact').includes('profile-filter-log')) || config.GetEntry('output-artifact') === 'profile-filter-log') {
-        result.push(await sink.WriteData('profile-filter-log.yaml', serialize({ 'file-used': [...specsReferencedAfterFiltering], 'files-not-used': [...specsNotUsed] }), [], 'profile-filter-log'));
+        result.push(await sink.WriteData('profile-filter-log.yaml', serialize({ 'files-used': [...specsReferencedAfterFiltering], 'files-not-used': [...specsNotUsed] }), [], 'profile-filter-log'));
       }
 
       result.push(await sink.WriteObject('profile-filtered-oai-doc...', output, each.identity, 'profile-filtered-oai3', await processor.getSourceMappings()));

--- a/src/autorest-core/resources/pipeline-merger.md
+++ b/src/autorest-core/resources/pipeline-merger.md
@@ -35,7 +35,7 @@ pipeline:
 
   openapi-document/emitter:
     input: profile-filter
-    input-artifact: specs-used 
+    input-artifact: profile-filter-log 
 ```
 
 ``` yaml $(enable-multi-api)


### PR DESCRIPTION
- --output-artifact=profile-filter-log outputs a files with files-used and files-not-used
- using --exclude-file= \<file\>  or exclude-file from configuration will filter files from the input-file list 
Fixes: https://github.com/Azure/autorest.powershell/issues/375