### PR TITLE
don't load v2 generators when v3 is being loaded from the cmdline. 

### DIFF
--- a/core/lib/parsing/literate-yaml.ts
+++ b/core/lib/parsing/literate-yaml.ts
@@ -10,6 +10,7 @@ import { OperationAbortedException } from '../exception';
 import { Channel, SourceLocation } from '../message';
 import { MergeYamls, resolveRValue } from '../source-map/merging';
 import { parse as ParseLiterate } from './literate';
+import { keys } from '@azure-tools/linq';
 
 export class CodeBlock {
   info!: string | null;
@@ -105,6 +106,17 @@ export function evaluateGuard(rawFenceGuard: string, contextObject: any): boolea
       // console.log(JSON.stringify(contextObject['used-extension']));
       // console.log(contextObject['used-extension'] && !!(contextObject['used-extension'].find(each => each.startsWith(`["${name}"`))));
       return contextObject['used-extension'] && !!(contextObject['used-extension'].find(each => each.startsWith(`["${name}"`)));
+    },
+
+    /** allows a check to see if a given extension is being requested already */
+    isRequested: (name: string) => {
+      return contextObject['use-extension'] && keys(contextObject['use-extension']).any(each => each === name);
+    },
+
+    /** prints a debug message from configuration. sssshhh. don't use this.  */
+    debugMessage: (text: string) => {
+      console.log(text);
+      return true;
     }
   };
 

--- a/core/lib/parsing/literate-yaml.ts
+++ b/core/lib/parsing/literate-yaml.ts
@@ -10,7 +10,8 @@ import { OperationAbortedException } from '../exception';
 import { Channel, SourceLocation } from '../message';
 import { MergeYamls, resolveRValue } from '../source-map/merging';
 import { parse as ParseLiterate } from './literate';
