### PR TITLE
Process components first in tree shaking to prevent duplicates

### DIFF
--- a/core/lib/pipeline/plugins/tree-shaker.ts
+++ b/core/lib/pipeline/plugins/tree-shaker.ts
@@ -103,8 +103,14 @@ export class OAI3Shaker extends Transformer<AnyObject, AnyObject> {
     // set the doc servers
     servers.forEach((s) => (this.docServers = s.value));
 
+    // Order in which the openapi properties should be tree shaked.
+    // Components needs to go first so other tree shaked element don't interfer with actual models.
+    const elementOrder = ["components", "paths", "x-ms-paths"].reverse();
+    const sortedNodes = theNodes.sort((a, b) => {
+      return elementOrder.indexOf(b.key) - elementOrder.indexOf(a.key);
+    });
     // initialize certain things ahead of time:
-    for (const { value, key, pointer, children } of theNodes) {
+    for (const { value, key, pointer, children } of sortedNodes) {
       switch (key) {
         case "x-ms-paths":
         case "paths":


### PR DESCRIPTION
Issue here is when using a response schema with a title it will create a model with that title. However if there is already a model with that title it will have a conflict error and not fail gracefully.

The main issue is that the `paths` are processed before the `components` which makes it that the model extracted from the response is inserted in the output first, then when times comes to move the model from the component it fails as there is already one present with that name.

This PR makes it that it process the components first as those start with a 1:1 mapping. Then when it goes to the response it will be able to use an alternative name for the model (e.g. `MyModel0`) automatically.
fix #3707
fix #3609