### PR TITLE
Fix publishing code model

### DIFF
--- a/.scripts/publish.yaml
+++ b/.scripts/publish.yaml
@@ -23,6 +23,6 @@ steps:
       for file in common/temp/artifacts/packages/*.tgz 
       do
         echo "Trying to publish $file:"
-        common/temp/pnpm-local/node_modules/.bin/pnpm publish $file --tag latest --access public --no-git-checks || echo no-worries 
+        npm publish $file --tag latest --access public --no-git-checks || echo no-worries 
       done
     displayName: Publish packages

--- a/packages/libs/codemodel/package.json
+++ b/packages/libs/codemodel/package.json
@@ -55,5 +55,8 @@
     "@azure-tools/autorest-extension-base": "~3.1.0",
     "@azure-tools/codegen": "~2.5.0",
     "@azure-tools/linq": "~3.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
For some reason it is not respecting the `--access public` option on `pnpm publish`