### PR TITLE
Fix issue with chsarp configuration 

### DIFF
--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -40,7 +40,7 @@
   },
   "typings": "./dist/src/exports.d.ts",
   "devDependencies": {
-    "@autorest/core": "~3.0.6371",
+    "@autorest/core": "~3.0.6372",
     "@azure-tools/async-io": "~3.0.0",
     "@azure-tools/extension": "~3.0.0",
     "@azure-tools/tasks": "~3.0.0",

--- a/packages/extensions/core/CHANGELOG.json
+++ b/packages/extensions/core/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/core",
   "entries": [
     {
+      "version": "3.0.6372",
+      "tag": "@autorest/core_v3.0.6372",
+      "date": "Tue, 09 Feb 2021 00:12:31 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Fix csharp generator configuration breaking default v2 settings"
+          }
+        ]
+      }
+    },
+    {
       "version": "3.0.6371",
       "tag": "@autorest/core_v3.0.6371",
       "date": "Mon, 08 Feb 2021 23:06:15 GMT",

--- a/packages/extensions/core/CHANGELOG.md
+++ b/packages/extensions/core/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/core
 
-This log was last generated on Mon, 08 Feb 2021 23:06:15 GMT and should not be manually modified.
+This log was last generated on Tue, 09 Feb 2021 00:12:31 GMT and should not be manually modified.
+
+## 3.0.6372
+Tue, 09 Feb 2021 00:12:31 GMT
+
+### Patches
+
+- Fix csharp generator configuration breaking default v2 settings
 
 ## 3.0.6371
 Mon, 08 Feb 2021 23:06:15 GMT

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/core",
-  "version": "3.0.6371",
+  "version": "3.0.6372",
   "description": "AutoRest core module",
   "engines": {
     "node": ">=10.13.0"

--- a/packages/extensions/core/resources/plugin-csharp.md
+++ b/packages/extensions/core/resources/plugin-csharp.md
@@ -1,6 +1,6 @@
 # Default Configuration - CSharp
 
-The V2 version of the C# Generator.
+The V3 version of the C# Generator.
 
 ``` yaml $(csharp) && !$(legacy) && !$(v2) && !isRequested('@microsoft.azure/autorest.csharp')
 version: ~3.0.6298
@@ -10,7 +10,9 @@ use-extension:
 try-require: ./readme.csharp.md
 ```
 
-``` yaml $(csharp) && $(preview) && $(legacy) || $(v2) || isRequested('@microsoft.azure/autorest.csharp')
+The V2 version of the C# Generator.
+
+``` yaml $(csharp) && $(preview) && ($(legacy) || $(v2) || isRequested('@microsoft.azure/autorest.csharp'))
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core
 version: ~2.0.4413
 
@@ -19,7 +21,7 @@ use-extension:
 try-require: ./readme.csharp.md
 ```
 
-``` yaml $(csharp) && !$(preview) && $(legacy) || $(v2) || isRequested('@microsoft.azure/autorest.csharp')
+``` yaml $(csharp) && !$(preview) && ($(legacy) || $(v2) || isRequested('@microsoft.azure/autorest.csharp'))
 # default the v2 generator to using the last stable @microsoft.azure/autorest-core
 version: ~2.0.4413
 

--- a/packages/testing/test-public-packages/package.json
+++ b/packages/testing/test-public-packages/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Azure/autorest#readme",
   "dependencies": {
-    "@autorest/core": "~3.0.6371",
+    "@autorest/core": "~3.0.6372",
     "autorest": "~3.0.6337",
     "source-map-support": "^0.5.19"
   },


### PR DESCRIPTION
Seems like in the PR to set the default to `v3` the condition for loading the v2 settings got broken.
This is fixing it