### PR TITLE
fix(documentation): Fix v2 installation verification command

### DIFF
--- a/docs/installing-autorest.md
+++ b/docs/installing-autorest.md
@@ -13,7 +13,7 @@ Installing AutoRest on Windows, MacOS or Linux involves two steps:
   npm install -g autorest
 
   # run using command 'autorest'
-  autorest-beta --help
+  autorest --help
   ```
 Or the beta version of AutoRest v3, side-by-side:
 


### PR DESCRIPTION
this PR fixes:

- command to verify that stable v2 version is installed properly (it was refering to beta V3 before)