### PR TITLE
Allow all `x-` extensions on the `xml` object

### DIFF
--- a/schema/swagger-extensions.json
+++ b/schema/swagger-extensions.json
@@ -1480,10 +1480,7 @@
         }
       },
       "patternProperties": {
-        "^x-(?!ms-).*$": {
-          "$ref": "#/definitions/vendorExtension"
-        },
-        "^x-ms-sf-.*$": {
+        "^x-": {
           "$ref": "#/definitions/vendorExtension"
         }
       }


### PR DESCRIPTION
This change enables the solution to https://github.com/Azure/autorest/issues/3535 by allowing all `x-` extensions to be applied to the `xml` object when configuring XML serialization for a schema.  Specifically, this allows an `x-ms-text` attribute to be passed through to the modelerfour CodeModel under the `extensions` sub-object.  Language generator implementors can use this information to serialize/deserialize the textual contents of an XML node into a property.