### PR TITLE
Handle circular dependency in additionalProperties

### DIFF
--- a/common/changes/@autorest/modelerfour/fix-additional-props-circular-dep_2021-01-29-18-24.json
+++ b/common/changes/@autorest/modelerfour/fix-additional-props-circular-dep_2021-01-29-18-24.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@autorest/modelerfour",
-      "comment": "Fix haivng circular dependencies in additionalProperties [PR #3819](https://github.com/Azure/autorest/pull/3819)",
+      "comment": "Fix the use of  circular dependencies in additionalProperties [PR #3819](https://github.com/Azure/autorest/pull/3819)",
       "type": "patch"
     }
   ],

--- a/common/changes/@autorest/modelerfour/fix-additional-props-circular-dep_2021-01-29-18-24.json
+++ b/common/changes/@autorest/modelerfour/fix-additional-props-circular-dep_2021-01-29-18-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "Fix haivng circular dependencies in additionalProperties [PR #3819](https://github.com/Azure/autorest/pull/3819)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -785,7 +785,6 @@ export class ModelerFour {
     for (const { key: propertyName, value: propertyDeclaration } of items(schema.properties)) {
       const property = this.resolve(propertyDeclaration);
       this.use(<OpenAPI.Refable<OpenAPI.Schema>>propertyDeclaration, (pSchemaName, pSchema) => {
-        console.error("process chema", pSchema);
 
         const pType = this.processSchema(pSchemaName || `type·for·${propertyName}`, pSchema);
         const prop = objectSchema.addProperty(

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -974,7 +974,6 @@ export class ModelerFour {
 
   trap = new Set();
   processSchemaImpl(schema: OpenAPI.Schema, name: string): Schema {
-    console.error("Here", schema);
     if (this.trap.has(schema)) {
       throw new Error(
         `RECURSING!  Saw schema ${schema.title || schema["x-ms-metadata"]?.name || name} more than once.`,

--- a/packages/extensions/modelerfour/test/modeler/modelerfour.schemas.test.ts
+++ b/packages/extensions/modelerfour/test/modeler/modelerfour.schemas.test.ts
@@ -1,0 +1,23 @@
+import { addOperation, addSchema, createTestSpec } from "../utils";
+import { runModeler } from "./modelerfour-utils";
+
+describe("Modelerfour.Schemas", () => {
+  describe("additionalProperties", () => {
+    it("support reference to itself(circular dependency", async () => {
+      const spec = createTestSpec();
+
+      addSchema(spec, "SelfRefSchema", {
+        additionalProperties: {
+          $ref: "#/components/schemas/SelfRefSchema",
+        },
+      });
+
+      const codeModel = await runModeler(spec);
+
+      const schema = codeModel.schemas.dictionaries?.[0];
+      expect(schema).not.toBeNull();
+      expect(schema?.language.default.name).toEqual("SelfRefSchema");
+      expect(schema?.elementType).toEqual(schema);
+    });
+  });
+});

--- a/packages/extensions/modelerfour/test/modeler/modelerfour.test.ts
+++ b/packages/extensions/modelerfour/test/modeler/modelerfour.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-non-null-assertion */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.


### PR DESCRIPTION
fix #3818

Contrary to how the properties of an object where handled for additionalProperties we weren't caching the current schema before recursing into the type
Todo: 
- [x] Add tests