### PR TITLE
Fix overridding config in subsequence yaml code block

### DIFF
--- a/common/changes/@autorest/core/fix-overritting_2021-02-09-16-30.json
+++ b/common/changes/@autorest/core/fix-overritting_2021-02-09-16-30.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Fix** Issue where it was not possible to override a config flag defined in the same markdown config. Markdown configuration loading now treats yaml code block in increasing priority order.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/lib/configuration/configuration-loader.ts
+++ b/packages/extensions/core/src/lib/configuration/configuration-loader.ts
@@ -54,7 +54,6 @@ export class ConfigurationLoader {
 
     // load config
     const hConfig = await parseCodeBlocks(contextConfig, configFile, contextConfig.DataStore.getDataSink());
-
     if (hConfig.length === 1 && hConfig[0].info === null && configFile.Description.toLowerCase().endsWith(".md")) {
       // this is a whole file, and it's a markdown file.
       return [];
@@ -246,7 +245,7 @@ export class ConfigurationLoader {
       configurationFiles[configFileUri] = await (await fsInputView.ReadStrict(configFileUri)).ReadData();
 
       const blocks = await this.parseCodeBlocks(await fsInputView.ReadStrict(configFileUri), await createView());
-      await addSegments(blocks, false);
+      await addSegments(blocks.reverse(), false);
     }
 
     // 3. resolve 'require'd configuration
@@ -277,7 +276,7 @@ export class ConfigurationLoader {
 
           configurationFiles[additionalConfig] = await (await inputView.ReadStrict(additionalConfig)).ReadData();
           const blocks = await this.parseCodeBlocks(await inputView.ReadStrict(additionalConfig), await createView());
-          await addSegments(blocks);
+          await addSegments(blocks.reverse());
         } catch (e) {
           messageEmitter.Message.Dispatch({
             Channel: Channel.Fatal,
@@ -297,7 +296,7 @@ export class ConfigurationLoader {
         await inputView.ReadStrict(ResolveUri(CreateFolderUri(AppRoot), "resources/default-configuration.md")),
         await createView(),
       );
-      await addSegments(blocks);
+      await addSegments(blocks.reverse());
     }
 
     await includeFn(fsLocal);
@@ -442,7 +441,7 @@ export class ConfigurationLoader {
             viewsToHandle.push(
               await createView(
                 await addSegments(
-                  blocks.map((each) => (each["pipeline-model"] ? { ...each, "load-priority": 1000 } : each)),
+                  blocks.reverse().map((each) => (each["pipeline-model"] ? { ...each, "load-priority": 1000 } : each)),
                 ),
               ),
             );
@@ -477,7 +476,7 @@ export class ConfigurationLoader {
     // reload files
     if (configFileUri !== null) {
       const blocks = await this.parseCodeBlocks(await fsInputView.ReadStrict(configFileUri), await createView());
-      await addSegments(blocks, false);
+      await addSegments(blocks.reverse(), false);
       await includeFn(this.fileSystem);
       await resolveExtensions();
 

--- a/packages/extensions/core/test/configuration.test.ts
+++ b/packages/extensions/core/test/configuration.test.ts
@@ -137,10 +137,10 @@ value:
     let cfg = await autorest.view;
 
     // output folder should be 'foo'
-    assert.deepEqual(cfg["value"], ["foo", "foo_and_not_bar", "not_bar"]);
+    assert.deepEqual(cfg["value"], ["not_bar", "foo_and_not_bar", "foo"]);
 
     autorest.AddConfiguration({ bar: true });
     cfg = await autorest.view;
-    assert.deepEqual(cfg["value"], ["foo", "foo_and_bar", "bar"]);
+    assert.deepEqual(cfg["value"], ["bar", "foo_and_bar", "foo"]);
   });
 });


### PR DESCRIPTION
fix #3625

Simple example of the issue is markdown as follow

````md

```yaml
output-folder: ./generated-default
```

```yaml $(python)
output-folder: ./generated-python
```
````

Bug was if the python flag was used the output-folder wasn't getting set to `./generated-python`