### PR TITLE
Set new default versions for Python, Java, and TypeScript generators

### DIFF
--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -62,10 +62,10 @@ languages:
   - language: python
     outputPath: ../core/test/regression/python
     oldArgs:
-      - --use:@autorest/python@5.4.0
+      - --version:~3.0.6320
+      - --use:@autorest/python
     newArgs:
       - --version:../core
-      - --use:@autorest/python@5.4.0
   - language: typescript
     outputPath: ../core/test/regression/typescript
     oldArgs:

--- a/.scripts/regression-compare.yaml
+++ b/.scripts/regression-compare.yaml
@@ -62,11 +62,9 @@ languages:
   - language: python
     outputPath: ../core/test/regression/python
     oldArgs:
-      - --v3
       - --use:@autorest/python@5.4.0
     newArgs:
       - --version:../core
-      - --v3
       - --use:@autorest/python@5.4.0
   - language: typescript
     outputPath: ../core/test/regression/typescript

--- a/core/resources/default-configuration.md
+++ b/core/resources/default-configuration.md
@@ -44,6 +44,15 @@ These extra settings are applied when `azure-arm: true`:
 head-as-boolean: true
 ```
 
+##### Extra configuration for `legacy `
+
+If `--legacy` isn't provided, we set the `track2` option to `true` to indicate
+to V3 generators that the user wants to generate a Track 2 library.
+
+``` yaml !$(legacy)
+track2: true
+```
+
 ##### Actually load files
 
 If we don't specify `--help`, we will trigger the setting to load files

--- a/core/resources/plugin-java.md
+++ b/core/resources/plugin-java.md
@@ -1,21 +1,22 @@
 # Default Configuration - Java
 
-The V2 version of the Java Generator.
+The V3 version of the Java Generator.
 
-``` yaml $(java) && $(preview) && !isRequested('@autorest/java')
-# default the v2 generator to using the last stable @microsoft.azure/autorest-core 
-version: ~2.0.4413
+``` yaml $(java) && !$(legacy) && !$(v2) && !isRequested('@microsoft.azure/autorest.java')
+version: ~3.0.6298
 
 use-extension:
-  "@microsoft.azure/autorest.java": "~2.1.88"
+  "@autorest/java": "4.0.4"
 try-require: ./readme.java.md
 ```
 
-``` yaml $(java) && !isRequested('@autorest/java')
+Enable use of the V2 Java generator (and V2 core) with the `--legacy` or `--v2` parameter:
+
+``` yaml $(java) && ($(legacy) || $(v2) || isRequested('@microsoft.azure/autorest.java'))
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 
 use-extension:
-  "@microsoft.azure/autorest.java": "~2.1.88"
+  "@microsoft.azure/autorest.java": "three"
 try-require: ./readme.java.md
 ```

--- a/core/resources/plugin-python.md
+++ b/core/resources/plugin-python.md
@@ -2,7 +2,7 @@
 
 The V3 version of the Python Generator.
 
-``` yaml $(python) && !$(v2) && !isRequested('@microsoft.azure/autorest.python')
+``` yaml $(python) && !$(legacy) && !$(v2) && !isRequested('@microsoft.azure/autorest.python')
 version: ~3.0.6298
 
 use-extension:
@@ -10,9 +10,9 @@ use-extension:
 try-require: ./readme.python.md
 ```
 
-Enable use of the V2 Python generator (and V2 core) with the `--v2` parameter:
+Enable use of the V2 Python generator (and V2 core) with the `--legacy` or `--v2` parameter:
 
-``` yaml $(python) && ($(v2) || isRequested('@microsoft.azure/autorest.python'))
+``` yaml $(python) && ($(legacy) || $(v2) || isRequested('@microsoft.azure/autorest.python'))
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 

--- a/core/resources/plugin-python.md
+++ b/core/resources/plugin-python.md
@@ -1,8 +1,8 @@
 # Default Configuration - Python
 