-import { keys } from '@azure-tools/linq';
+import { keys, length } from '@azure-tools/linq';
+import { typeOf } from '@azure-tools/openapi';
 
 export class CodeBlock {
   info!: string | null;
@@ -111,6 +112,11 @@ export function evaluateGuard(rawFenceGuard: string, contextObject: any): boolea
     /** allows a check to see if a given extension is being requested already */
     isRequested: (name: string) => {
       return contextObject['use-extension'] && keys(contextObject['use-extension']).any(each => each === name);
+    },
+
+    /** if they are specifying one or more profiles or api-versions, then they are   */
+    enableAllVersionsMode: () => {
+      return length(contextObject['profile']) > 0 || length(contextObject['api-version']) > 0
     },
 
     /** prints a debug message from configuration. sssshhh. don't use this.  */

--- a/core/resources/default-configuration.md
+++ b/core/resources/default-configuration.md
@@ -44,9 +44,9 @@ If we don't specify `--help`, we will trigger the setting to load files
 perform-load: true # kick off loading
 ```
 
-
-``` yaml $(pipeline-model) == 'v3'
-# when an autorest-v3 generator is loading, we need to force the tag: all-api-versions so that it loads the whole api set.
+``` yaml enableAllVersionsMode()
+# when an autorest-v3 generator is loading, and a profile or api-verison is specified, 
+# we need to force the tag: all-api-versions so that it loads the whole api set.
 # but not TOO high, as then it'll be evaluated before $(pipeline-model)
 tag: all-api-versions
 load-priority: 500

--- a/core/resources/plugin-csharp.md
+++ b/core/resources/plugin-csharp.md
@@ -2,26 +2,26 @@
 
 The V2 version of the C# Generator.
 
-``` yaml $(csharp) && $(preview)
+``` yaml $(csharp) && $(preview) && !isRequested('@autorest/csharp')
 use-extension:
   "@microsoft.azure/autorest.csharp": "preview"
 try-require: ./readme.csharp.md
 ```
 
-``` yaml $(csharp) && $(pipeline-model) !== 'v3'
+``` yaml $(csharp) && !isRequested('@autorest/csharp')
 use-extension:
   "@microsoft.azure/autorest.csharp": "~2.3.79"
 try-require: ./readme.csharp.md
 ```
 
-``` yaml $(jsonrpcclient)
+``` yaml $(jsonrpcclient) && !isRequested('@autorest/csharp')
 use-extension:
   "@microsoft.azure/autorest.csharp": "~2.3.79"
 ```
 
 ##### Input API versions (azure-rest-api-specs + C# specific)
 
-``` yaml $(csharp)
+``` yaml $(csharp) && !isRequested('@autorest/csharp')
 pipeline:
   swagger-document/reflect-api-versions-cs: # emits a *.cs file containing information about the API versions involved in this call
     input:
@@ -34,7 +34,7 @@ pipeline:
     scope: scope-reflect-api-versions-cs-emitter
 ```
 
-``` yaml $(csharp)
+``` yaml $(csharp) && !isRequested('@autorest/csharp')
 pipeline:
   openapi-document/reflect-api-versions-cs: # emits a *.cs file containing information about the API versions involved in this call
     input:

--- a/core/resources/plugin-go.md
+++ b/core/resources/plugin-go.md
@@ -2,13 +2,13 @@
 
 The V2 version of the Go Generator.
 
-``` yaml $(go) && $(preview)
+``` yaml $(go) && $(preview) && !isRequested('@autorest/go')
 use-extension:
   "@microsoft.azure/autorest.go": "preview"
 try-require: ./readme.go.md
 ```
 
-``` yaml $(go) && $(pipeline-model) !== 'v3'
+``` yaml $(go) && && !isRequested('@autorest/go')
 use-extension:
   "@microsoft.azure/autorest.go": "~2.1.47"
 try-require: ./readme.go.md

--- a/core/resources/plugin-java.md
+++ b/core/resources/plugin-java.md
@@ -2,13 +2,13 @@
 
 The V2 version of the Java Generator.
 
-``` yaml $(java) && $(preview) 
+``` yaml $(java) && $(preview) && !isRequested('@autorest/java')
 use-extension:
   "@microsoft.azure/autorest.java": "~2.1.88"
 try-require: ./readme.java.md
 ```
 
-``` yaml $(java) && $(pipeline-model) !== 'v3'
+``` yaml $(java) && !isRequested('@autorest/csharp')
 use-extension:
   "@microsoft.azure/autorest.java": "~2.1.88"
 try-require: ./readme.java.md

--- a/core/resources/plugin-nodejs.md
+++ b/core/resources/plugin-nodejs.md
@@ -3,13 +3,13 @@
 The V2 version of the NodeJS Generator.
 
 
-``` yaml $(nodejs) && $(preview)
+``` yaml $(nodejs) && $(preview) && !isRequested('@autorest/nodejs')
 use-extension:
   "@microsoft.azure/autorest.nodejs": "preview"
 try-require: ./readme.nodejs.md
 ```
 
-``` yaml $(nodejs) && $(pipeline-model) !== 'v3'
+``` yaml $(nodejs) && !isRequested('@autorest/nodejs')
 use-extension:
   "@microsoft.azure/autorest.nodejs": "~2.1.25"
 try-require: ./readme.nodejs.md

--- a/core/resources/plugin-python.md
+++ b/core/resources/plugin-python.md
@@ -10,7 +10,7 @@ use-extension:
 try-require: ./readme.python.md
 ```
 
-``` yaml $(v2-python)  && $(pipeline-model) !== 'v3'
+``` yaml $(v2-python) 
 use-extension:
   "@microsoft.azure/autorest.python": "~3.0.56"
 try-require: ./readme.python.md

--- a/core/resources/plugin-typescript.md
+++ b/core/resources/plugin-typescript.md
@@ -2,14 +2,15 @@
 
 The V2 version of the Typescript Generator.
 
-``` yaml $(typescript) && $(preview)
+``` yaml $(typescript) && $(preview) && !isRequested('@autorest/typescript')
 use-extension:
   "@microsoft.azure/autorest.typescript": "preview"
 try-require: ./readme.typescript.md
 ```
 
-``` yaml $(typescript) && $(pipeline-model) !== 'v3'
+``` yaml $(typescript) && !isRequested('@autorest/typescript')
 use-extension:
   "@microsoft.azure/autorest.typescript": "~4.2.0"
 try-require: ./readme.typescript.md
 ```
+


### PR DESCRIPTION
and allow loading other tags in v3 mode (by only enabling all-api-versions when `profile` or `api-version` is specified