### PR TITLE
Update plugin-validators.md

### DIFF
--- a/packages/extensions/core/resources/plugin-validators.md
+++ b/packages/extensions/core/resources/plugin-validators.md
@@ -22,6 +22,7 @@ use-extension:
 ``` yaml $(model-validator)
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
+
 use-extension:
   "oav": "~0.4.20"
 ```

--- a/packages/extensions/core/resources/plugin-validators.md
+++ b/packages/extensions/core/resources/plugin-validators.md
@@ -19,6 +19,9 @@ use-extension:
   "@microsoft.azure/openapi-validator": "^1.7.0"
 ```
 
+``` yaml $(model-validator)
+# default the v2 generator to using the last stable @microsoft.azure/autorest-core 
+version: ~2.0.4413
 use-extension:
   "oav": "~0.4.20"
 ```

--- a/packages/extensions/core/resources/plugin-validators.md
+++ b/packages/extensions/core/resources/plugin-validators.md
@@ -3,18 +3,21 @@
 The Azure and Model validators
 
 
-``` yaml $(azure-validator)
-# default the v2 generator to using the last stable @microsoft.azure/autorest-core 
+``` yaml $(azure-validator) && !$(v3)
+# default the v2 validator to using the last stable @microsoft.azure/autorest-core 
 version: ~2.0.4413
 
 use-extension:
-  "@microsoft.azure/classic-openapi-validator": "~1.0.9"
-  "@microsoft.azure/openapi-validator": "~1.0.2"
+  "@microsoft.azure/classic-openapi-validator": "~1.1.5"
+  "@microsoft.azure/openapi-validator": "~1.7.0"
 ```
 
-``` yaml $(model-validator)
-# default the v2 generator to using the last stable @microsoft.azure/autorest-core 
-version: ~2.0.4413
+``` yaml $(azure-validator) && $(v3)
+# the v3 validator to using the last stable @microsoft.azure/autorest-core 
+version: ~3.0.5537
+use-extension:
+  "@microsoft.azure/openapi-validator": "^1.7.0"
+```
 
 use-extension:
   "oav": "~0.4.20"


### PR DESCRIPTION
I am the owner of the autorest extension: https://github.com/Azure/azure-openapi-validator , I want to support autorest/core v3 to use its new internal pipelines or modelerfour , so I want to add optional argument  `--v3`  , also I updated the default version of this extension as it's too old.