### PR TITLE
Improve backslash escaping when launching Core out of process

### DIFF
--- a/autorest/autorest-as-a-service.ts
+++ b/autorest/autorest-as-a-service.ts
@@ -163,7 +163,7 @@ export async function runCoreOutOfProc(localPath: string | null, entrypoint: str
         if (require('fs').existsSync('${__dirname}/static-loader.js')) { require('${__dirname}/static-loader.js').load('${__dirname}/static_modules.fs'); }
         const { color } = require('${__dirname}/coloring');
         require('${ep}')
-      `.replace(/"/g, '\'').replace(/\\+/g, '/');
+      `.replace(/"/g, '\'').replace(/(\\(?![']))+/g, '/');
 
       const p = spawn(process.execPath, ['-e', cmd], { stdio: ['inherit', 'inherit', 'inherit',] });
       p.on('close', (code, signal) => {


### PR DESCRIPTION
This change fixes an issue I encountered when programmatically invoking AutoRest CLI from another Node process.  When AutoRest prepares to execute `@autorest/core` in a separate Node process, it generates a command string to be evaluted in the subprocess and then tweaks quotes and backslashes to ensure that the script can be transmitted as a program argument.

This regex replace operation caused escaped double-quotes (`\"`) to be turned into improperly escaped single quotes (`/'`).  Look closely at the `--python.output-folder=` parameter here:

```
        process.argv = ['/gnu/store/h00qbcrg4wk3fadh85i585az80mx37j4-node-10.16.0/bin/node','/home/daviwil/Projects/Code/autorest/autorest/entrypoints/app.js','--python','--python.output-folder=/
'/home/daviwil/Projects/Code/autorest.modelerfour/modelerfour/test/regression/python/additionalProperties.json/old/'','--python.clear-output-folder','--input-file=/'/home/daviwil/Projects/Code/au
torest.modelerfour/modelerfour/node_modules/@microsoft.azure/autorest.testserver/swagger/additionalProperties.json/'','--v3','--use:@autorest/python@5.0.0-dev.20200225.1'];
```

The fix is to make the backslash-reversing regex reject any backslash that comes before a single quote.