### PR TITLE
Add --max-memory-size parameter for increasing Node.js heap size

### DIFF
--- a/autorest/entrypoints/app.js
+++ b/autorest/entrypoints/app.js
@@ -1,13 +1,23 @@
 #!/usr/bin/env node
-// load modules from static linker filesystem.
+
+global.isDebuggerEnabled =
+  !!require('inspector').url()
+    || global.v8debug
+    || /--debug|--inspect/.test(process.execArgv.join(' '));
+
+const maxMemorySizeArg = process.argv.join(' ').match(/--max-memory-size=(\w+)/);
+const maxMemorySize = maxMemorySizeArg && parseInt(maxMemorySizeArg[1]);
+if (isNaN(maxMemorySize)) {
+  console.error(`\nWarning: --max-memory-size parameter '${maxMemorySizeArg[1]}' is not an integer, ignoring it.\n`);
+}
+
 // if the process was started with a low heap size (and we're not debugging!) then respawn with a bigger heap size.
-if ((require('v8').getHeapStatistics()).heap_size_limit < 8000000000 && !(require('inspector').url() || global.v8debug || /--debug|--inspect/.test(process.execArgv.join(' ')))) {
-  process.env['NODE_OPTIONS'] = `${process.env['NODE_OPTIONS'] || ''} --max-old-space-size=8192 --no-warnings`;
+if (maxMemorySize && !isDebuggerEnabled && (require('v8').getHeapStatistics()).heap_size_limit < (maxMemorySize * 1024000)) {
+  process.env['NODE_OPTIONS'] = `${process.env['NODE_OPTIONS'] || ''} --max-old-space-size=${maxMemorySize} --no-warnings`;
   const argv = process.argv.indexOf('--break') === -1 ? process.argv.slice(1) : ['--inspect-brk', ...process.argv.slice(1).filter(each => each !== '--break')];
   require('child_process').spawn(process.execPath, argv, { argv0: 'node', stdio: 'inherit' }).on('close', code => { process.exit(code); });
 } else {
-  global.isDebuggerEnabled = !!require('inspector').url();
-
+  // load modules from static linker filesystem.
   if (isDebuggerEnabled) {
     try {
       // try to let source maps resolve

--- a/core/resources/help-configuration.md
+++ b/core/resources/help-configuration.md
@@ -64,6 +64,9 @@ help-content: # type: Help as defined in autorest-core/help.ts
     - key: github-auth-token
       type: string
       description: OAuth token to use when pointing AutoRest at files living in a private GitHub repository
+    - key: max-memory-size
+      type: string
+      description: Increases the maximum memory size in MB used by Node.js when running AutoRest (translates to the Node.js parameter --max-old-space-size)
   _autorest-core-1:
     categoryFriendlyName: Core Functionality
     description: "> While AutoRest can be extended arbitrarily by 3rd parties (say, with a custom generator),\n> we officially support and maintain the following functionality.\n> More specific help is shown when combining the following switches with `--help` ."


### PR DESCRIPTION
This change addresses #3857 (and supersedes #3523) to fix an issue where AutoRest will fail to run on some machines where the amount of available memory is less than what AutoRest requests through the `--max-old-space-size` parameter to Node.js.  

The fix is to not increase the requested heap size by default and add an `--max-memory-size` parameter that will allow the user to specify their desired memory size if needed.