### PR TITLE
Use latest npm version of @autorest/python for --v3 --python config

### DIFF
--- a/core/resources/plugin-python.md
+++ b/core/resources/plugin-python.md
@@ -1,8 +1,14 @@
-# Default Configuration - Pythong
+# Default Configuration - Python
 
 The V2 version of the Python Generator.
 
+``` yaml $(python) && $(v3)
+version: ~3.0.6298
 
+use-extension:
+  "@autorest/python": "latest"
+try-require: ./readme.python.md
+```
 
 ``` yaml $(python) && $(preview) && !isRequested('@autorest/python')
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 


### PR DESCRIPTION
This change causes the latest version of `@autorest/python` on `npm` to be used when AutoRest is invoked with the `--v3 --python` parameters.  I double checked that removing the `--v3` causes the v2 version of the pipeline and generator to be used:

**With `--v3`**

```
λ autorest --v3 --python --debug --input-file=keyvault.json
AutoRest code generation utility [cli version: 3.0.6187; node: v10.19.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/daviwil/Projects/Code/autorest.megarepo/autorest/core/dist' (3.0.0)
   Loading local AutoRest extension '@autorest/modelerfour' (/home/daviwil/Projects/Code/autorest.megarepo/modelerfour/modelerfour)
   Loading AutoRest extension '@autorest/python' (latest->5.1.0-preview.4)
   Loading AutoRest extension '@autorest/modelerfour' (4.15.378->4.15.378)
```

**Without `--v3`**
```
λ autorest --python --debug --input-file=keyvault.json
AutoRest code generation utility [cli version: 3.0.6187; node: v10.19.0, max-memory: 8192 gb]
(C) 2018 Microsoft Corporation.
https://aka.ms/autorest
   Loading AutoRest core      '/home/daviwil/Projects/Code/autorest.megarepo/autorest/core/dist' (3.0.0)
   Loading local AutoRest extension '@autorest/modelerfour' (/home/daviwil/Projects/Code/autorest.megarepo/modelerfour/modelerfour)
   Loading AutoRest extension '@microsoft.azure/autorest.python' (~3.0.56->3.0.62)
   Installing AutoRest extension '@microsoft.azure/autorest.modeler' (2.3.44)
   Installed AutoRest extension '@microsoft.azure/autorest.modeler' (2.3.44->2.3.44)
```