### PR TITLE
Updates to new-composer, tree-shaker and merger.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -27,14 +27,16 @@
       "program": "${workspaceRoot}/src/autorest/dist/app.js",
       "args": [
         "--version=${workspaceRoot}/src/autorest-core",        
-        "--use=c:/work/2019/autorest.csharp",
+        "--use=c:/work/2019/autorest.modeler",
         "--verbose",
         "--debug",
         "--output-folder=./new",
         "--csharp",
+        "--modeler.debugger",
         "--interactive",
+        "--simple-tree-shake"
       ],
-      "cwd": "C:/work/2019/test-generator/tmp/azure-rest-api-specs/specification/addons/resource-manager"
+      "cwd": "C:/work/2019/test-generator/tmp/azure-rest-api-specs/specification/appconfiguration/resource-manager"
     },
     {
       "type": "node",

--- a/src/autorest-core/lib/configuration.ts
+++ b/src/autorest-core/lib/configuration.ts
@@ -65,6 +65,7 @@ export interface AutoRestConfigurationImpl {
   'payload-flattening-threshold'?: number;
   'openapi-type'?: string; // the specification type (ARM/Data-Plane/Default)
   'tag'?: string;
+  'simple-tree-shake'?: boolean;
 
   // multi-api specific
   'profiles'?: any;

--- a/src/autorest-core/test/shaker.ts
+++ b/src/autorest-core/test/shaker.ts
@@ -45,7 +45,7 @@ const resources = `${__dirname}../../../test/resources/shaker`;
     if (inputDataHandle && outputDataHandle) {
       // if (inputDataHandle) {
       const outputObject = await outputDataHandle.ReadObject();
-      const shaker = new OAI3Shaker(inputDataHandle);
+      const shaker = new OAI3Shaker(inputDataHandle, false);
 
       // testing: dump out the converted file
       // console.log(FastStringify(shaken));


### PR DESCRIPTION
- simple-tree-shake flag
  - inlines strings (non-enum) and arrays
- skip shaking of enum that are equivalent to constants. I.e. enums with a single value and required.
- some extensions were lost in the merge. Fixed
- new-composer: when two schemas have the same name, now it clones the latest
