### PR TITLE
Add a new field tracking if a parameter is for a multipart request

### DIFF
--- a/common/changes/@autorest/codemodel/feature-multipart-param-model_2021-02-05-17-00.json
+++ b/common/changes/@autorest/codemodel/feature-multipart-param-model_2021-02-05-17-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/codemodel",
+      "comment": "Add a new `isInMultipart` field on parameters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/codemodel",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/modelerfour/feature-multipart-param-model_2021-02-05-17-00.json
+++ b/common/changes/@autorest/modelerfour/feature-multipart-param-model_2021-02-05-17-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "Set `isInMultipart: true` for multipart parameters",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -287,7 +287,7 @@ export class ModelerFour {
     if (i.instance) {
       return action(i.name, i.instance);
     }
-    throw "Unresolved item.";
+    throw new Error(`Unresolved item '${item}'`);
   }
 
   resolveArray<T>(source?: Array<Refable<T>>) {

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -1508,6 +1508,7 @@ export class ModelerFour {
                   },
                 },
                 clientDefaultValue: this.interpret.getClientDefault(propertyDeclaration, pSchema),
+                isInMultipart: true,
               },
             ),
           );

--- a/packages/extensions/modelerfour/test/modeler/modelerfour.requests.test.ts
+++ b/packages/extensions/modelerfour/test/modeler/modelerfour.requests.test.ts
@@ -1,10 +1,12 @@
+import { Parameter } from "@autorest/codemodel";
+import { HttpOperation, JsonType, ParameterLocation, RequestBody } from "@azure-tools/openapi";
 import { addOperation, createTestSpec } from "../utils";
 import { runModeler } from "./modelerfour-utils";
 
 describe("Modelerfour.Request", () => {
   describe("Body", () => {
     describe("Required attribute", () => {
-      const runModelerWithBody = async (body: any) => {
+      const runModelerWithBody = async (body: RequestBody) => {
         const spec = createTestSpec();
 
         addOperation(spec, "/test", {
@@ -26,7 +28,7 @@ describe("Modelerfour.Request", () => {
         content: {
           "application/octet-stream": {
             schema: {
-              type: "object",
+              type: JsonType.Object,
               format: "file",
             },
           },
@@ -47,6 +49,59 @@ describe("Modelerfour.Request", () => {
         const parameter = await runModelerWithBody(defaultBody);
         expect(parameter?.required).toBe(undefined);
       });
+    });
+  });
+
+  describe("multipart/form-data", () => {
+    let parameters: Parameter[] | undefined;
+
+    beforeEach(async () => {
+      const spec = createTestSpec();
+      const operation: HttpOperation = {
+        requestBody: {
+          content: {
+            "multipart/form-data": {
+              schema: {
+                type: JsonType.Object,
+                properties: {
+                  id: {
+                    type: JsonType.String,
+                  },
+                  address: {
+                    type: JsonType.String,
+                  },
+                },
+              },
+            },
+          },
+        },
+        parameters: [{ in: ParameterLocation.Query, name: "queryParam", schema: { type: JsonType.String } }],
+        responses: { "200": { description: "Ok." } },
+      };
+
+      addOperation(spec, "/test", {
+        post: operation,
+      });
+
+      const codeModel = await runModeler(spec);
+      parameters = codeModel.operationGroups[0]?.operations[0]?.requests?.[0]?.parameters;
+      expect(parameters).not.toBeNull();
+    });
+
+    it("mark body parameter as isInMultipart", async () => {
+      const idParameter = parameters?.[0];
+      const addressParameter = parameters?.[1];
+      expect(idParameter?.language.default.name).toEqual("id");
+      expect(idParameter?.isInMultipart).toBe(true);
+      expect(addressParameter?.language.default.name).toEqual("address");
+      expect(idParameter?.isInMultipart).toBe(true);
+    });
+
+    it("doesn't mark other parameter as isInMultipart", async () => {
+      const queryParam = parameters?.[2];
+
+      expect(queryParam?.language.default.name).toEqual(queryParam);
+      expect(queryParam?.isInMultipart).toBeFalsy();
     });
   });
 });

--- a/packages/extensions/modelerfour/test/utils/specs.ts
+++ b/packages/extensions/modelerfour/test/utils/specs.ts
@@ -1,4 +1,5 @@
 import { clone } from "@azure-tools/linq";
+import * as oai3 from "@azure-tools/openapi";
 
 export const InitialTestSpec = Object.freeze({
   info: {
@@ -30,7 +31,7 @@ export function createTestSpec(...customizers: Array<TestSpecCustomizer>): any {
 export function addOperation(
   spec: any,
   path: string,
-  operationDict: any,
+  operationDict: oai3.PathItem | any,
   metadata: any = { apiVersions: ["1.0.0"] },
 ): void {
   operationDict = { ...operationDict, ...{ "x-ms-metadata": metadata } };

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "ApiVersion": {
-      "description": "- since API version formats range from \nAzure ARM API date style (2018-01-01) to semver (1.2.3) \nand virtually any other text, this value tends to be an \nopaque string with the possibility of a modifier to indicate\nthat it is a range.\n\noptions: \n- prepend a dash or append a plus to indicate a range \n(ie, '2018-01-01+' or '-2019-01-01', or '1.0+' )\n\n- semver-range style (ie, '^1.0.0' or '~1.0.0' )",
+      "description": "- since API version formats range from\nAzure ARM API date style (2018-01-01) to semver (1.2.3)\nand virtually any other text, this value tends to be an\nopaque string with the possibility of a modifier to indicate\nthat it is a range.\n\noptions:\n- prepend a dash or append a plus to indicate a range\n(ie, '2018-01-01+' or '-2019-01-01', or '1.0+' )\n\n- semver-range style (ie, '^1.0.0' or '~1.0.0' )",
       "type": "object",
       "properties": {
         "version": {
@@ -1041,6 +1041,10 @@
         "groupedBy": {
           "$ref": "#/definitions/Parameter",
           "description": "When a parameter is grouped into another, this will tell where the parameter got grouped into."
+        },
+        "isInMultipart": {
+          "description": "If this parameter is to be included in a multipart request body.",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],
@@ -1802,7 +1806,7 @@
           }
         },
         "choices": {
-          "description": "- this is essentially can be thought of as an 'enum' \nthat is a choice between one of several items, but an unspecified value is permitted.",
+          "description": "- this is essentially can be thought of as an 'enum'\nthat is a choice between one of several items, but an unspecified value is permitted.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/ChoiceSchema"
@@ -1860,7 +1864,7 @@
           }
         },
         "unknowns": {
-          "description": "it's possible that we just may make this an error \nin representation.",
+          "description": "it's possible that we just may make this an error\nin representation.",
           "type": "array",
           "items": {
             "$ref": "#/definitions/Schema"
@@ -2214,6 +2218,20 @@
       "defaultProperties": [],
       "additionalProperties": false
     },
+    "HttpMethod": {
+      "description": "standard HTTP protocol methods",
+      "enum": [
+        "delete",
+        "get",
+        "head",
+        "options",
+        "patch",
+        "post",
+        "put",
+        "trace"
+      ],
+      "type": "string"
+    },
     "SerializationStyle": {
       "description": "The Serialization Style used for the parameter.\n\nDescribes how the parameter value will be serialized depending on the type of the parameter value.",
       "enum": [
@@ -2245,20 +2263,6 @@
         "label",
         "matrix",
         "simple"
-      ],
-      "type": "string"
-    },
-    "HttpMethod": {
-      "description": "standard HTTP protocol methods",
-      "enum": [
-        "delete",
-        "get",
-        "head",
-        "options",
-        "patch",
-        "post",
-        "put",
-        "trace"
       ],
       "type": "string"
     },
@@ -2716,7 +2720,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "A relative path to an individual endpoint. \n\nThe field name MUST begin with a slash. \nThe path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. \nPath templating is allowed. \n\nWhen matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.",
+          "description": "A relative path to an individual endpoint.\n\nThe field name MUST begin with a slash.\nThe path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL.\nPath templating is allowed.\n\nWhen matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.",
           "type": "string"
         },
         "uri": {
@@ -2801,7 +2805,7 @@
       "type": "object",
       "properties": {
         "multipart": {
-          "description": "indicates that the HTTP Request should be a multipart request \n\nie, that it has multiple requests in a single request.",
+          "description": "indicates that the HTTP Request should be a multipart request\n\nie, that it has multiple requests in a single request.",
           "type": "boolean",
           "enum": [
             true

--- a/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -1,6 +1,6 @@
 type: object
 description: the model that contains all the information required to generate a service api
-$schema: 'http://json-schema.org/draft-07/schema#'
+$schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false
 definitions:
   APIKeySecurityScheme:
@@ -70,14 +70,14 @@ definitions:
   ApiVersion:
     type: object
     description: |-
-      - since API version formats range from 
-      Azure ARM API date style (2018-01-01) to semver (1.2.3) 
-      and virtually any other text, this value tends to be an 
+      - since API version formats range from
+      Azure ARM API date style (2018-01-01) to semver (1.2.3)
+      and virtually any other text, this value tends to be an
       opaque string with the possibility of a modifier to indicate
       that it is a range.
 
-      options: 
-      - prepend a dash or append a plus to indicate a range 
+      options:
+      - prepend a dash or append a plus to indicate a range
       (ie, '2018-01-01+' or '-2019-01-01', or '1.0+' )
 
       - semver-range style (ie, '^1.0.0' or '~1.0.0' )
@@ -237,7 +237,7 @@ definitions:
       - type
   ChoiceSchema:
     type: object
-    description: 'a schema that represents a choice of several values (ie, an ''enum'')'
+    description: a schema that represents a choice of several values (ie, an 'enum')
     additionalProperties: false
     allOf:
       - $ref: '#/definitions/ValueSchema'
@@ -372,7 +372,7 @@ definitions:
         description: the actual constant value
         $ref: '#/definitions/ConstantValue'
       valueType:
-        description: 'the schema type of the constant value (ie, StringSchema, NumberSchema, etc)'
+        description: the schema type of the constant value (ie, StringSchema, NumberSchema, etc)
         $ref: '#/definitions/Schema'
     required:
       - language
@@ -393,9 +393,9 @@ definitions:
         items:
           $ref: '#/definitions/ApiVersion'
       defaultValue:
-        description: 'If the value isn''t sent on the wire, the service will assume this'
+        description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
         $ref: '#/definitions/Deprecation'
       example:
         description: example information
@@ -404,7 +404,7 @@ definitions:
         $ref: '#/definitions/ExternalDocumentation'
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       serialization:
         description: per-serialization information for this Schema
         $ref: '#/definitions/SerializationFormats'
@@ -583,7 +583,7 @@ definitions:
       - type
   Example:
     type: object
-    description: 'example data [UNFINISHED]'
+    description: example data [UNFINISHED]
     additionalProperties: false
     properties:
       description:
@@ -765,7 +765,7 @@ definitions:
       multipart:
         type: boolean
         description: |-
-          indicates that the HTTP Request should be a multipart request 
+          indicates that the HTTP Request should be a multipart request
 
           ie, that it has multiple requests in a single request.
         enum:
@@ -786,13 +786,13 @@ definitions:
     properties:
       explode:
         type: boolean
-        description: 'when set, ''form'' style parameters generate separate parameters for each value of an array.'
+        description: when set, 'form' style parameters generate separate parameters for each value of an array.
       in:
         description: the location that this parameter is placed in the http request
         $ref: '#/definitions/ParameterLocation'
       skipUriEncoding:
         type: boolean
-        description: 'when set, this indicates that the content of the parameter should not be subject to URI encoding rules.'
+        description: when set, this indicates that the content of the parameter should not be subject to URI encoding rules.
       style:
         description: the Serialization Style used for the parameter.
         $ref: '#/definitions/SerializationStyle'
@@ -808,11 +808,11 @@ definitions:
       path:
         type: string
         description: |-
-          A relative path to an individual endpoint. 
+          A relative path to an individual endpoint.
 
-          The field name MUST begin with a slash. 
-          The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. 
-          Path templating is allowed. 
+          The field name MUST begin with a slash.
+          The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL.
+          Path templating is allowed.
 
           When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.
       method:
@@ -842,7 +842,7 @@ definitions:
         items:
           $ref: '#/definitions/HttpHeader'
       knownMediaType:
-        description: 'canonical response type (ie, ''json'')'
+        description: canonical response type (ie, 'json')
         $ref: '#/definitions/KnownMediaType'
       mediaTypes:
         type: array
@@ -929,7 +929,7 @@ definitions:
       - $ref: '#/definitions/HttpRequest'
     properties:
       knownMediaType:
-        description: 'a normalized value for the media type (ie, distills down to a well-known moniker (ie, ''json''))'
+        description: a normalized value for the media type (ie, distills down to a well-known moniker (ie, 'json'))
         $ref: '#/definitions/KnownMediaType'
       mediaTypes:
         type: array
@@ -1129,22 +1129,22 @@ definitions:
     properties:
       exclusiveMaximum:
         type: boolean
-        description: 'if present, the value must be lower than maximum'
+        description: if present, the value must be lower than maximum
       exclusiveMinimum:
         type: boolean
-        description: 'if present, the value must be higher than minimum'
+        description: if present, the value must be higher than minimum
       maximum:
         type: number
-        description: 'if present, the value must be lower than or equal to this (unless exclusiveMaximum is true)'
+        description: if present, the value must be lower than or equal to this (unless exclusiveMaximum is true)
       minimum:
         type: number
-        description: 'if present, the value must be highter than or equal to this (unless exclusiveMinimum is true)'
+        description: if present, the value must be highter than or equal to this (unless exclusiveMinimum is true)
       multipleOf:
         type: number
-        description: 'if present, the number must be an exact multiple of this value'
+        description: if present, the number must be an exact multiple of this value
       precision:
         type: number
-        description: 'precision (# of bits?) of the number'
+        description: precision (# of bits?) of the number
     required:
       - language
       - precision
@@ -1204,7 +1204,7 @@ definitions:
       children:
         $ref: '#/definitions/Relations'
       discriminator:
-        description: 'the property of the polymorphic descriminator for this type, if there is one'
+        description: the property of the polymorphic descriminator for this type, if there is one
         $ref: '#/definitions/Discriminator'
       discriminatorValue:
         type: string
@@ -1252,7 +1252,7 @@ definitions:
       - type
   Operation:
     type: object
-    description: 'represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)'
+    description: represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)
     additionalProperties: false
     properties:
       apiVersions:
@@ -1261,7 +1261,7 @@ definitions:
         items:
           $ref: '#/definitions/ApiVersion'
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
         $ref: '#/definitions/Deprecation'
       exceptions:
         type: array
@@ -1273,7 +1273,7 @@ definitions:
         $ref: '#/definitions/ExternalDocumentation'
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       parameters:
         type: array
         description: common parameters when there are multiple requests
@@ -1356,13 +1356,16 @@ definitions:
     properties:
       flattened:
         type: boolean
-        description: 'When a parameter is flattened, it will be left in the list, but marked hidden (so, don''t generate those!)'
+        description: When a parameter is flattened, it will be left in the list, but marked hidden (so, don't generate those!)
       groupedBy:
-        description: 'When a parameter is grouped into another, this will tell where the parameter got grouped into.'
+        description: When a parameter is grouped into another, this will tell where the parameter got grouped into.
         $ref: '#/definitions/Parameter'
       implementation:
         description: suggested implementation location for this parameter
         $ref: '#/definitions/ImplementationLocation'
+      isInMultipart:
+        type: boolean
+        description: If this parameter is to be included in a multipart request body.
     required:
       - language
       - protocol
@@ -1451,7 +1454,7 @@ definitions:
         description: if this property is used as a discriminator for a polymorphic type
       readOnly:
         type: boolean
-        description: 'if the property is marked read-only (ie, not intended to be sent to the service)'
+        description: if the property is marked read-only (ie, not intended to be sent to the service)
       serializedName:
         type: string
         description: the wire name of this property
@@ -1466,7 +1469,7 @@ definitions:
     additionalProperties: false
   Protocols:
     type: object
-    description: 'custom extensible metadata for individual protocols (ie, HTTP, etc)'
+    description: custom extensible metadata for individual protocols (ie, HTTP, etc)
     additionalProperties: false
     properties:
       amqp:
@@ -1540,9 +1543,9 @@ definitions:
         items:
           $ref: '#/definitions/ApiVersion'
       defaultValue:
-        description: 'If the value isn''t sent on the wire, the service will assume this'
+        description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
         $ref: '#/definitions/Deprecation'
       example:
         description: example information
@@ -1551,7 +1554,7 @@ definitions:
         $ref: '#/definitions/ExternalDocumentation'
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       serialization:
         description: per-serialization information for this Schema
         $ref: '#/definitions/SerializationFormats'
@@ -1645,7 +1648,7 @@ definitions:
           $ref: '#/definitions/SchemaContext'
   Schemas:
     type: object
-    description: 'the full set of schemas for a given service, categorized into convenient collections'
+    description: the full set of schemas for a given service, categorized into convenient collections
     additionalProperties: false
     properties:
       any:
@@ -1679,13 +1682,13 @@ definitions:
       choices:
         type: array
         description: |-
-          - this is essentially can be thought of as an 'enum' 
+          - this is essentially can be thought of as an 'enum'
           that is a choice between one of several items, but an unspecified value is permitted.
         items:
           $ref: '#/definitions/ChoiceSchema'
       conditionals:
         type: array
-        description: 'ie, when ''profile'' is ''production'', use ''2018-01-01'' for apiversion'
+        description: ie, when 'profile' is 'production', use '2018-01-01' for apiversion
         items:
           $ref: '#/definitions/ConditionalSchema'
       constants:
@@ -1710,7 +1713,7 @@ definitions:
           $ref: '#/definitions/DateSchema'
       dictionaries:
         type: array
-        description: 'an associative array (ie, dictionary, hashtable, etc)'
+        description: an associative array (ie, dictionary, hashtable, etc)
         items:
           $ref: '#/definitions/DictionarySchema'
       durations:
@@ -1778,7 +1781,7 @@ definitions:
       unknowns:
         type: array
         description: |-
-          it's possible that we just may make this an error 
+          it's possible that we just may make this an error
           in representation.
         items:
           $ref: '#/definitions/Schema'
@@ -1802,7 +1805,7 @@ definitions:
       - bearer
   SealedChoiceSchema:
     type: object
-    description: 'a schema that represents a choice of several values (ie, an ''enum'')'
+    description: a schema that represents a choice of several values (ie, an 'enum')
     additionalProperties: false
     allOf:
       - $ref: '#/definitions/ValueSchema'
@@ -2050,7 +2053,7 @@ definitions:
       - type
   Value:
     type: object
-    description: 'common base interface for properties, parameters and the like.'
+    description: common base interface for properties, parameters and the like.
     additionalProperties: false
     properties:
       schema:
@@ -2066,7 +2069,7 @@ definitions:
       clientDefaultValue:
         description: the value that the client should provide if the consumer doesn't provide one
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
         $ref: '#/definitions/Deprecation'
       externalDocs:
         description: External Documentation Links
@@ -2076,7 +2079,7 @@ definitions:
         description: can null be passed in instead
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       required:
         type: boolean
         description: if the value is marked 'required'.
@@ -2140,7 +2143,7 @@ definitions:
         $ref: '#/definitions/Parameter'
       pathToProperty:
         type: array
-        description: 'if this parameter is for a nested property, this is the path of properties it takes to get there'
+        description: if this parameter is for a nested property, this is the path of properties it takes to get there
         items:
           $ref: '#/definitions/Property'
       targetProperty:
@@ -2203,7 +2206,7 @@ properties:
     $ref: '#/definitions/Schemas'
   globalParameters:
     type: array
-    description: 'all global parameters (ie, ImplementationLocation = client )'
+    description: all global parameters (ie, ImplementationLocation = client )
     items:
       $ref: '#/definitions/Parameter'
   info:

--- a/packages/libs/codemodel/.resources/model/json/enums.json
+++ b/packages/libs/codemodel/.resources/model/json/enums.json
@@ -54,6 +54,20 @@
       ],
       "type": "string"
     },
+    "HttpMethod": {
+      "description": "standard HTTP protocol methods",
+      "enum": [
+        "delete",
+        "get",
+        "head",
+        "options",
+        "patch",
+        "post",
+        "put",
+        "trace"
+      ],
+      "type": "string"
+    },
     "SerializationStyle": {
       "description": "The Serialization Style used for the parameter.\n\nDescribes how the parameter value will be serialized depending on the type of the parameter value.",
       "enum": [
@@ -85,20 +99,6 @@
         "label",
         "matrix",
         "simple"
-      ],
-      "type": "string"
-    },
-    "HttpMethod": {
-      "description": "standard HTTP protocol methods",
-      "enum": [
-        "delete",
-        "get",
-        "head",
-        "options",
-        "patch",
-        "post",
-        "put",
-        "trace"
       ],
       "type": "string"
     },

--- a/packages/libs/codemodel/.resources/model/json/http.json
+++ b/packages/libs/codemodel/.resources/model/json/http.json
@@ -351,7 +351,7 @@
       "type": "object",
       "properties": {
         "path": {
-          "description": "A relative path to an individual endpoint. \n\nThe field name MUST begin with a slash. \nThe path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. \nPath templating is allowed. \n\nWhen matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.",
+          "description": "A relative path to an individual endpoint.\n\nThe field name MUST begin with a slash.\nThe path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL.\nPath templating is allowed.\n\nWhen matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.",
           "type": "string"
         },
         "uri": {
@@ -436,7 +436,7 @@
       "type": "object",
       "properties": {
         "multipart": {
-          "description": "indicates that the HTTP Request should be a multipart request \n\nie, that it has multiple requests in a single request.",
+          "description": "indicates that the HTTP Request should be a multipart request\n\nie, that it has multiple requests in a single request.",
           "type": "boolean",
           "enum": [
             true

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
     "ApiVersion": {
-      "description": "- since API version formats range from \nAzure ARM API date style (2018-01-01) to semver (1.2.3) \nand virtually any other text, this value tends to be an \nopaque string with the possibility of a modifier to indicate\nthat it is a range.\n\noptions: \n- prepend a dash or append a plus to indicate a range \n(ie, '2018-01-01+' or '-2019-01-01', or '1.0+' )\n\n- semver-range style (ie, '^1.0.0' or '~1.0.0' )",
+      "description": "- since API version formats range from\nAzure ARM API date style (2018-01-01) to semver (1.2.3)\nand virtually any other text, this value tends to be an\nopaque string with the possibility of a modifier to indicate\nthat it is a range.\n\noptions:\n- prepend a dash or append a plus to indicate a range\n(ie, '2018-01-01+' or '-2019-01-01', or '1.0+' )\n\n- semver-range style (ie, '^1.0.0' or '~1.0.0' )",
       "type": "object",
       "properties": {
         "version": {
@@ -406,6 +406,10 @@
         "groupedBy": {
           "$ref": "./master.json#/definitions/Parameter",
           "description": "When a parameter is grouped into another, this will tell where the parameter got grouped into."
+        },
+        "isInMultipart": {
+          "description": "If this parameter is to be included in a multipart request body.",
+          "type": "boolean"
         }
       },
       "defaultProperties": [],

--- a/packages/libs/codemodel/.resources/model/json/schemas.json
+++ b/packages/libs/codemodel/.resources/model/json/schemas.json
@@ -939,7 +939,7 @@
           }
         },
         "choices": {
-          "description": "- this is essentially can be thought of as an 'enum' \nthat is a choice between one of several items, but an unspecified value is permitted.",
+          "description": "- this is essentially can be thought of as an 'enum'\nthat is a choice between one of several items, but an unspecified value is permitted.",
           "type": "array",
           "items": {
             "$ref": "./schemas.json#/definitions/ChoiceSchema"
@@ -997,7 +997,7 @@
           }
         },
         "unknowns": {
-          "description": "it's possible that we just may make this an error \nin representation.",
+          "description": "it's possible that we just may make this an error\nin representation.",
           "type": "array",
           "items": {
             "$ref": "./schemas.json#/definitions/Schema"

--- a/packages/libs/codemodel/.resources/model/yaml/enums.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/enums.yaml
@@ -1,4 +1,4 @@
-$schema: 'http://json-schema.org/draft-07/schema#'
+$schema: http://json-schema.org/draft-07/schema#
 definitions:
   Default:
     type: string

--- a/packages/libs/codemodel/.resources/model/yaml/http.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/http.yaml
@@ -1,4 +1,4 @@
-$schema: 'http://json-schema.org/draft-07/schema#'
+$schema: http://json-schema.org/draft-07/schema#
 definitions:
   APIKeySecurityScheme:
     type: object
@@ -13,10 +13,10 @@ definitions:
       description:
         type: string
       in:
-        $ref: './enums.yaml#/definitions/ParameterLocation'
+        $ref: ./enums.yaml#/definitions/ParameterLocation
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - in
       - name
@@ -32,13 +32,13 @@ definitions:
         type: string
         description: an URI
       scopes:
-        $ref: './master.yaml#/definitions/Dictionary<string>'
+        $ref: ./master.yaml#/definitions/Dictionary<string>
       tokenUrl:
         type: string
         description: an URI
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - authorizationUrl
       - scopes
@@ -61,7 +61,7 @@ definitions:
           - bearer
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - scheme
       - type
@@ -73,25 +73,25 @@ definitions:
         type: string
         description: an URI
       scopes:
-        $ref: './master.yaml#/definitions/Dictionary<string>'
+        $ref: ./master.yaml#/definitions/Dictionary<string>
       tokenUrl:
         type: string
         description: an URI
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - scopes
       - tokenUrl
   HTTPSecurityScheme:
     anyOf:
-      - $ref: './http.yaml#/definitions/BearerHTTPSecurityScheme'
-      - $ref: './http.yaml#/definitions/NonBearerHTTPSecurityScheme'
+      - $ref: ./http.yaml#/definitions/BearerHTTPSecurityScheme
+      - $ref: ./http.yaml#/definitions/NonBearerHTTPSecurityScheme
   HttpBinaryRequest:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './http.yaml#/definitions/HttpWithBodyRequest'
+      - $ref: ./http.yaml#/definitions/HttpWithBodyRequest
     properties:
       binary:
         type: boolean
@@ -108,7 +108,7 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './http.yaml#/definitions/HttpResponse'
+      - $ref: ./http.yaml#/definitions/HttpResponse
     properties:
       binary:
         type: boolean
@@ -125,14 +125,14 @@ definitions:
     additionalProperties: false
     properties:
       schema:
-        $ref: './schemas.yaml#/definitions/Schema'
+        $ref: ./schemas.yaml#/definitions/Schema
       header:
         type: string
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
     required:
       - header
       - language
@@ -142,23 +142,23 @@ definitions:
     description: code model metadata for HTTP protocol
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Protocol'
+      - $ref: ./master.yaml#/definitions/Protocol
     properties:
       security:
         type: array
         description: a collection of security requirements for the service
         items:
-          $ref: './http.yaml#/definitions/SecurityRequirement'
+          $ref: ./http.yaml#/definitions/SecurityRequirement
   HttpMultipartRequest:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './http.yaml#/definitions/HttpWithBodyRequest'
+      - $ref: ./http.yaml#/definitions/HttpWithBodyRequest
     properties:
       multipart:
         type: boolean
         description: |-
-          indicates that the HTTP Request should be a multipart request 
+          indicates that the HTTP Request should be a multipart request
 
           ie, that it has multiple requests in a single request.
         enum:
@@ -175,20 +175,20 @@ definitions:
     description: extended metadata for HTTP operation parameters
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Protocol'
+      - $ref: ./master.yaml#/definitions/Protocol
     properties:
       explode:
         type: boolean
-        description: 'when set, ''form'' style parameters generate separate parameters for each value of an array.'
+        description: when set, 'form' style parameters generate separate parameters for each value of an array.
       in:
         description: the location that this parameter is placed in the http request
-        $ref: './enums.yaml#/definitions/ParameterLocation'
+        $ref: ./enums.yaml#/definitions/ParameterLocation
       skipUriEncoding:
         type: boolean
-        description: 'when set, this indicates that the content of the parameter should not be subject to URI encoding rules.'
+        description: when set, this indicates that the content of the parameter should not be subject to URI encoding rules.
       style:
         description: the Serialization Style used for the parameter.
-        $ref: './enums.yaml#/definitions/SerializationStyle'
+        $ref: ./enums.yaml#/definitions/SerializationStyle
     required:
       - in
   HttpRequest:
@@ -196,21 +196,21 @@ definitions:
     description: HTTP operation protocol data
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Protocol'
+      - $ref: ./master.yaml#/definitions/Protocol
     properties:
       path:
         type: string
         description: |-
-          A relative path to an individual endpoint. 
+          A relative path to an individual endpoint.
 
-          The field name MUST begin with a slash. 
-          The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL. 
-          Path templating is allowed. 
+          The field name MUST begin with a slash.
+          The path is appended (no relative URL resolution) to the expanded URL from the Server Object's url field in order to construct the full URL.
+          Path templating is allowed.
 
           When matching URLs, concrete (non-templated) paths would be matched before their templated counterparts.
       method:
         description: the HTTP Method used to process this operation
-        $ref: './enums.yaml#/definitions/HttpMethod'
+        $ref: ./enums.yaml#/definitions/HttpMethod
       uri:
         type: string
         description: the base URI template for the operation. This will be a template that has Uri parameters to craft the base url to use.
@@ -222,21 +222,21 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Protocol'
+      - $ref: ./master.yaml#/definitions/Protocol
     properties:
       headerGroups:
         type: array
         description: sets of HTTP headers grouped together into a single schema
         items:
-          $ref: './schemas.yaml#/definitions/GroupSchema'
+          $ref: ./schemas.yaml#/definitions/GroupSchema
       headers:
         type: array
         description: content returned by the service in the HTTP headers
         items:
-          $ref: './http.yaml#/definitions/HttpHeader'
+          $ref: ./http.yaml#/definitions/HttpHeader
       knownMediaType:
-        description: 'canonical response type (ie, ''json'')'
-        $ref: './enums.yaml#/definitions/KnownMediaType'
+        description: canonical response type (ie, 'json')
+        $ref: ./enums.yaml#/definitions/KnownMediaType
       mediaTypes:
         type: array
         description: the possible media types that this response MUST match one of
@@ -319,11 +319,11 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './http.yaml#/definitions/HttpRequest'
+      - $ref: ./http.yaml#/definitions/HttpRequest
     properties:
       knownMediaType:
-        description: 'a normalized value for the media type (ie, distills down to a well-known moniker (ie, ''json''))'
-        $ref: './enums.yaml#/definitions/KnownMediaType'
+        description: a normalized value for the media type (ie, distills down to a well-known moniker (ie, 'json'))
+        $ref: ./enums.yaml#/definitions/KnownMediaType
       mediaTypes:
         type: array
         description: must contain at least one media type to send for the body
@@ -346,10 +346,10 @@ definitions:
         type: string
         description: an URI
       scopes:
-        $ref: './master.yaml#/definitions/Dictionary<string>'
+        $ref: ./master.yaml#/definitions/Dictionary<string>
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - authorizationUrl
       - scopes
@@ -367,7 +367,7 @@ definitions:
         type: string
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - scheme
       - type
@@ -382,10 +382,10 @@ definitions:
       description:
         type: string
       flows:
-        $ref: './http.yaml#/definitions/OAuthFlows'
+        $ref: ./http.yaml#/definitions/OAuthFlows
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - flows
       - type
@@ -394,16 +394,16 @@ definitions:
     additionalProperties: false
     properties:
       authorizationCode:
-        $ref: './http.yaml#/definitions/AuthorizationCodeOAuthFlow'
+        $ref: ./http.yaml#/definitions/AuthorizationCodeOAuthFlow
       clientCredentials:
-        $ref: './http.yaml#/definitions/ClientCredentialsFlow'
+        $ref: ./http.yaml#/definitions/ClientCredentialsFlow
       implicit:
-        $ref: './http.yaml#/definitions/ImplicitOAuthFlow'
+        $ref: ./http.yaml#/definitions/ImplicitOAuthFlow
       password:
-        $ref: './http.yaml#/definitions/PasswordOAuthFlow'
+        $ref: ./http.yaml#/definitions/PasswordOAuthFlow
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
   OpenIdConnectSecurityScheme:
     type: object
     additionalProperties: false
@@ -419,7 +419,7 @@ definitions:
         description: an URI
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - openIdConnectUrl
       - type
@@ -431,13 +431,13 @@ definitions:
         type: string
         description: an URI
       scopes:
-        $ref: './master.yaml#/definitions/Dictionary<string>'
+        $ref: ./master.yaml#/definitions/Dictionary<string>
       tokenUrl:
         type: string
         description: an URI
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - scopes
       - tokenUrl
@@ -447,8 +447,8 @@ definitions:
     additionalProperties: false
   SecurityScheme:
     anyOf:
-      - $ref: './http.yaml#/definitions/BearerHTTPSecurityScheme'
-      - $ref: './http.yaml#/definitions/NonBearerHTTPSecurityScheme'
-      - $ref: './http.yaml#/definitions/OAuth2SecurityScheme'
-      - $ref: './http.yaml#/definitions/APIKeySecurityScheme'
-      - $ref: './http.yaml#/definitions/OpenIdConnectSecurityScheme'
+      - $ref: ./http.yaml#/definitions/BearerHTTPSecurityScheme
+      - $ref: ./http.yaml#/definitions/NonBearerHTTPSecurityScheme
+      - $ref: ./http.yaml#/definitions/OAuth2SecurityScheme
+      - $ref: ./http.yaml#/definitions/APIKeySecurityScheme
+      - $ref: ./http.yaml#/definitions/OpenIdConnectSecurityScheme

--- a/packages/libs/codemodel/.resources/model/yaml/master.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/master.yaml
@@ -1,19 +1,19 @@
 type: object
 description: the model that contains all the information required to generate a service api
-$schema: 'http://json-schema.org/draft-07/schema#'
+$schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false
 definitions:
   ApiVersion:
     type: object
     description: |-
-      - since API version formats range from 
-      Azure ARM API date style (2018-01-01) to semver (1.2.3) 
-      and virtually any other text, this value tends to be an 
+      - since API version formats range from
+      Azure ARM API date style (2018-01-01) to semver (1.2.3)
+      and virtually any other text, this value tends to be an
       opaque string with the possibility of a modifier to indicate
       that it is a range.
 
-      options: 
-      - prepend a dash or append a plus to indicate a range 
+      options:
+      - prepend a dash or append a plus to indicate a range
       (ie, '2018-01-01+' or '-2019-01-01', or '1.0+' )
 
       - semver-range style (ie, '^1.0.0' or '~1.0.0' )
@@ -33,13 +33,13 @@ definitions:
     type: array
     description: a collection of api versions
     items:
-      $ref: './master.yaml#/definitions/ApiVersion'
+      $ref: ./master.yaml#/definitions/ApiVersion
   BinaryResponse:
     type: object
     description: a response where the content should be treated as a binary instead of a value or object
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Response'
+      - $ref: ./master.yaml#/definitions/Response
     properties:
       binary:
         type: boolean
@@ -72,10 +72,10 @@ definitions:
         description: the actual value
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for this value
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
     required:
       - language
       - source
@@ -94,7 +94,7 @@ definitions:
         description: an URI
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
   Deprecation:
     type: object
     description: represents  deprecation information for a given aspect
@@ -104,7 +104,7 @@ definitions:
         type: array
         description: the api versions that this deprecation is applicable to.
         items:
-          $ref: './master.yaml#/definitions/ApiVersion'
+          $ref: ./master.yaml#/definitions/ApiVersion
       message:
         type: string
         description: the reason why this aspect
@@ -114,11 +114,11 @@ definitions:
   Dictionary<ApiVersion>:
     type: object
     additionalProperties:
-      $ref: './master.yaml#/definitions/ApiVersion'
+      $ref: ./master.yaml#/definitions/ApiVersion
   Dictionary<ComplexSchema>:
     type: object
     additionalProperties:
-      $ref: './schemas.yaml#/definitions/ComplexSchema'
+      $ref: ./schemas.yaml#/definitions/ComplexSchema
   Dictionary<any>:
     type: object
     additionalProperties:
@@ -132,18 +132,18 @@ definitions:
     additionalProperties: false
     properties:
       all:
-        $ref: './master.yaml#/definitions/Dictionary<ComplexSchema>'
+        $ref: ./master.yaml#/definitions/Dictionary<ComplexSchema>
       immediate:
-        $ref: './master.yaml#/definitions/Dictionary<ComplexSchema>'
+        $ref: ./master.yaml#/definitions/Dictionary<ComplexSchema>
       property:
-        $ref: './master.yaml#/definitions/Property'
+        $ref: ./master.yaml#/definitions/Property
     required:
       - all
       - immediate
       - property
   Example:
     type: object
-    description: 'example data [UNFINISHED]'
+    description: example data [UNFINISHED]
     additionalProperties: false
     properties:
       description:
@@ -160,7 +160,7 @@ definitions:
     properties:
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
   ExternalDocumentation:
     type: object
     description: a reference to external documentation
@@ -173,7 +173,7 @@ definitions:
         description: an URI
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - url
   FlagValue:
@@ -184,10 +184,10 @@ definitions:
         type: number
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for this value
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
     required:
       - language
       - value
@@ -195,12 +195,12 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Property'
+      - $ref: ./master.yaml#/definitions/Property
     properties:
       originalParameter:
         type: array
         items:
-          $ref: './master.yaml#/definitions/Parameter'
+          $ref: ./master.yaml#/definitions/Parameter
     required:
       - language
       - originalParameter
@@ -217,13 +217,13 @@ definitions:
         description: a text description of the service
       contact:
         description: contact information for the service
-        $ref: './master.yaml#/definitions/Contact'
+        $ref: ./master.yaml#/definitions/Contact
       externalDocs:
         description: External Documentation
-        $ref: './master.yaml#/definitions/ExternalDocumentation'
+        $ref: ./master.yaml#/definitions/ExternalDocumentation
       license:
         description: license information for th service
-        $ref: './master.yaml#/definitions/License'
+        $ref: ./master.yaml#/definitions/License
       termsOfService:
         type: string
         description: an uri to the terms of service specified to access the service
@@ -232,7 +232,7 @@ definitions:
         description: the title of this service.
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - title
   Language:
@@ -256,33 +256,33 @@ definitions:
     additionalProperties: false
     properties:
       default:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       c:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       cpp:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       csharp:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       go:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       java:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       javascript:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       objectivec:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       powershell:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       python:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       ruby:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       sputnik:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       swift:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
       typescript:
-        $ref: './master.yaml#/definitions/Language'
+        $ref: ./master.yaml#/definitions/Language
     required:
       - default
   License:
@@ -298,7 +298,7 @@ definitions:
         description: an uri pointing to the full license text
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
     required:
       - name
   Metadata:
@@ -308,75 +308,75 @@ definitions:
     properties:
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for this aspect
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
       protocol:
         description: per-protocol information for this aspect
-        $ref: './master.yaml#/definitions/Protocols'
+        $ref: ./master.yaml#/definitions/Protocols
     required:
       - language
       - protocol
   Operation:
     type: object
-    description: 'represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)'
+    description: represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)
     additionalProperties: false
     properties:
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions
         items:
-          $ref: './master.yaml#/definitions/ApiVersion'
+          $ref: ./master.yaml#/definitions/ApiVersion
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
-        $ref: './master.yaml#/definitions/Deprecation'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
+        $ref: ./master.yaml#/definitions/Deprecation
       exceptions:
         type: array
         description: responses that indicate a failed call
         items:
-          $ref: './master.yaml#/definitions/Response'
+          $ref: ./master.yaml#/definitions/Response
       externalDocs:
         description: External Documentation Links
-        $ref: './master.yaml#/definitions/ExternalDocumentation'
+        $ref: ./master.yaml#/definitions/ExternalDocumentation
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       parameters:
         type: array
         description: common parameters when there are multiple requests
         items:
-          $ref: './master.yaml#/definitions/Parameter'
+          $ref: ./master.yaml#/definitions/Parameter
       profile:
         description: the apiVersion to use for a given profile name
-        $ref: './master.yaml#/definitions/Dictionary<ApiVersion>'
+        $ref: ./master.yaml#/definitions/Dictionary<ApiVersion>
       requests:
         type: array
         description: the different possibilities to build the request.
         items:
-          $ref: './master.yaml#/definitions/Request'
+          $ref: ./master.yaml#/definitions/Request
       responses:
         type: array
         description: responses that indicate a successful call
         items:
-          $ref: './master.yaml#/definitions/Response'
+          $ref: ./master.yaml#/definitions/Response
       signatureParameters:
         type: array
         description: a common filtered list of parameters that is (assumably) the actual method signature parameters
         items:
-          $ref: './master.yaml#/definitions/Parameter'
+          $ref: ./master.yaml#/definitions/Parameter
       summary:
         type: string
         description: a short description
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for this aspect
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
       protocol:
         description: per-protocol information for this aspect
-        $ref: './master.yaml#/definitions/Protocols'
+        $ref: ./master.yaml#/definitions/Protocols
     required:
       - language
       - protocol
@@ -385,14 +385,14 @@ definitions:
     description: an operation group represents a container around set of operations
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Metadata'
+      - $ref: ./master.yaml#/definitions/Metadata
     properties:
       $key:
         type: string
       operations:
         type: array
         items:
-          $ref: './master.yaml#/definitions/Operation'
+          $ref: ./master.yaml#/definitions/Operation
     required:
       - $key
       - language
@@ -403,17 +403,20 @@ definitions:
     description: a definition of an discrete input for an operation
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Value'
+      - $ref: ./master.yaml#/definitions/Value
     properties:
       flattened:
         type: boolean
-        description: 'When a parameter is flattened, it will be left in the list, but marked hidden (so, don''t generate those!)'
+        description: When a parameter is flattened, it will be left in the list, but marked hidden (so, don't generate those!)
       groupedBy:
-        description: 'When a parameter is grouped into another, this will tell where the parameter got grouped into.'
-        $ref: './master.yaml#/definitions/Parameter'
+        description: When a parameter is grouped into another, this will tell where the parameter got grouped into.
+        $ref: ./master.yaml#/definitions/Parameter
       implementation:
         description: suggested implementation location for this parameter
-        $ref: './enums.yaml#/definitions/ImplementationLocation'
+        $ref: ./enums.yaml#/definitions/ImplementationLocation
+      isInMultipart:
+        type: boolean
+        description: If this parameter is to be included in a multipart request body.
     required:
       - language
       - protocol
@@ -423,7 +426,7 @@ definitions:
     description: a property is a child value in an object
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Value'
+      - $ref: ./master.yaml#/definitions/Value
     properties:
       flattenedNames:
         type: array
@@ -440,7 +443,7 @@ definitions:
         description: if this property is used as a discriminator for a polymorphic type
       readOnly:
         type: boolean
-        description: 'if the property is marked read-only (ie, not intended to be sent to the service)'
+        description: if the property is marked read-only (ie, not intended to be sent to the service)
       serializedName:
         type: string
         description: the wire name of this property
@@ -455,17 +458,17 @@ definitions:
     additionalProperties: false
   Protocols:
     type: object
-    description: 'custom extensible metadata for individual protocols (ie, HTTP, etc)'
+    description: custom extensible metadata for individual protocols (ie, HTTP, etc)
     additionalProperties: false
     properties:
       amqp:
-        $ref: './master.yaml#/definitions/Protocol'
+        $ref: ./master.yaml#/definitions/Protocol
       jsonrpc:
-        $ref: './master.yaml#/definitions/Protocol'
+        $ref: ./master.yaml#/definitions/Protocol
       mqtt:
-        $ref: './master.yaml#/definitions/Protocol'
+        $ref: ./master.yaml#/definitions/Protocol
       http:
-        $ref: './master.yaml#/definitions/Protocol'
+        $ref: ./master.yaml#/definitions/Protocol
   Relations:
     type: object
     additionalProperties: false
@@ -473,11 +476,11 @@ definitions:
       all:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/ComplexSchema'
+          $ref: ./schemas.yaml#/definitions/ComplexSchema
       immediate:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/ComplexSchema'
+          $ref: ./schemas.yaml#/definitions/ComplexSchema
     required:
       - all
       - immediate
@@ -485,18 +488,18 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Metadata'
+      - $ref: ./master.yaml#/definitions/Metadata
     properties:
       parameters:
         type: array
         description: the parameter inputs to the operation
         items:
-          $ref: './master.yaml#/definitions/Parameter'
+          $ref: ./master.yaml#/definitions/Parameter
       signatureParameters:
         type: array
         description: a filtered list of parameters that is (assumably) the actual method signature parameters
         items:
-          $ref: './master.yaml#/definitions/Parameter'
+          $ref: ./master.yaml#/definitions/Parameter
     required:
       - language
       - protocol
@@ -505,7 +508,7 @@ definitions:
     description: a response from a service.
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Metadata'
+      - $ref: ./master.yaml#/definitions/Metadata
     required:
       - language
       - protocol
@@ -514,11 +517,11 @@ definitions:
     description: a response that should be deserialized into a result of type(schema)
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Response'
+      - $ref: ./master.yaml#/definitions/Response
     properties:
       schema:
         description: the content returned by the service for a given operaiton
-        $ref: './schemas.yaml#/definitions/Schema'
+        $ref: ./schemas.yaml#/definitions/Schema
       nullable:
         type: boolean
         description: indicates whether the response can be 'null'
@@ -534,12 +537,12 @@ definitions:
         type: array
         description: Known media types in which this schema can be serialized
         items:
-          $ref: './enums.yaml#/definitions/KnownMediaType'
+          $ref: ./enums.yaml#/definitions/KnownMediaType
       usage:
         type: array
         description: contexts in which the schema is used
         items:
-          $ref: './schemas.yaml#/definitions/SchemaContext'
+          $ref: ./schemas.yaml#/definitions/SchemaContext
   Security:
     type: object
     description: The security information for the API surface
@@ -556,49 +559,49 @@ definitions:
     properties:
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
   SerializationFormats:
     type: object
     description: custom extensible metadata for individual serialization formats
     additionalProperties: false
     properties:
       binary:
-        $ref: './master.yaml#/definitions/SerializationFormat'
+        $ref: ./master.yaml#/definitions/SerializationFormat
       json:
-        $ref: './master.yaml#/definitions/SerializationFormat'
+        $ref: ./master.yaml#/definitions/SerializationFormat
       protobuf:
-        $ref: './master.yaml#/definitions/SerializationFormat'
+        $ref: ./master.yaml#/definitions/SerializationFormat
       xml:
-        $ref: './master.yaml#/definitions/XmlSerlializationFormat'
+        $ref: ./master.yaml#/definitions/XmlSerlializationFormat
   Value:
     type: object
-    description: 'common base interface for properties, parameters and the like.'
+    description: common base interface for properties, parameters and the like.
     additionalProperties: false
     properties:
       schema:
         description: the schema of this Value
-        $ref: './schemas.yaml#/definitions/Schema'
+        $ref: ./schemas.yaml#/definitions/Schema
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions
         items:
-          $ref: './master.yaml#/definitions/ApiVersion'
+          $ref: ./master.yaml#/definitions/ApiVersion
       assumedValue:
         description: the value that the remote will assume if this value is not present
       clientDefaultValue:
         description: the value that the client should provide if the consumer doesn't provide one
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
-        $ref: './master.yaml#/definitions/Deprecation'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
+        $ref: ./master.yaml#/definitions/Deprecation
       externalDocs:
         description: External Documentation Links
-        $ref: './master.yaml#/definitions/ExternalDocumentation'
+        $ref: ./master.yaml#/definitions/ExternalDocumentation
       nullable:
         type: boolean
         description: can null be passed in instead
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       required:
         type: boolean
         description: if the value is marked 'required'.
@@ -607,13 +610,13 @@ definitions:
         description: a short description
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for this aspect
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
       protocol:
         description: per-protocol information for this aspect
-        $ref: './master.yaml#/definitions/Protocols'
+        $ref: ./master.yaml#/definitions/Protocols
     required:
       - language
       - protocol
@@ -622,19 +625,19 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/Parameter'
+      - $ref: ./master.yaml#/definitions/Parameter
     properties:
       originalParameter:
         description: the original body parameter that this parameter is in effect replacing
-        $ref: './master.yaml#/definitions/Parameter'
+        $ref: ./master.yaml#/definitions/Parameter
       pathToProperty:
         type: array
-        description: 'if this parameter is for a nested property, this is the path of properties it takes to get there'
+        description: if this parameter is for a nested property, this is the path of properties it takes to get there
         items:
-          $ref: './master.yaml#/definitions/Property'
+          $ref: ./master.yaml#/definitions/Property
       targetProperty:
         description: the target property this virtual parameter represents
-        $ref: './master.yaml#/definitions/Property'
+        $ref: ./master.yaml#/definitions/Property
     required:
       - language
       - originalParameter
@@ -646,7 +649,7 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './master.yaml#/definitions/SerializationFormat'
+      - $ref: ./master.yaml#/definitions/SerializationFormat
     properties:
       name:
         type: string
@@ -672,31 +675,31 @@ definitions:
 properties:
   schemas:
     description: All schemas for the model
-    $ref: './schemas.yaml#/definitions/Schemas'
+    $ref: ./schemas.yaml#/definitions/Schemas
   globalParameters:
     type: array
-    description: 'all global parameters (ie, ImplementationLocation = client )'
+    description: all global parameters (ie, ImplementationLocation = client )
     items:
-      $ref: './master.yaml#/definitions/Parameter'
+      $ref: ./master.yaml#/definitions/Parameter
   info:
     description: Code model information
-    $ref: './master.yaml#/definitions/Info'
+    $ref: ./master.yaml#/definitions/Info
   operationGroups:
     type: array
     description: All operations
     items:
-      $ref: './master.yaml#/definitions/OperationGroup'
+      $ref: ./master.yaml#/definitions/OperationGroup
   security:
-    $ref: './master.yaml#/definitions/Security'
+    $ref: ./master.yaml#/definitions/Security
   extensions:
     description: additional metadata extensions dictionary
-    $ref: './master.yaml#/definitions/Dictionary<any>'
+    $ref: ./master.yaml#/definitions/Dictionary<any>
   language:
     description: per-language information for this aspect
-    $ref: './master.yaml#/definitions/Languages'
+    $ref: ./master.yaml#/definitions/Languages
   protocol:
     description: per-protocol information for this aspect
-    $ref: './master.yaml#/definitions/Protocols'
+    $ref: ./master.yaml#/definitions/Protocols
 required:
   - info
   - language

--- a/packages/libs/codemodel/.resources/model/yaml/schemas.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/schemas.yaml
@@ -1,10 +1,10 @@
-$schema: 'http://json-schema.org/draft-07/schema#'
+$schema: http://json-schema.org/draft-07/schema#
 definitions:
   AnySchema:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - protocol
@@ -14,11 +14,11 @@ definitions:
     description: a Schema that represents and array of values
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ValueSchema'
+      - $ref: ./schemas.yaml#/definitions/ValueSchema
     properties:
       elementType:
         description: elementType of the array
-        $ref: './schemas.yaml#/definitions/Schema'
+        $ref: ./schemas.yaml#/definitions/Schema
       maxItems:
         type: number
         description: maximum number of elements in the array
@@ -40,7 +40,7 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - protocol
@@ -50,7 +50,7 @@ definitions:
     description: a schema that represents a boolean value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     required:
       - language
       - protocol
@@ -60,7 +60,7 @@ definitions:
     description: a schema that represents a ByteArray value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ValueSchema'
+      - $ref: ./schemas.yaml#/definitions/ValueSchema
     properties:
       format:
         type: string
@@ -78,7 +78,7 @@ definitions:
     description: a schema that represents a Char value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     required:
       - language
       - protocol
@@ -96,10 +96,10 @@ definitions:
         description: the actual value
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for this value
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
     required:
       - language
       - value
@@ -108,7 +108,7 @@ definitions:
     description: schema types that can be objects
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - protocol
@@ -118,19 +118,19 @@ definitions:
     description: a schema that represents a value dependent on another
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ValueSchema'
+      - $ref: ./schemas.yaml#/definitions/ValueSchema
     properties:
       conditionalType:
         description: the primitive type for the conditional
-        $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+        $ref: ./schemas.yaml#/definitions/PrimitiveSchema
       conditions:
         type: array
         description: the possible conditinal values
         items:
-          $ref: './master.yaml#/definitions/ConditionalValue'
+          $ref: ./master.yaml#/definitions/ConditionalValue
       sourceValue:
         description: the source value that drives the target value (property or parameter)
-        $ref: './master.yaml#/definitions/Value'
+        $ref: ./master.yaml#/definitions/Value
     required:
       - conditionalType
       - conditions
@@ -143,14 +143,14 @@ definitions:
     description: a schema that represents a constant value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     properties:
       value:
         description: the actual constant value
-        $ref: './schemas.yaml#/definitions/ConstantValue'
+        $ref: ./schemas.yaml#/definitions/ConstantValue
       valueType:
-        description: 'the schema type of the constant value (ie, StringSchema, NumberSchema, etc)'
-        $ref: './schemas.yaml#/definitions/Schema'
+        description: the schema type of the constant value (ie, StringSchema, NumberSchema, etc)
+        $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - protocol
@@ -163,40 +163,40 @@ definitions:
     properties:
       type:
         description: the schema type
-        $ref: './types.yaml#/definitions/AllSchemaTypes'
+        $ref: ./types.yaml#/definitions/AllSchemaTypes
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions
         items:
-          $ref: './master.yaml#/definitions/ApiVersion'
+          $ref: ./master.yaml#/definitions/ApiVersion
       defaultValue:
-        description: 'If the value isn''t sent on the wire, the service will assume this'
+        description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
-        $ref: './master.yaml#/definitions/Deprecation'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
+        $ref: ./master.yaml#/definitions/Deprecation
       example:
         description: example information
       externalDocs:
         description: External Documentation Links
-        $ref: './master.yaml#/definitions/ExternalDocumentation'
+        $ref: ./master.yaml#/definitions/ExternalDocumentation
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       serialization:
         description: per-serialization information for this Schema
-        $ref: './master.yaml#/definitions/SerializationFormats'
+        $ref: ./master.yaml#/definitions/SerializationFormats
       summary:
         type: string
         description: a short description
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for Schema
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
       protocol:
         description: per-protocol information for this aspect
-        $ref: './master.yaml#/definitions/Protocols'
+        $ref: ./master.yaml#/definitions/Protocols
     required:
       - language
       - protocol
@@ -210,10 +210,10 @@ definitions:
         description: the actual constant value to use
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for this value
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
     required:
       - value
   CredentialSchema:
@@ -221,7 +221,7 @@ definitions:
     description: a schema that represents a Credential value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     properties:
       maxLength:
         type: number
@@ -241,7 +241,7 @@ definitions:
     description: a schema that represents a Date value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     required:
       - language
       - protocol
@@ -251,7 +251,7 @@ definitions:
     description: a schema that represents a DateTime value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     properties:
       format:
         type: string
@@ -269,11 +269,11 @@ definitions:
     description: a schema that represents a key-value collection
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ComplexSchema'
+      - $ref: ./schemas.yaml#/definitions/ComplexSchema
     properties:
       elementType:
         description: the element type of the dictionary. (Keys are always strings)
-        $ref: './schemas.yaml#/definitions/Schema'
+        $ref: ./schemas.yaml#/definitions/Schema
       nullableItems:
         type: boolean
         description: if elements in the dictionary should be nullable
@@ -287,7 +287,7 @@ definitions:
     description: a schema that represents a Duration value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     required:
       - language
       - protocol
@@ -296,13 +296,13 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ValueSchema'
+      - $ref: ./schemas.yaml#/definitions/ValueSchema
     properties:
       choices:
         type: array
         description: the possible choices for in the set
         items:
-          $ref: './master.yaml#/definitions/FlagValue'
+          $ref: ./master.yaml#/definitions/FlagValue
     required:
       - choices
       - language
@@ -312,13 +312,13 @@ definitions:
     type: object
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
-      - $ref: './schemas.yaml#/definitions/SchemaUsage'
+      - $ref: ./schemas.yaml#/definitions/Schema
+      - $ref: ./schemas.yaml#/definitions/SchemaUsage
     properties:
       properties:
         type: array
         items:
-          $ref: './master.yaml#/definitions/GroupProperty'
+          $ref: ./master.yaml#/definitions/GroupProperty
     required:
       - language
       - protocol
@@ -328,11 +328,11 @@ definitions:
     description: a NOT relationship between schemas
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     properties:
       not:
         description: the schema that this may not be.
-        $ref: './schemas.yaml#/definitions/Schema'
+        $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - not
@@ -343,26 +343,26 @@ definitions:
     description: a Schema that represents a Number value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     properties:
       exclusiveMaximum:
         type: boolean
-        description: 'if present, the value must be lower than maximum'
+        description: if present, the value must be lower than maximum
       exclusiveMinimum:
         type: boolean
-        description: 'if present, the value must be higher than minimum'
+        description: if present, the value must be higher than minimum
       maximum:
         type: number
-        description: 'if present, the value must be lower than or equal to this (unless exclusiveMaximum is true)'
+        description: if present, the value must be lower than or equal to this (unless exclusiveMaximum is true)
       minimum:
         type: number
-        description: 'if present, the value must be highter than or equal to this (unless exclusiveMinimum is true)'
+        description: if present, the value must be highter than or equal to this (unless exclusiveMinimum is true)
       multipleOf:
         type: number
-        description: 'if present, the number must be an exact multiple of this value'
+        description: if present, the number must be an exact multiple of this value
       precision:
         type: number
-        description: 'precision (# of bits?) of the number'
+        description: precision (# of bits?) of the number
     required:
       - language
       - precision
@@ -373,7 +373,7 @@ definitions:
     description: a schema that represents a ODataQuery value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - protocol
@@ -383,14 +383,14 @@ definitions:
     description: a schema that represents a type with child properties.
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ComplexSchema'
-      - $ref: './schemas.yaml#/definitions/SchemaUsage'
+      - $ref: ./schemas.yaml#/definitions/ComplexSchema
+      - $ref: ./schemas.yaml#/definitions/SchemaUsage
     properties:
       children:
-        $ref: './master.yaml#/definitions/Relations'
+        $ref: ./master.yaml#/definitions/Relations
       discriminator:
-        description: 'the property of the polymorphic descriminator for this type, if there is one'
-        $ref: './master.yaml#/definitions/Discriminator'
+        description: the property of the polymorphic descriminator for this type, if there is one
+        $ref: ./master.yaml#/definitions/Discriminator
       discriminatorValue:
         type: string
       maxProperties:
@@ -400,12 +400,12 @@ definitions:
         type: number
         description: minimum number of properties permitted
       parents:
-        $ref: './master.yaml#/definitions/Relations'
+        $ref: ./master.yaml#/definitions/Relations
       properties:
         type: array
         description: the collection of properties that are in this object
         items:
-          $ref: './master.yaml#/definitions/Property'
+          $ref: ./master.yaml#/definitions/Property
     required:
       - language
       - protocol
@@ -415,13 +415,13 @@ definitions:
     description: an OR relationship between several schemas
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ComplexSchema'
+      - $ref: ./schemas.yaml#/definitions/ComplexSchema
     properties:
       anyOf:
         type: array
         description: the set of schemas that this schema is composed of. Every schema is optional
         items:
-          $ref: './schemas.yaml#/definitions/ComplexSchema'
+          $ref: ./schemas.yaml#/definitions/ComplexSchema
     required:
       - anyOf
       - language
@@ -432,7 +432,7 @@ definitions:
     description: Schema types that are primitive language values
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ValueSchema'
+      - $ref: ./schemas.yaml#/definitions/ValueSchema
     required:
       - language
       - protocol
@@ -443,215 +443,215 @@ definitions:
     properties:
       type:
         description: the schema type
-        $ref: './types.yaml#/definitions/AllSchemaTypes'
+        $ref: ./types.yaml#/definitions/AllSchemaTypes
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions
         items:
-          $ref: './master.yaml#/definitions/ApiVersion'
+          $ref: ./master.yaml#/definitions/ApiVersion
       defaultValue:
-        description: 'If the value isn''t sent on the wire, the service will assume this'
+        description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: 'deprecation information -- ie, when this aspect doesn''t apply and why'
-        $ref: './master.yaml#/definitions/Deprecation'
+        description: deprecation information -- ie, when this aspect doesn't apply and why
+        $ref: ./master.yaml#/definitions/Deprecation
       example:
         description: example information
       externalDocs:
         description: External Documentation Links
-        $ref: './master.yaml#/definitions/ExternalDocumentation'
+        $ref: ./master.yaml#/definitions/ExternalDocumentation
       origin:
         type: string
-        description: 'where did this aspect come from (jsonpath or ''modelerfour:<soemthing>'')'
+        description: where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')
       serialization:
         description: per-serialization information for this Schema
-        $ref: './master.yaml#/definitions/SerializationFormats'
+        $ref: ./master.yaml#/definitions/SerializationFormats
       summary:
         type: string
         description: a short description
       extensions:
         description: additional metadata extensions dictionary
-        $ref: './master.yaml#/definitions/Dictionary<any>'
+        $ref: ./master.yaml#/definitions/Dictionary<any>
       language:
         description: per-language information for Schema
-        $ref: './master.yaml#/definitions/Languages'
+        $ref: ./master.yaml#/definitions/Languages
       protocol:
         description: per-protocol information for this aspect
-        $ref: './master.yaml#/definitions/Protocols'
+        $ref: ./master.yaml#/definitions/Protocols
     required:
       - language
       - protocol
       - type
   Schemas:
     type: object
-    description: 'the full set of schemas for a given service, categorized into convenient collections'
+    description: the full set of schemas for a given service, categorized into convenient collections
     additionalProperties: false
     properties:
       any:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/AnySchema'
+          $ref: ./schemas.yaml#/definitions/AnySchema
       arrays:
         type: array
         description: a collection of items
         items:
-          $ref: './schemas.yaml#/definitions/ArraySchema'
+          $ref: ./schemas.yaml#/definitions/ArraySchema
       binaries:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/BinarySchema'
+          $ref: ./schemas.yaml#/definitions/BinarySchema
       booleans:
         type: array
         description: a true or false value
         items:
-          $ref: './schemas.yaml#/definitions/BooleanSchema'
+          $ref: ./schemas.yaml#/definitions/BooleanSchema
       byteArrays:
         type: array
         description: ByteArray -- an array of bytes
         items:
-          $ref: './schemas.yaml#/definitions/ByteArraySchema'
+          $ref: ./schemas.yaml#/definitions/ByteArraySchema
       chars:
         type: array
         description: a single character
         items:
-          $ref: './schemas.yaml#/definitions/CharSchema'
+          $ref: ./schemas.yaml#/definitions/CharSchema
       choices:
         type: array
         description: |-
-          - this is essentially can be thought of as an 'enum' 
+          - this is essentially can be thought of as an 'enum'
           that is a choice between one of several items, but an unspecified value is permitted.
         items:
-          $ref: './schemas.yaml#/definitions/ChoiceSchema'
+          $ref: ./schemas.yaml#/definitions/ChoiceSchema
       conditionals:
         type: array
-        description: 'ie, when ''profile'' is ''production'', use ''2018-01-01'' for apiversion'
+        description: ie, when 'profile' is 'production', use '2018-01-01' for apiversion
         items:
-          $ref: './schemas.yaml#/definitions/ConditionalSchema'
+          $ref: ./schemas.yaml#/definitions/ConditionalSchema
       constants:
         type: array
         description: a constant value
         items:
-          $ref: './schemas.yaml#/definitions/ConstantSchema'
+          $ref: ./schemas.yaml#/definitions/ConstantSchema
       credentials:
         type: array
         description: a password or credential
         items:
-          $ref: './schemas.yaml#/definitions/CredentialSchema'
+          $ref: ./schemas.yaml#/definitions/CredentialSchema
       dateTimes:
         type: array
         description: a DateTime
         items:
-          $ref: './schemas.yaml#/definitions/DateTimeSchema'
+          $ref: ./schemas.yaml#/definitions/DateTimeSchema
       dates:
         type: array
         description: a Date
         items:
-          $ref: './schemas.yaml#/definitions/DateSchema'
+          $ref: ./schemas.yaml#/definitions/DateSchema
       dictionaries:
         type: array
-        description: 'an associative array (ie, dictionary, hashtable, etc)'
+        description: an associative array (ie, dictionary, hashtable, etc)
         items:
-          $ref: './schemas.yaml#/definitions/DictionarySchema'
+          $ref: ./schemas.yaml#/definitions/DictionarySchema
       durations:
         type: array
         description: a Duration
         items:
-          $ref: './schemas.yaml#/definitions/DurationSchema'
+          $ref: ./schemas.yaml#/definitions/DurationSchema
       flags:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/FlagSchema'
+          $ref: ./schemas.yaml#/definitions/FlagSchema
       groups:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/GroupSchema'
+          $ref: ./schemas.yaml#/definitions/GroupSchema
       numbers:
         type: array
         description: a number value
         items:
-          $ref: './schemas.yaml#/definitions/NumberSchema'
+          $ref: ./schemas.yaml#/definitions/NumberSchema
       objects:
         type: array
         description: an object of some type
         items:
-          $ref: './schemas.yaml#/definitions/ObjectSchema'
+          $ref: ./schemas.yaml#/definitions/ObjectSchema
       odataQueries:
         type: array
         description: OData Query
         items:
-          $ref: './schemas.yaml#/definitions/ODataQuerySchema'
+          $ref: ./schemas.yaml#/definitions/ODataQuerySchema
       ors:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/OrSchema'
+          $ref: ./schemas.yaml#/definitions/OrSchema
       sealedChoices:
         type: array
         description: |-
           - this is essentially can be thought of as an 'enum'
           that is a choice between one of several items, but an unknown value is not allowed.
         items:
-          $ref: './schemas.yaml#/definitions/SealedChoiceSchema'
+          $ref: ./schemas.yaml#/definitions/SealedChoiceSchema
       sealedConditionals:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/SealedConditionalSchema'
+          $ref: ./schemas.yaml#/definitions/SealedConditionalSchema
       streams:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/Schema'
+          $ref: ./schemas.yaml#/definitions/Schema
       strings:
         type: array
         description: a string of characters
         items:
-          $ref: './schemas.yaml#/definitions/StringSchema'
+          $ref: ./schemas.yaml#/definitions/StringSchema
       times:
         type: array
         description: a time
         items:
-          $ref: './schemas.yaml#/definitions/TimeSchema'
+          $ref: ./schemas.yaml#/definitions/TimeSchema
       unixtimes:
         type: array
         description: UnixTime
         items:
-          $ref: './schemas.yaml#/definitions/UnixTimeSchema'
+          $ref: ./schemas.yaml#/definitions/UnixTimeSchema
       unknowns:
         type: array
         description: |-
-          it's possible that we just may make this an error 
+          it's possible that we just may make this an error
           in representation.
         items:
-          $ref: './schemas.yaml#/definitions/Schema'
+          $ref: ./schemas.yaml#/definitions/Schema
       uris:
         type: array
         description: an URI of some kind
         items:
-          $ref: './schemas.yaml#/definitions/UriSchema'
+          $ref: ./schemas.yaml#/definitions/UriSchema
       uuids:
         type: array
         description: a universally unique identifier
         items:
-          $ref: './schemas.yaml#/definitions/UuidSchema'
+          $ref: ./schemas.yaml#/definitions/UuidSchema
       xors:
         type: array
         items:
-          $ref: './schemas.yaml#/definitions/XorSchema'
+          $ref: ./schemas.yaml#/definitions/XorSchema
   SealedConditionalSchema:
     type: object
     description: a schema that represents a value dependent on another (not overridable)
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/ValueSchema'
+      - $ref: ./schemas.yaml#/definitions/ValueSchema
     properties:
       conditionalType:
         description: the primitive type for the condition
-        $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+        $ref: ./schemas.yaml#/definitions/PrimitiveSchema
       conditions:
         type: array
         description: the possible conditional values
         items:
-          $ref: './master.yaml#/definitions/ConditionalValue'
+          $ref: ./master.yaml#/definitions/ConditionalValue
       sourceValue:
         description: the source value that drives the target value
-        $ref: './master.yaml#/definitions/Value'
+        $ref: ./master.yaml#/definitions/Value
     required:
       - conditionalType
       - conditions
@@ -664,7 +664,7 @@ definitions:
     description: a Schema that represents a string value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     properties:
       maxLength:
         type: number
@@ -684,7 +684,7 @@ definitions:
     description: a schema that represents a Date value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     required:
       - language
       - protocol
@@ -694,7 +694,7 @@ definitions:
     description: a schema that represents a UnixTime value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     required:
       - language
       - protocol
@@ -704,7 +704,7 @@ definitions:
     description: a schema that represents a Uri value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     properties:
       maxLength:
         type: number
@@ -724,7 +724,7 @@ definitions:
     description: a schema that represents a Uuid value
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/PrimitiveSchema'
+      - $ref: ./schemas.yaml#/definitions/PrimitiveSchema
     required:
       - language
       - protocol
@@ -734,7 +734,7 @@ definitions:
     description: schema types that are non-object or complex types
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - protocol
@@ -744,13 +744,13 @@ definitions:
     description: an XOR relationship between several schemas
     additionalProperties: false
     allOf:
-      - $ref: './schemas.yaml#/definitions/Schema'
+      - $ref: ./schemas.yaml#/definitions/Schema
     properties:
       oneOf:
         type: array
         description: the set of schemas that this must be one and only one of.
         items:
-          $ref: './schemas.yaml#/definitions/Schema'
+          $ref: ./schemas.yaml#/definitions/Schema
     required:
       - language
       - oneOf

--- a/packages/libs/codemodel/.resources/model/yaml/types.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/types.yaml
@@ -1,4 +1,4 @@
-$schema: 'http://json-schema.org/draft-07/schema#'
+$schema: http://json-schema.org/draft-07/schema#
 definitions:
   AllSchemaTypes:
     type: string

--- a/packages/libs/codemodel/.scripts/generate-schema.js
+++ b/packages/libs/codemodel/.scripts/generate-schema.js
@@ -1,13 +1,13 @@
-const jsyaml = require('js-yaml');
-const fs = require('fs').promises;
+const jsyaml = require("js-yaml");
+const fs = require("fs").promises;
 
-const g = require('glob');
+const g = require("glob");
 const TJS = require("typescript-json-schema");
-const tsm = require('ts-morph');
+const tsm = require("ts-morph");
 
-const project = new tsm.Project({ tsConfigFilePath: `{__dirname}/../tsconfig.json` });
+const project = new tsm.Project({ tsConfigFilePath: `${__dirname}/../tsconfig.json` });
 
-const x = project.getSourceFiles().map(each => each.getInterfaces());
+const x = project.getSourceFiles().map((each) => each.getInterfaces());
 
 function flatten(arr) {
   return arr.reduce(function (flat, toFlatten) {
@@ -18,28 +18,28 @@ function flatten(arr) {
 const interfaces = flatten(x);
 
 const propertyPriority = [
-  '$key',
-  'name',
-  'schemas',
-  'name',
-  'type',
-  'format',
-  'schema',
-  'operationId',
-  'path',
-  'method',
-  'description',
-  'default',
+  "$key",
+  "name",
+  "schemas",
+  "name",
+  "type",
+  "format",
+  "schema",
+  "operationId",
+  "path",
+  "method",
+  "description",
+  "default",
 ];
 const propertyNegativePriority = [
-  'callbacks',
-  'http',
-  'commands',
-  'operations',
-  'extensions',
-  'details',
-  'language',
-  'protocol'
+  "callbacks",
+  "http",
+  "commands",
+  "operations",
+  "extensions",
+  "details",
+  "language",
+  "protocol",
 ];
 function sortWithPriorty(a, b) {
   if (a == b) {
@@ -49,14 +49,13 @@ function sortWithPriorty(a, b) {
   const ib = propertyPriority.indexOf(b);
   const na = propertyNegativePriority.indexOf(a);
   const nb = propertyNegativePriority.indexOf(b);
-  const dota = `${a}`.startsWith('.');
-  const dotb = `${b}`.startsWith('.');
+  const dota = `${a}`.startsWith(".");
+  const dotb = `${b}`.startsWith(".");
   if (dota) {
     if (!dotb) {
       return 1;
     }
-  }
-  else {
+  } else {
     if (dotb) {
       return -1;
     }
@@ -77,58 +76,58 @@ function sortWithPriorty(a, b) {
 }
 
 function serialize(model) {
-  return jsyaml.dump(model, {
-    sortKeys: sortWithPriorty,
-    schema: jsyaml.DEFAULT_SAFE_SCHEMA,
-    skipInvalid: true,
-    lineWidth: 240
-  }).
-    replace(/\s*\w*: {}/g, '').
-    replace(/\s*\w*: \[\]/g, '').
-    replace(/(\s*- \$key:)/g, '\n$1')
+  return jsyaml
+    .dump(model, {
+      sortKeys: sortWithPriorty,
+      schema: jsyaml.DEFAULT_SCHEMA,
+      skipInvalid: true,
+      lineWidth: 240,
+    })
+    .replace(/\s*\w*: {}/g, "")
+    .replace(/\s*\w*: \[\]/g, "")
+    .replace(/(\s*- \$key:)/g, "\n$1");
   // replace(/(\s*)(language:)/g, '\n$1## ----------------------------------------------------------------------$1$2');
   //.replace(/(\s*language:)/g, '\n$1');
 }
 
-
 function fix(txt) {
   return txt
-    .replace(/<Schema<AllSchemaTypes>>/g, '')
-    .replace(/<Schema<PrimitiveSchemaTypes>>/g, '')
-    .replace(/Schema\.TSchemaType_1/g, 'NumericSchemaTypes')
-    .replace(/Schema\.TSchemaType_2/g, 'ObjectSchemaTypes')
-    .replace(/Schema\.TSchemaType_3/g, 'PrimitiveSchemaTypes')
-    .replace(/Schema\.TSchemaType/g, 'AllSchemaTypes')
-    .replace(/T_1/g, 'Language')
-    .replace(/T_2/g, 'Protocol')
-    .replace(/Protocols<Protocol>/g, 'Protocols')
+    .replace(/<Schema<AllSchemaTypes>>/g, "")
+    .replace(/<Schema<PrimitiveSchemaTypes>>/g, "")
+    .replace(/Schema\.TSchemaType_1/g, "NumericSchemaTypes")
+    .replace(/Schema\.TSchemaType_2/g, "ObjectSchemaTypes")
+    .replace(/Schema\.TSchemaType_3/g, "PrimitiveSchemaTypes")
+    .replace(/Schema\.TSchemaType/g, "AllSchemaTypes")
+    .replace(/T_1/g, "Language")
+    .replace(/T_2/g, "Protocol")
+    .replace(/Protocols<Protocol>/g, "Protocols");
 }
 
 function fixmodel(schema) {
   txt = JSON.stringify(schema);
   txt = txt
-    .replace(/<Schema<AllSchemaTypes>>/g, '')
-    .replace(/Schema<AllSchemaTypes>/g, 'Schema')
-    .replace(/<Schema<PrimitiveSchemaTypes>>/g, '')
-    .replace(/<ComplexSchema>/g, '!ComplexSchema!')
-    .replace(/<\w*Schema>/g, '')
-    .replace(/!ComplexSchema!/g, '<ComplexSchema>')
-    .replace(/Schema\.TSchemaType_1/g, 'NumericSchemaTypes')
-    .replace(/Schema\.TSchemaType_2/g, 'ObjectSchemaTypes')
-    .replace(/Schema\.TSchemaType_3/g, 'PrimitiveSchemaTypes')
-    .replace(/Schema\.TSchemaType/g, 'AllSchemaTypes')
-    .replace(/T_1/g, 'Language')
-    .replace(/T_2/g, 'Protocol')
-    .replace(/T_3/g, 'Extensions')
-    .replace(/Protocols<Protocol>/g, 'Protocols')
-    .replace(/Languages<Language>/g, 'Languages')
+    .replace(/<Schema<AllSchemaTypes>>/g, "")
+    .replace(/Schema<AllSchemaTypes>/g, "Schema")
+    .replace(/<Schema<PrimitiveSchemaTypes>>/g, "")
+    .replace(/<ComplexSchema>/g, "!ComplexSchema!")
+    .replace(/<\w*Schema>/g, "")
+    .replace(/!ComplexSchema!/g, "<ComplexSchema>")
+    .replace(/Schema\.TSchemaType_1/g, "NumericSchemaTypes")
+    .replace(/Schema\.TSchemaType_2/g, "ObjectSchemaTypes")
+    .replace(/Schema\.TSchemaType_3/g, "PrimitiveSchemaTypes")
+    .replace(/Schema\.TSchemaType/g, "AllSchemaTypes")
+    .replace(/T_1/g, "Language")
+    .replace(/T_2/g, "Protocol")
+    .replace(/T_3/g, "Extensions")
+    .replace(/Protocols<Protocol>/g, "Protocols")
+    .replace(/Languages<Language>/g, "Languages")
     .replace(/definitions\/T"/g, 'definitions/ApiVersion"')
-    .replace(/ElementType_1/g, 'Schema')
-    .replace(/ElementType/g, 'Schema')
-    .replace(/SerializationFormats<SerializationFormat>/g, 'SerializationFormats')
+    .replace(/ElementType_1/g, "Schema")
+    .replace(/ElementType/g, "Schema")
+    .replace(/SerializationFormats<SerializationFormat>/g, "SerializationFormats");
 
   model = JSON.parse(txt, undefined, 2);
-  return model
+  return model;
 }
 
 async function main() {
@@ -140,46 +139,50 @@ async function main() {
     noExtraProps: true,
   };
 
-  const program = TJS.getProgramFromFiles(g.sync(`${__dirname}/../model/**/*.ts`), { downlevelIteration: true }, __dirname);
+  const program = TJS.getProgramFromFiles(
+    g.sync(`${__dirname}/../src/model/**/*.ts`),
+    { downlevelIteration: true },
+    __dirname,
+  );
 
   // We can either get the schema for one file and one type...
   let schema = TJS.generateSchema(program, "*", settings);
 
   schema = fixmodel(schema);
 
-  delete schema.definitions['ValueSchemas'];
-  delete schema.definitions['AllSchemas'];
-  delete schema.definitions['ArraySchema<Schema>'];
-  delete schema.definitions['ConstantSchema<Schema>'];
-  delete schema.definitions['DictionarySchema<Schema>'];
+  delete schema.definitions["ValueSchemas"];
+  delete schema.definitions["AllSchemas"];
+  delete schema.definitions["ArraySchema<Schema>"];
+  delete schema.definitions["ConstantSchema<Schema>"];
+  delete schema.definitions["DictionarySchema<Schema>"];
 
-  delete schema.definitions['ChoiceSchema<Schema>'];
-  delete schema.definitions['Aspect'];
-  delete schema.definitions['Schema.TSchemaType'];
-  delete schema.definitions['Schema.TSchemaType_2'];
-  delete schema.definitions['Languages<Language>'];
-  delete schema.definitions['T'];
-  delete schema.definitions['ElementType'];
-  delete schema.definitions['ElementType_1'];
-  delete schema.definitions['ChoiceType'];
-  delete schema.definitions['ChoiceType_1'];
-  delete schema.definitions['ConditionalType'];
-  delete schema.definitions['ConditionalType_1'];
-  delete schema.definitions['SerializationFormats<SerializationFormat>'];
+  delete schema.definitions["ChoiceSchema<Schema>"];
+  delete schema.definitions["Aspect"];
+  delete schema.definitions["Schema.TSchemaType"];
+  delete schema.definitions["Schema.TSchemaType_2"];
+  delete schema.definitions["Languages<Language>"];
+  delete schema.definitions["T"];
+  delete schema.definitions["ElementType"];
+  delete schema.definitions["ElementType_1"];
+  delete schema.definitions["ChoiceType"];
+  delete schema.definitions["ChoiceType_1"];
+  delete schema.definitions["ConditionalType"];
+  delete schema.definitions["ConditionalType_1"];
+  delete schema.definitions["SerializationFormats<SerializationFormat>"];
 
-  schema.definitions['ChoiceSchema'].properties['choiceType'].$ref = '#/definitions/PrimitiveSchema'
-  schema.definitions['SealedChoiceSchema'].properties['choiceType'].$ref = '#/definitions/PrimitiveSchema'
-  schema.definitions['ConditionalSchema'].properties['conditionalType'].$ref = '#/definitions/PrimitiveSchema'
-  schema.definitions['SealedConditionalSchema'].properties['conditionalType'].$ref = '#/definitions/PrimitiveSchema'
+  schema.definitions["ChoiceSchema"].properties["choiceType"].$ref = "#/definitions/PrimitiveSchema";
+  schema.definitions["SealedChoiceSchema"].properties["choiceType"].$ref = "#/definitions/PrimitiveSchema";
+  schema.definitions["ConditionalSchema"].properties["conditionalType"].$ref = "#/definitions/PrimitiveSchema";
+  schema.definitions["SealedConditionalSchema"].properties["conditionalType"].$ref = "#/definitions/PrimitiveSchema";
 
-  for (let each in schema.definitions['CodeModel']) {
-    schema[each] = schema.definitions['CodeModel'][each]
+  for (let each in schema.definitions["CodeModel"]) {
+    schema[each] = schema.definitions["CodeModel"][each];
   }
-  schema.title = 'CodeModel';
-  delete schema.definitions['CodeModel'];
+  schema.title = "CodeModel";
+  delete schema.definitions["CodeModel"];
 
   for (let each in schema.definitions) {
-    if (schema.definitions[each].type === 'number') {
+    if (schema.definitions[each].type === "number") {
       delete schema.definitions[each];
     }
   }
@@ -188,12 +191,20 @@ async function main() {
     const heritage = each.getHeritageClauses();
     if (heritage.length > 0) {
       for (const h of heritage) {
-        const parents = h.getText().replace(/.*extends/g, '').split(',').map(i => i.trim()).filter(each => each != 'Extensions' && each != 'Dictionary<any>' && each != 'Dictionary<string>' && each != 'Aspect');
+        const parents = h
+          .getText()
+          .replace(/.*extends/g, "")
+          .split(",")
+          .map((i) => i.trim())
+          .filter(
+            (each) =>
+              each != "Extensions" && each != "Dictionary<any>" && each != "Dictionary<string>" && each != "Aspect",
+          );
         if (parents.length > 0) {
           const parent = parents[0];
           const child = each.getName();
           if (schema.definitions[child] && schema.definitions[parent]) {
-            schema.definitions[child].allOf = [{ $ref: `#/definitions/${parent}` }]
+            schema.definitions[child].allOf = [{ $ref: `#/definitions/${parent}` }];
             for (const pp in schema.definitions[parent].properties) {
               schema.definitions[child].properties[pp].deleteMe = true;
             }
@@ -210,24 +221,24 @@ async function main() {
     }
   }
 
-  schema.definitions['Dictionary<string>'].additionalProperties = { type: 'string' };
-  schema.definitions['Dictionary<any>'].additionalProperties = { type: 'object' };
-  schema.definitions['Dictionary<ComplexSchema>'].additionalProperties = { $ref: `#/definitions/ComplexSchema` };
-  schema.definitions['Language'].additionalProperties = { type: 'object' };
-  schema.definitions['Languages'].additionalProperties = false;//  { type: 'object' };
-  schema.definitions['Protocols'].additionalProperties = false;// { type: 'object' };
-  schema.definitions['SerializationFormats'].additionalProperties = false; // { type: 'object' };
+  schema.definitions["Dictionary<string>"].additionalProperties = { type: "string" };
+  schema.definitions["Dictionary<any>"].additionalProperties = { type: "object" };
+  schema.definitions["Dictionary<ComplexSchema>"].additionalProperties = { $ref: `#/definitions/ComplexSchema` };
+  schema.definitions["Language"].additionalProperties = { type: "object" };
+  schema.definitions["Languages"].additionalProperties = false; //  { type: 'object' };
+  schema.definitions["Protocols"].additionalProperties = false; // { type: 'object' };
+  schema.definitions["SerializationFormats"].additionalProperties = false; // { type: 'object' };
 
   // console.log(schema.definitions['Language']);
 
   // Fix up the SchemaUsage spec and its consumers
-  schema.definitions['SchemaUsage'].properties['usage'].items = { $ref: '#/definitions/SchemaContext' };
-  schema.definitions['SchemaUsage'].properties['serializationFormats'].items = { $ref: '#/definitions/KnownMediaType' };
-  refSchemaUsage(schema, 'ObjectSchema');
-  refSchemaUsage(schema, 'GroupSchema');
+  schema.definitions["SchemaUsage"].properties["usage"].items = { $ref: "#/definitions/SchemaContext" };
+  schema.definitions["SchemaUsage"].properties["serializationFormats"].items = { $ref: "#/definitions/KnownMediaType" };
+  refSchemaUsage(schema, "ObjectSchema");
+  refSchemaUsage(schema, "GroupSchema");
 
   // write out the full all in one model
-  await writemodels('code-model', 'all-in-one', schema);
+  await writemodels("code-model", "all-in-one", schema);
 
   schema = JSON.parse(JSON.stringify(schema).replace(/#\/definitions(.*?)"/g, './master.json#/definitions$1"'));
 
@@ -236,102 +247,111 @@ async function main() {
     master: schema,
 
     enums: {
-      $schema: 'http://json-schema.org/draft-07/schema#',
-      definitions: {}
+      $schema: "http://json-schema.org/draft-07/schema#",
+      definitions: {},
     },
 
     schemas: {
-      $schema: 'http://json-schema.org/draft-07/schema#',
-      definitions: {}
+      $schema: "http://json-schema.org/draft-07/schema#",
+      definitions: {},
     },
 
     types: {
-      $schema: 'http://json-schema.org/draft-07/schema#',
-      definitions: {}
+      $schema: "http://json-schema.org/draft-07/schema#",
+      definitions: {},
     },
 
     http: {
-      $schema: 'http://json-schema.org/draft-07/schema#',
-      definitions: {}
-    }
-  }
+      $schema: "http://json-schema.org/draft-07/schema#",
+      definitions: {},
+    },
+  };
 
   //move schemas
   for (let each in all.master.definitions) {
-    if (each.endsWith('Schema') || each.startsWith('Schema<') || each.indexOf('Schema<') > -1) {
-      moveTo(all, each, 'schemas')
+    if (each.endsWith("Schema") || each.startsWith("Schema<") || each.indexOf("Schema<") > -1) {
+      moveTo(all, each, "schemas");
     }
   }
-  moveTo(all, 'Schemas', 'schemas');
-  moveTo(all, 'ChoiceType', 'schemas');
-  moveTo(all, 'ChoiceValue', 'schemas');
-  moveTo(all, 'ChoiceSchema', 'schemas');
-  moveTo(all, 'SealedChoiceSchema', 'schemas');
-  moveTo(all, 'ConstantType', 'schemas');
-  moveTo(all, 'ConstantValue', 'schemas');
-
+  moveTo(all, "Schemas", "schemas");
+  moveTo(all, "ChoiceType", "schemas");
+  moveTo(all, "ChoiceValue", "schemas");
+  moveTo(all, "ChoiceSchema", "schemas");
+  moveTo(all, "SealedChoiceSchema", "schemas");
+  moveTo(all, "ConstantType", "schemas");
+  moveTo(all, "ConstantValue", "schemas");
 
   for (let each in all.master.definitions) {
-    if (each.endsWith('Schemas')) {
-      moveTo(all, each, 'types')
+    if (each.endsWith("Schemas")) {
+      moveTo(all, each, "types");
     }
   }
 
   // move types
   for (let each in all.master.definitions) {
-    if (each.endsWith('Types')) {
-      moveTo(all, each, 'types')
+    if (each.endsWith("Types")) {
+      moveTo(all, each, "types");
     }
   }
 
   //move enums
   for (let each in all.master.definitions) {
     if (all.master.definitions[each].enum) {
-      moveTo(all, each, 'enums')
+      moveTo(all, each, "enums");
     }
   }
 
   for (let each in all.master.definitions) {
-    if (['APIKeySecurityScheme',
-      'BearerHTTPSecurityScheme',
-      'AuthorizationCodeOAuthFlow',
-      'HTTPSecurityScheme',
-      'ImplicitOAuthFlow',
-      'NonBearerHTTPSecurityScheme',
-      'OAuth2SecurityScheme',
-      'OAuthFlows',
-      'OpenIdConnectSecurityScheme',
-      'PasswordOAuthFlow',
-      'SecurityRequirement',
-      'SecurityScheme',
-      'ServerVariable',
-      'Server',
-      'StreamResponse',
-      'ClientCredentialsFlow',
-
-
-    ].indexOf(each) > -1 || each.startsWith('Http')) {
-      moveTo(all, each, 'http')
+    if (
+      [
+        "APIKeySecurityScheme",
+        "BearerHTTPSecurityScheme",
+        "AuthorizationCodeOAuthFlow",
+        "HTTPSecurityScheme",
+        "ImplicitOAuthFlow",
+        "NonBearerHTTPSecurityScheme",
+        "OAuth2SecurityScheme",
+        "OAuthFlows",
+        "OpenIdConnectSecurityScheme",
+        "PasswordOAuthFlow",
+        "SecurityRequirement",
+        "SecurityScheme",
+        "ServerVariable",
+        "Server",
+        "StreamResponse",
+        "ClientCredentialsFlow",
+      ].indexOf(each) > -1 ||
+      each.startsWith("Http")
+    ) {
+      moveTo(all, each, "http");
     }
   }
 
   for (const each in all) {
-    await writemodels(each, 'model', all[each]);
+    await writemodels(each, "model", all[each]);
   }
 }
 
 function refSchemaUsage(schema, schemaName) {
-  delete schema.definitions[schemaName].properties['usage'];
-  delete schema.definitions[schemaName].properties['serializationFormats'];
+  delete schema.definitions[schemaName].properties["usage"];
+  delete schema.definitions[schemaName].properties["serializationFormats"];
+  if (!schema.definitions[schemaName].allOf) {
+    schema.definitions[schemaName].allOf = [];
+  }
   schema.definitions[schemaName].allOf.push({ $ref: `#/definitions/SchemaUsage` });
 }
 
-function moveTo(all, name, target, ) {
+function moveTo(all, name, target) {
   all[target].definitions[name] = all.master.definitions[name];
   delete all.master.definitions[name];
 
   for (const each in all) {
-    all[each] = JSON.parse(JSON.stringify(all[each]).replace(new RegExp(`./master.json(#\/definitions\/${name})`, 'g'), `./${target}.json$1`));
+    all[each] = JSON.parse(
+      JSON.stringify(all[each]).replace(
+        new RegExp(`./master.json(#\/definitions\/${name})`, "g"),
+        `./${target}.json$1`,
+      ),
+    );
   }
 }
 
@@ -341,7 +361,7 @@ async function writemodels(name, folder, schema) {
   const yaml = serialize(schema);
   const json = JSON.stringify(schema, undefined, 2);
 
-  await fs.writeFile(`${__dirname}/../.resources/${folder}/yaml/${name}.yaml`, yaml.replace(/\.json/g, '.yaml'));
+  await fs.writeFile(`${__dirname}/../.resources/${folder}/yaml/${name}.yaml`, yaml.replace(/\.json/g, ".yaml"));
   await fs.writeFile(`${__dirname}/../.resources/${folder}/json/${name}.json`, json);
 }
 

--- a/packages/libs/codemodel/src/model/common/parameter.ts
+++ b/packages/libs/codemodel/src/model/common/parameter.ts
@@ -29,6 +29,11 @@ export interface Parameter extends Value {
 
   /** When a parameter is grouped into another, this will tell where the parameter got grouped into. */
   groupedBy?: Parameter;
+
+  /**
+   * If this parameter is to be included in a multipart request body.
+   */
+  isInMultipart?: boolean;
 }
 
 export class Parameter extends Value implements Parameter {


### PR DESCRIPTION
fix #3835

Add a new field on the codemodel `isInMultipart`(Name open to suggestion) to specify if a parameter is part of the multipart body request
![image](https://user-images.githubusercontent.com/1031227/107064690-ab310480-6790-11eb-8882-212febb4fca6.png)
