### PR TITLE
Fix syntax error in 'catch' statement

### DIFF
--- a/autorest/entrypoints/app.js
+++ b/autorest/entrypoints/app.js
@@ -12,7 +12,7 @@ if ((require('v8').getHeapStatistics()).heap_size_limit < 8000000000 && !(requir
     try {
       // try to let source maps resolve
       require('source-map-support').install();
-    } catch {
+    } catch (e) {
       // no worries
     }
   }


### PR DESCRIPTION
The following error appeared:

```
$ autorest protocol-generator.md 
/usr/local/lib/node_modules/autorest/entrypoints/app.js:15
    } catch {
            ^

SyntaxError: Unexpected token {
    at createScript (vm.js:80:10)
    at Object.runInThisContext (vm.js:139:10)
    at Module._compile (module.js:616:28)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
```

After the fix it seems to show the real problem:

```
$ autorest protocol-generator.md 

FATAL: Node v10 (v10.12.x minimum, v10.16.x LTS recommended) is required for AutoRest.

```