### PR TITLE
Enable formData parameters to have arrays of files

### DIFF
--- a/schema/swagger-extensions.json
+++ b/schema/swagger-extensions.json
@@ -935,7 +935,7 @@
           "type": "string"
         },
         "items": {
-          "$ref": "#/definitions/primitivesItems"
+          "$ref": "#/definitions/primitivesItemsWithFile"
         },
         "collectionFormat": {
           "$ref": "#/definitions/collectionFormatWithMulti"
@@ -1376,19 +1376,12 @@
       },
       "additionalProperties": false
     },
-    "primitivesItems": {
+    "primitivesItemsBase": {
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "type": {
-          "type": "string",
-          "enum": [
-            "string",
-            "number",
-            "integer",
-            "boolean",
-            "array"
-          ]
+          "type": "string"
         },
         "format": {
           "type": "string"
@@ -1454,6 +1447,45 @@
         },
         "^x-ms-sf-.*$": {
           "$ref": "#/definitions/vendorExtension"
+        }
+      }
+    },
+    "primitivesItems": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/primitivesItemsBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array"
+          ]
+        }
+      }
+    },
+    "primitivesItemsWithFile": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/primitivesItemsBase"
+        }
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "enum": [
+            "string",
+            "number",
+            "integer",
+            "boolean",
+            "array",
+            "file"
+          ]
         }
       }
     },


### PR DESCRIPTION
This change updates our `swagger-extensions.json` schema to allow operation parameters in `formData` to specify arrays with items of type `file` for the purpose of enabling multi-file uploads for the `multipart/form-data` content type.  I basically just copied the `primitivesItems` definition and added `file` to the `type` property's enum set.