### PR TITLE
Fix releases link in autorest-versioning document

### DIFF
--- a/docs/autorest-versioning.md
+++ b/docs/autorest-versioning.md
@@ -18,7 +18,7 @@ The AutoRest core module is the real processing hub for AutoRest.
 
 The CLI can load any version of the AutoRest Core module by using the command line `--version:[VERSION]`  where `[VERSION]` is one of:
  - a semver version range that matches a published nodejs package `@autorest/core` package.<br>AutoRest v3 defaults to `~3.0.6000` (ie, the latest published `3.0` package above build `6000` )
- - the specific version of the core module package, which can come from npm or a prerelase build in [github releases](https://github.com/azure/autorest/relases)<br>ie,  `--version:3.0.6189`
+ - the specific version of the core module package, which can come from npm or a prerelase build in [github releases](https://github.com/azure/autorest/releases)<br>ie,  `--version:3.0.6189`
  - a folder where the core package has been cloned and compiled. (ie, `c:\work\autorest` )
  - a URL to a nodejs autorest-core package 
 


### PR DESCRIPTION
Link was pointing to `/relases` it should be pointing to `/releases`