### PR TITLE
Update @autorest/compare, add regression-compare.yaml configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -293,3 +293,6 @@ temp
 common/temp/**
 package-deps.json
 common/config/rush/shrinkwrap.yaml
+
+# Code generation output for regression tests
+core/test/regression

--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -1,0 +1,82 @@
+# This file describes the set of languages and specs that will have generated
+# output comparisons run to check for regressions in @autorest/core.
+
+debug: false
+specs:
+  - specRootPath: ../node_modules/@microsoft.azure/autorest.testserver/swagger
+    specPaths:
+     - additionalProperties.json
+     - azure-parameter-grouping.json
+     - azure-report.json
+     - azure-resource-x.json
+     - azure-resource.json
+     - azure-special-properties.json
+     - body-array.json
+     - body-boolean.json
+     - body-boolean.quirks.json
+     - body-byte.json
+     - body-complex.json
+     - body-date.json
+     - body-datetime-rfc1123.json
+     - body-datetime.json
+     - body-duration.json
+     - body-dictionary.json
+     - body-file.json
+     - body-formdata-urlencoded.json
+     - body-formdata.json
+     - body-integer.json
+     - body-number.json
+     - body-number.quirks.json
+     - body-string.json
+     - body-string.quirks.json
+     - complex-model.json
+     - custom-baseUrl.json
+     - custom-baseUrl-more-options.json
+     - custom-baseUrl-paging.json
+     - extensible-enums-swagger.json
+     - head-exceptions.json
+     - head.json
+     - header.json
+     - httpInfrastructure.json
+     - httpInfrastructure.quirks.json
+     - lro.json
+     - model-flattening.json
+     - paging.json
+     - parameter-flattening.json
+     - report.json
+     - required-optional.json
+     - storage.json
+     - subscriptionId-apiVersion.json
+     - url-multi-collectionFormat.json
+     - url.json
+     - validation.json
+     - xml-service.json
+     - xms-error-responses.json
+languages:
+  - language: typescript
+    excludeSpecs:
+      # The following specs currently crash the v3 TypeScript generator
+      - additionalProperties.json
+      - azure-parameter-grouping.json
+      - azure-special-properties.json
+      - body-array.json
+      - body-dictionary.json
+      - body-formdata-urlencoded.json
+      - body-formdata.json
+      - custom-baseUrl-paging.json
+      - header.json
+      - lro.json
+      - model-flattening.json
+      - paging.json
+      - required-optional.json
+    outputPath: ../core/test/regression/typescript
+    oldArgs:
+      - --v3
+      - --version:3.0.6200
+      - --package-name:test-package
+      - --use:@autorest/typescript@0.1.0-dev.20200203.1
+    newArgs:
+      - --v3
+      - --version:../core
+      - --package-name:test-package
+      - --use:@autorest/typescript@0.1.0-dev.20200203.1

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -24,66 +24,10 @@ steps:
 
   displayName: 'Rush install, build and test'
 
-- script : |
+- script: |
     npm install @microsoft.azure/autorest.testserver --no-save
-    npm install -g @autorest/compare
+    npm install -g @autorest/compare@~0.2.0
   displayName: Install autorest-compare
 
-- script : |
-    export AUTOREST_TYPESCRIPT=@autorest/typescript@0.1.0-dev.20200203.1
-    autorest-compare --typescript \
-                     --spec-path:azure-report.json \
-                     --spec-path:azure-resource-x.json \
-                     --spec-path:azure-resource.json \
-                     --spec-path:body-boolean.json \
-                     --spec-path:body-boolean.quirks.json \
-                     --spec-path:body-byte.json \
-                     --spec-path:body-complex.json \
-                     --spec-path:body-date.json \
-                     --spec-path:body-datetime-rfc1123.json \
-                     --spec-path:body-datetime.json \
-                     --spec-path:body-duration.json \
-                     --spec-path:body-file.json \
-                     --spec-path:body-integer.json \
-                     --spec-path:body-number.json \
-                     --spec-path:body-number.quirks.json \
-                     --spec-path:body-string.json \
-                     --spec-path:body-string.quirks.json \
-                     --spec-path:complex-model.json \
-                     --spec-path:custom-baseUrl-more-options.json \
-                     --spec-path:custom-baseUrl.json \
-                     --spec-path:extensible-enums-swagger.json \
-                     --spec-path:head-exceptions.json \
-                     --spec-path:head.json \
-                     --spec-path:httpInfrastructure.json \
-                     --spec-path:httpInfrastructure.quirks.json \
-                     --spec-path:parameter-flattening.json \
-                     --spec-path:report.json \
-                     --spec-path:storage.json \
-                     --spec-path:subscriptionId-apiVersion.json \
-                     --spec-path:url-multi-collectionFormat.json \
-                     --spec-path:url.json \
-                     --spec-path:validation.json \
-                     --spec-path:xml-service.json \
-                     --spec-path:xms-error-responses.json \
-                     --spec-root-path:./node_modules/@microsoft.azure/autorest.testserver/__files/ \
-                     --output-path:./core/test/generated/typescript/ \
-                     --compare-old --v3 --package-name:test-package --version:3.0.6200 --use:$AUTOREST_TYPESCRIPT \
-                     --compare-new --v3 --package-name:test-package --version:./core --use:$AUTOREST_TYPESCRIPT
-
-                     # Disabled due to errors in the TypeScript generator
-                     # --spec-path:additionalProperties.json \
-                     # --spec-path:azure-parameter-grouping.json \
-                     # --spec-path:azure-special-properties.json \
-                     # --spec-path:body-array.json \
-                     # --spec-path:body-dictionary.json \
-                     # --spec-path:body-formdata-urlencoded.json \
-                     # --spec-path:body-formdata.json \
-                     # --spec-path:custom-baseUrl-paging.json \
-                     # --spec-path:header.json \
-                     # --spec-path:lro.json \
-                     # --spec-path:model-flattening.json \
-                     # --spec-path:paging.json \
-                     # --spec-path:required-optional.json \
+- script: autorest-compare --compare:.scripts/regression-compare.yaml
   displayName: Regression Test - @autorest/typescript
-  continueOnError: true # Don't make this a hard fail just yet


### PR DESCRIPTION
This change updates `@autorest/compare` to 0.2.0 which adds the ability to use a configuration file (`.scripts/regression-compare.yaml`) to configure the set of languages and specs that are run in regression tests. This improves our ability to run regression comparisons both locally and on CI.