### PR TITLE
Use a version range for Java generator v4

### DIFF
--- a/core/resources/plugin-java.md
+++ b/core/resources/plugin-java.md
@@ -6,7 +6,7 @@ The V3 version of the Java Generator.
 version: ~3.0.6298
 
 use-extension:
-  "@autorest/java": "4.0.4"
+  "@autorest/java": "^4.0.4"
 try-require: ./readme.java.md
 ```
 


### PR DESCRIPTION
Forgot to use a version range to allow newer versions of the generator to be pulled when `autorest --java` is specified.