### PR TITLE
Only turn on client-side-validation for the v2 pipeline

### DIFF
--- a/core/resources/plugin-validators.md
+++ b/core/resources/plugin-validators.md
@@ -47,8 +47,8 @@ pipeline:
 
 ## Client Side Validation
 
-On by default for backwards compatibility, but see https://github.com/Azure/autorest/issues/2100
+On by default in AutoRest v2 for backwards compatibility, but see https://github.com/Azure/autorest/issues/2100.
 
-``` yaml
+``` yaml $(pipeline-model) == 'v2'
 client-side-validation: true
 ```


### PR DESCRIPTION
This change explicitly disables the `client-side-validation` option when the `--v3` flag is used so that it doesn't get applied for AutoRest v3 generators.