-The V2 version of the Python Generator.
+The V3 version of the Python Generator.
 
-``` yaml $(python) && $(v3)
+``` yaml $(python) && !isRequested('@microsoft.azure/autorest.python')
 version: ~3.0.6298
 
 use-extension:
@@ -10,7 +10,9 @@ use-extension:
 try-require: ./readme.python.md
 ```
 
-``` yaml $(python) && $(preview) && !isRequested('@autorest/python')
+Enable use of the V2 Python generator (and V2 core) with the `--v2` parameter:
+
+``` yaml $(python) && $(preview) && $(v2)
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 
@@ -19,7 +21,7 @@ use-extension:
 try-require: ./readme.python.md
 ```
 
-``` yaml $(python) && !isRequested('@autorest/python')
+``` yaml $(python) && $(v2)
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 

--- a/core/resources/plugin-python.md
+++ b/core/resources/plugin-python.md
@@ -2,7 +2,7 @@
 
 The V3 version of the Python Generator.
 
-``` yaml $(python) && !isRequested('@microsoft.azure/autorest.python')
+``` yaml $(python) && !$(v2) && !isRequested('@microsoft.azure/autorest.python')
 version: ~3.0.6298
 
 use-extension:
@@ -12,20 +12,11 @@ try-require: ./readme.python.md
 
 Enable use of the V2 Python generator (and V2 core) with the `--v2` parameter:
 
-``` yaml $(python) && $(preview) && $(v2)
+``` yaml $(python) && ($(v2) || isRequested('@microsoft.azure/autorest.python'))
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 
 use-extension:
-  "@microsoft.azure/autorest.python": "preview"
-try-require: ./readme.python.md
-```
-
-``` yaml $(python) && $(v2)
-# default the v2 generator to using the last stable @microsoft.azure/autorest-core 
-version: ~2.0.4413
-
-use-extension:
-  "@microsoft.azure/autorest.python": "~3.0.56"
+  "@microsoft.azure/autorest.python": "~4.0.73"
 try-require: ./readme.python.md
 ```

--- a/core/resources/plugin-typescript.md
+++ b/core/resources/plugin-typescript.md
@@ -1,22 +1,23 @@
-# Default Configuration - Typescript
+# Default Configuration - TypeScript
 
-The V2 version of the Typescript Generator.
+The V3 version of the Typescript Generator.
 
-``` yaml $(typescript) && $(preview) && !isRequested('@autorest/typescript')
-# default the v2 generator to using the last stable @microsoft.azure/autorest-core 
-version: ~2.0.4413
+``` yaml $(typescript) && !$(legacy) && !$(v2) && !isRequested('@microsoft.azure/autorest.typescript')
+version: ~3.0.6298
 
 use-extension:
-  "@microsoft.azure/autorest.typescript": "preview"
+  "@autorest/typescript": "6.0.0-dev.20201105.2"
 try-require: ./readme.typescript.md
 ```
 
-``` yaml $(typescript) && !isRequested('@autorest/typescript')
+Enable use of the V2 TypeScript generator (and V2 core) with the `--legacy` or `--v2` parameter:
+
+``` yaml $(typescript) && ($(legacy) || $(v2) || isRequested('@microsoft.azure/autorest.typescript'))
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 
 use-extension:
-  "@microsoft.azure/autorest.typescript": "~4.2.0"
+  "@microsoft.azure/autorest.typescript": "~4.4.4"
 try-require: ./readme.typescript.md
 ```
 


### PR DESCRIPTION
We've got a few V3-era generators that are ready to have their default versions updated so that new code is generated with them.  I've added a `--legacy` parameter that will default back to the last stable versions of the V2-era generators in case things go wrong (@iscai-msft, can you add this parameter to the new docs?)

/cc @pakrym - I added the `track2: true` configuration variable when `--legacy` is **not** specified, as requested in #3622