### PR TITLE
Default --python to AutoRest v3 and @autorest/python

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -62,10 +62,10 @@ languages:
   - language: python
     outputPath: ../core/test/regression/python
     oldArgs:
-      - --use:@autorest/python@5.4.0
+      - --version:~3.0.6320
+      - --use:@autorest/python
     newArgs:
       - --version:../core
-      - --use:@autorest/python@5.4.0
   - language: typescript
     outputPath: ../core/test/regression/typescript
     oldArgs:

--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -62,11 +62,9 @@ languages:
   - language: python
     outputPath: ../core/test/regression/python
     oldArgs:
-      - --v3
       - --use:@autorest/python@5.4.0
     newArgs:
       - --version:../core
-      - --v3
       - --use:@autorest/python@5.4.0
   - language: typescript
     outputPath: ../core/test/regression/typescript

--- a/core/resources/plugin-python.md
+++ b/core/resources/plugin-python.md
@@ -1,8 +1,8 @@
 # Default Configuration - Python
 
-The V2 version of the Python Generator.
+The V3 version of the Python Generator.
 
-``` yaml $(python) && $(v3)
+``` yaml $(python) && !isRequested('@microsoft.azure/autorest.python')
 version: ~3.0.6298
 
 use-extension:
@@ -10,7 +10,9 @@ use-extension:
 try-require: ./readme.python.md
 ```
 
-``` yaml $(python) && $(preview) && !isRequested('@autorest/python')
+Enable use of the V2 Python generator (and V2 core) with the `--v2` parameter:
+
+``` yaml $(python) && $(preview) && $(v2)
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 
@@ -19,7 +21,7 @@ use-extension:
 try-require: ./readme.python.md
 ```
 
-``` yaml $(python) && !isRequested('@autorest/python')
+``` yaml $(python) && $(v2)
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 

--- a/core/resources/plugin-python.md
+++ b/core/resources/plugin-python.md
@@ -2,7 +2,7 @@
 
 The V3 version of the Python Generator.
 
-``` yaml $(python) && !isRequested('@microsoft.azure/autorest.python')
+``` yaml $(python) && !$(v2) && !isRequested('@microsoft.azure/autorest.python')
 version: ~3.0.6298
 
 use-extension:
@@ -12,20 +12,11 @@ try-require: ./readme.python.md
 
 Enable use of the V2 Python generator (and V2 core) with the `--v2` parameter:
 
-``` yaml $(python) && $(preview) && $(v2)
+``` yaml $(python) && ($(v2) || isRequested('@microsoft.azure/autorest.python'))
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 
 use-extension:
-  "@microsoft.azure/autorest.python": "preview"
-try-require: ./readme.python.md
-```
-
-``` yaml $(python) && $(v2)
-# default the v2 generator to using the last stable @microsoft.azure/autorest-core 
-version: ~2.0.4413
-
-use-extension:
-  "@microsoft.azure/autorest.python": "~3.0.56"
+  "@microsoft.azure/autorest.python": "~4.0.73"
 try-require: ./readme.python.md
 ```


### PR DESCRIPTION
Since `@autorest/python` is now GA (congrats! 🎉) this change will default all requests for `--python` to use the new generator without requiring `--v3` to also be supplied as a parameter.  Note that using `--v3` will still work and we'll also support `--v2` for falling back to the old V2 generation and core pipeline.