### PR TITLE
Include spec path in schema validation error messages

### DIFF
--- a/core/lib/pipeline/schema-validation.ts
+++ b/core/lib/pipeline/schema-validation.ts
@@ -22,13 +22,14 @@ export function createSwaggerSchemaValidatorPlugin(): PipelinePlugin {
     const errors = await new Promise<Array<{ code: string; params: Array<string>; message: string; path: string }> | null>(res => validator.validate(obj, extendedSwaggerSchema, (err, valid) => res(valid ? null : err)));
     if (errors !== null) {
       for (const error of errors) {
+        const path = parseJsonPointer(error.path);
         config.Message({
           // secondary files have reduced schema compliancy, so we're gonna just warn them for now.
           Channel: isSecondary ? Channel.Warning : Channel.Error,
           Details: error,
           Plugin: 'schema-validator-swagger',
-          Source: [{ document: fileIn.key, Position: <any>{ path: parseJsonPointer(error.path) } }],
-          Text: `Schema violation: ${error.message}`
+          Source: [{ document: fileIn.key, Position: <any>{ path } }],
+          Text: `Schema violation: ${error.message} (${path.join(" > ")})`
         });
       }
       if (!isSecondary) {
@@ -50,12 +51,13 @@ export function createOpenApiSchemaValidatorPlugin(): PipelinePlugin {
     const errors = await new Promise<Array<{ code: string; params: Array<string>; message: string; path: string }> | null>(res => validator.validate(obj, extendedOpenApiSchema, (err, valid) => res(valid ? null : err)));
     if (errors !== null) {
       for (const error of errors) {
+        const path = parseJsonPointer(error.path);
         config.Message({
           Channel: Channel.Warning,
           Details: error,
           Plugin: 'schema-validator-openapi',
           Source: [{ document: fileIn.key, Position: <any>{ path: parseJsonPointer(error.path) } }],
-          Text: `Schema violation: ${error.message}`
+          Text: `Schema violation: ${error.message} (${path.join(" > ")})`
         });
       }
       // throw new OperationAbortedException();


### PR DESCRIPTION
While investigating Azure/autorest.modelerfour#307, I noticed that errors from Swagger schema validation can be pretty impenetrable:

```
ERROR: Schema violation: Data does not match any schemas from 'oneOf'
    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/31587d1257192ea12a767edb86d84aa2d01bef8f/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.0/keyvault.json
/home/daviwil/Projects/Code/autorest.megarepo/autorest/core/dist/lib/pipeline/pipeline.js - FAILURE {"exitCode":1}
```

This change includes the error-inducing spec path in the error message so that it's easier to track down:

```
ERROR: Schema violation: Data does not match any schemas from 'oneOf' (paths > /keys/{key-name}/{key-version} > get > parameters > 1)
    - https://raw.githubusercontent.com/Azure/azure-rest-api-specs/31587d1257192ea12a767edb86d84aa2d01bef8f/specification/keyvault/data-plane/Microsoft.KeyVault/stable/7.0/keyvault.json
/home/daviwil/Projects/Code/autorest.megarepo/autorest/core/dist/lib/pipeline/pipeline.js - FAILURE {"exitCode":1}
```

@fearthecowboy - Do you have a suggestion for a better delimiter to use in the path string?  Using `/` is a little redundant since paths also contains that character.