### PR TITLE
Use 'tag' and 'altTag' parameters for setting NPM tags on published packages

### DIFF
--- a/.scripts/push-to-npm.yaml
+++ b/.scripts/push-to-npm.yaml
@@ -1,4 +1,5 @@
 # publishes a package to NPM (passed in as $(pkg) variable)
+# you can also customize the tag used for NPM with the $(tag) variable (defaults to 'latest')
 
 trigger:
 - master 
@@ -19,12 +20,18 @@ steps:
 
     # grab the file specified
     wget $(pkg)
-    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi 
+    rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
+
+    # determine the tag
+    npmTag = "latest"
+    if [ -n "$(tag)" ]; then
+      npmTag = $(tag)
+    fi
 
     # publish it to npm 
     for file in *.tgz 
     do
-      npm publish $file --tag latest --access public
+      npm publish $file --tag $npmTag --access public
       rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
     done
 

--- a/.scripts/push-to-npm.yaml
+++ b/.scripts/push-to-npm.yaml
@@ -1,5 +1,6 @@
 # publishes a package to NPM (passed in as $(pkg) variable)
 # you can also customize the tag used for NPM with the $(tag) variable (defaults to 'latest')
+# if you want to set a secondary tag on the package (like V2), set the $(altTag) variable
 
 trigger:
 - master 
@@ -33,8 +34,11 @@ steps:
     do
       npm publish $file --tag $npmTag --access public
       rc=$?; if [ $rc -ne 0 ]; then exit $rc ; fi
+
+      # set the alternate tag, if applicable
+      if [ -n "$(altTag)" ]; then
+        tar -zxvf $file
+        cd package/
+        npm dist-tag add $(npm show . name)@$(npm show . version) --tag $(altTag)
+      fi
     done
-
-
-    
-


### PR DESCRIPTION
This will make it easier to push updates to AutoRest Core v2 since we need to ensure the `V2` tag is also added for the latest release.