### PR TITLE
Add Python regression tests to PR validation pipeline

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -53,6 +53,19 @@ specs:
      - xml-service.json
      - xms-error-responses.json
 languages:
+  - language: python
+    excludeSpecs:
+      # The following specs aren't yet supported by @autorest/modelerfour
+      - body-formdata-urlencoded.json
+      - body-formdata.json
+    outputPath: ../core/test/regression/python
+    oldArgs:
+      - --v3
+      - --use:@autorest/python@5.0.0-dev.20200225.1
+    newArgs:
+      - --version:../core
+      - --v3
+      - --use:@autorest/python@5.0.0-dev.20200225.1
   - language: typescript
     excludeSpecs:
       # The following specs currently crash the v3 TypeScript generator
@@ -72,7 +85,6 @@ languages:
     outputPath: ../core/test/regression/typescript
     oldArgs:
       - --v3
-      - --version:3.0.6200
       - --package-name:test-package
       - --use:@autorest/typescript@0.1.0-dev.20200203.1
     newArgs:

--- a/.scripts/verify-pull-request.yaml
+++ b/.scripts/verify-pull-request.yaml
@@ -11,7 +11,7 @@ pool:
 steps:
 - task: NodeTool@0
   inputs:
-    versionSpec: '10.x'
+    versionSpec: '13.x'
   displayName: 'Install Node.js'
 
 - script: |
@@ -24,10 +24,18 @@ steps:
 
   displayName: 'Rush install, build and test'
 
+- task: UsePythonVersion@0
+  inputs:
+    versionSpec: '3.x'
+  displayName: Install Python 3
+
 - script: |
     npm install @microsoft.azure/autorest.testserver --no-save
-    npm install -g @autorest/compare@~0.2.0
+    npm install -g @autorest/compare@~0.3.0
   displayName: Install autorest-compare
 
-- script: autorest-compare --compare:.scripts/regression-compare.yaml
+- script: autorest-compare --compare:.scripts/regression-compare.yaml --language:python
+  displayName: Regression Test - @autorest/python
+
+- script: autorest-compare --compare:.scripts/regression-compare.yaml --language:typescript
   displayName: Regression Test - @autorest/typescript

--- a/rush.json
+++ b/rush.json
@@ -3,7 +3,7 @@
   "rushVersion": "5.12.0",
   "pnpmVersion": "2.15.1",
   "pnpmOptions": {},
-  "nodeSupportedVersionRange": ">=8.9.4 <11.0.0",
+  "nodeSupportedVersionRange": ">=8.9.4 <14.0.0",
   "ensureConsistentVersions": true,
   "projectFolderMinDepth": 1,
   "projectFolderMaxDepth": 3,


### PR DESCRIPTION
This change leverages the new Python language support in`@autorest/compare` to add regression tests using the new Python generator because it has more complete support for the new CodeModel.