### PR TITLE
Fix: Custom name conflict

### DIFF
--- a/.default-eslintrc.yaml
+++ b/.default-eslintrc.yaml
@@ -27,6 +27,7 @@ rules:
   "@typescript-eslint/no-unused-vars": "off"
   "@typescript-eslint/no-parameter-properties": "off"
   "@typescript-eslint/no-angle-bracket-type-assertion": "off"
+  "@typescript-eslint/no-use-before-define": "off"
   "require-atomic-updates": "off"
   "@typescript-eslint/consistent-type-assertions":
     - warn

--- a/core/lib/pipeline/plugins/tree-shaker.ts
+++ b/core/lib/pipeline/plugins/tree-shaker.ts
@@ -608,8 +608,10 @@ export class OAI3Shaker extends Transformer<AnyObject, AnyObject> {
     // copy the parts of the parameter across
     visitor.bind(this)(newRef, children);
 
-    // x-ms-client-name correspond to the property, parameter, etc. name, not the model.
-    delete newRef["x-ms-client-name"];
+    if (baseReferencePath === '/components/schemas') {
+      // x-ms-client-name correspond to the property, parameter, etc. name, not the model.
+      delete newRef["x-ms-client-name"];
+    }
 
     if (isAnonymous) {
       newRef['x-internal-autorest-anonymous-schema'] = { value: { anonymous: true }, pointer: '' };


### PR DESCRIPTION
fix #3655

When extracting schemas tree-shaker was copying the `x-ms-client-name` property down to the model even though it was mean to describe the property name or parameter name. This could cause issues down the line with duplicate model names
