### PR TITLE
Don't hard code max-old-space-size

### DIFF
--- a/autorest/entrypoints/app.js
+++ b/autorest/entrypoints/app.js
@@ -2,7 +2,7 @@
 // load modules from static linker filesystem.
 // if the process was started with a low heap size (and we're not debugging!) then respawn with a bigger heap size.
 if ((require('v8').getHeapStatistics()).heap_size_limit < 8000000000 && !(require('inspector').url() || global.v8debug || /--debug|--inspect/.test(process.execArgv.join(' ')))) {
-  process.env['NODE_OPTIONS'] = `${process.env['NODE_OPTIONS'] || ''} --max-old-space-size=8192 --no-warnings`;
+  process.env['NODE_OPTIONS'] = `${process.env['NODE_OPTIONS'] || ''} --no-warnings`;
   const argv = process.argv.indexOf('--break') === -1 ? process.argv.slice(1) : ['--inspect-brk', ...process.argv.slice(1).filter(each => each !== '--break')];
   require('child_process').spawn(process.execPath, argv, { argv0: 'node', stdio: 'inherit' }).on('close', code => { process.exit(code); });
 } else {


### PR DESCRIPTION
Windows 10

Tried to execute the app.js file directly with both NODE_OPTIONS and then of course, max-old-space-size as as an option against node.exe. Both failed.

Looked into the app.js file and found the option was hard coded. 

This effectively overrides the system configured option.