### PR TITLE
Update @azure-tools/extensions which allows it to be bundled in webpack bundle

### DIFF
--- a/common/changes/@autorest/core/internal-optimize-webpack_2021-02-10-21-43.json
+++ b/common/changes/@autorest/core/internal-optimize-webpack_2021-02-10-21-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Update** @azure-tools/extension to ~3.1.272 and bundle it in the webpack file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/autorest/internal-optimize-webpack_2021-02-10-21-43.json
+++ b/common/changes/autorest/internal-optimize-webpack_2021-02-10-21-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "**Update** @azure-tools/extension to ~3.1.272 ",
+      "type": "patch"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -1,6 +1,6 @@
 dependencies:
   '@azure-tools/async-io': 3.0.253
-  '@azure-tools/extension': 3.1.271
+  '@azure-tools/extension': 3.1.272
   '@azure-tools/linq': 3.1.262
   '@azure-tools/object-comparison': 3.0.252
   '@azure-tools/tasks': 3.0.253
@@ -9,7 +9,7 @@ dependencies:
   '@rush-temp/autorest': file:projects/autorest.tgz_ts-node@9.1.1
   '@rush-temp/codegen': file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/codemodel': file:projects/codemodel.tgz_prettier@2.2.1
-  '@rush-temp/compare': file:projects/compare.tgz
+  '@rush-temp/compare': file:projects/compare.tgz_prettier@2.2.1
   '@rush-temp/core': file:projects/core.tgz_ts-node@9.1.1
   '@rush-temp/datastore': file:projects/datastore.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/deduplication': file:projects/deduplication.tgz_prettier@2.2.1+ts-node@9.1.1
@@ -113,7 +113,7 @@ packages:
       node: '>=10.12.0'
     resolution:
       integrity: sha512-mgWKlHQeqn2i46xtoo+cfW+147lW8RCTwdIDl9XmyeZqsVx8FxBssTdEbKUCvYqFtS+7b6QZXnrYGZuXHD9Ayg==
-  /@azure-tools/extension/3.1.271:
+  /@azure-tools/extension/3.1.272:
     dependencies:
       '@azure-tools/async-io': 3.0.253
       '@azure-tools/eventing': 3.0.252
@@ -128,7 +128,7 @@ packages:
     engines:
       node: '>=10.12.0'
     resolution:
-      integrity: sha512-oMntEJukwqd1C2VgbJ6sOKNMUQivat4Jr8/2ByRZCOYXdnzHwKwuYIFr9NlDmH21ZkeMqS54PQibo4HROtTyeg==
+      integrity: sha512-jLcUCdpUhMgmYqrGzaa9CJQWMA6ZParNMsvHSxIGizIYuf34rtlPA1Fq2R18oeRI8SMKLMKKi+XlGaOrAej4Bg==
   /@azure-tools/linq/3.1.262:
     dev: false
     engines:
@@ -9815,7 +9815,7 @@ packages:
   file:projects/autorest.tgz_ts-node@9.1.1:
     dependencies:
       '@azure-tools/async-io': 3.0.253
-      '@azure-tools/extension': 3.1.271
+      '@azure-tools/extension': 3.1.272
       '@azure-tools/tasks': 3.0.253
       '@azure-tools/uri': 3.0.255
       '@types/commonmark': 0.27.4
@@ -9845,7 +9845,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-JDSI5D2t3oBVSu3RpcbdQBgrRwgelW8FJjWXJvjji96CazsYDUKocjKeDAucNGy9EquETUTkFJCzDF6tLxbARA==
+      integrity: sha512-l+lTDXi+0+f85cEcAMRtkRC0//vXffGDZRJNcQECdLcEVqhUn6t9vWs5lJfSwQVZtJ4hxmnneB/Tyl2D8wiVAw==
       tarball: file:projects/autorest.tgz
     version: 0.0.0
   file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9902,15 +9902,20 @@ packages:
       integrity: sha512-vhewttjjPT80EkaPZ1kN3kUvS/ncPbggJgmVgO03gN8lgkPxdtlDwNaXePeR48jecLekjZJlKivhAG+nUdDG7A==
       tarball: file:projects/codemodel.tgz
     version: 0.0.0
-  file:projects/compare.tgz:
+  file:projects/compare.tgz_prettier@2.2.1:
     dependencies:
       '@types/diff': 4.0.2
       '@types/js-yaml': 4.0.0
       '@types/mocha': 5.2.7
       '@types/node': 14.14.22
       '@types/source-map-support': 0.5.3
+      '@typescript-eslint/eslint-plugin': 4.14.2_e5f964fa93e839b7a7927397f6cb9cb1
+      '@typescript-eslint/parser': 4.14.2_eslint@7.19.0+typescript@4.1.3
       chalk: 4.1.0
       diff: 4.0.2
+      eslint: 7.19.0
+      eslint-plugin-prettier: 3.2.0_eslint@7.19.0+prettier@2.2.1
+      eslint-plugin-unicorn: 27.0.0_eslint@7.19.0
       js-yaml: 4.0.0
       mocha: 6.2.3
       source-map-support: 0.5.19
@@ -9921,15 +9926,18 @@ packages:
       ts-node: 9.1.1_typescript@4.1.3
       typescript: 4.1.3
     dev: false
+    id: file:projects/compare.tgz
     name: '@rush-temp/compare'
+    peerDependencies:
+      prettier: '*'
     resolution:
-      integrity: sha512-n6c/gJk7FCAvpGjjV5ckJtBiuALxT57Ncm54ypp8j/+nW8PvVr2BsRv6QZIySNbIeMNU2gUJwCv7OW+7Myhmjg==
+      integrity: sha512-Twa6pn0zBRB7MWM+rMR71EEQMYc7tM1iVAfStb1i04lQaN1DZZ/Eh4mb1jdPJE+/kR24PoKLxvMLjKm3rnvOXA==
       tarball: file:projects/compare.tgz
     version: 0.0.0
   file:projects/core.tgz_ts-node@9.1.1:
     dependencies:
       '@azure-tools/async-io': 3.0.253
-      '@azure-tools/extension': 3.1.271
+      '@azure-tools/extension': 3.1.272
       '@azure-tools/linq': 3.1.262
       '@azure-tools/object-comparison': 3.0.252
       '@azure-tools/tasks': 3.0.253
@@ -9975,7 +9983,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-cLN7ZritReZLr1Q6MCDqUCv8kfpm12gnjvRZ5824WN2X3j8YE8lE4O84XL6s4+6k25PQCQKZIwGK2t7ThBk6ng==
+      integrity: sha512-rClVUIcTSsreGuuNM2/Pzh9IIyvgfu9ODcO33u6vAnWTMxMSXfmDi3CVU+42AB6gfjIeWx6ufp/7VbfZ4UadRA==
       tarball: file:projects/core.tgz
     version: 0.0.0
   file:projects/datastore.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -10237,7 +10245,7 @@ packages:
 registry: ''
 specifiers:
   '@azure-tools/async-io': ~3.0.0
-  '@azure-tools/extension': ~3.1.271
+  '@azure-tools/extension': ~3.1.272
   '@azure-tools/linq': ~3.1.0
   '@azure-tools/object-comparison': ~3.0.0
   '@azure-tools/tasks': ~3.0.0

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@autorest/core": "~3.0.6372",
     "@azure-tools/async-io": "~3.0.0",
-    "@azure-tools/extension": "~3.1.271",
+    "@azure-tools/extension": "~3.1.272",
     "@azure-tools/tasks": "~3.0.0",
     "@azure-tools/uri": "~3.0.0",
     "@types/commonmark": "^0.27.0",
@@ -72,7 +72,7 @@
     "dependencies": {
       "@azure-tools/async-io": "~3.0.0",
       "@azure-tools/uri": "~3.0.0",
-      "@azure-tools/extension": "~3.1.271",
+      "@azure-tools/extension": "~3.1.272",
       "@azure-tools/tasks": "~3.0.0",
       "semver": "^5.5.1",
       "chalk": "2.3.0"

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -44,6 +44,7 @@
     "@azure-tools/codegen": "~2.5.293",
     "@azure-tools/datastore": "~4.1.271",
     "@azure-tools/deduplication": "~3.0.266",
+    "@azure-tools/extension": "~3.1.272",
     "@azure-tools/linq": "~3.1.0",
     "@azure-tools/oai2-to-oai3": "~4.2.276",
     "@azure-tools/object-comparison": "~3.0.0",
@@ -86,7 +87,6 @@
     "webpack-node-externals": "~2.5.2"
   },
   "dependencies": {
-    "jsonpath": "1.0.0",
-    "@azure-tools/extension": "~3.1.271"
+    "jsonpath": "1.0.0"
   }
 }

--- a/packages/extensions/core/webpack.config.js
+++ b/packages/extensions/core/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   externals: [
     nodeExternals({
-      allowlist: [/^(?:(?!jsonpath|@azure-tools\/extension).)*$/],
+      allowlist: [/^(?:(?!jsonpath).)*$/],
     }),
   ],
   optimization: {


### PR DESCRIPTION
Issue was the library was using require to load package.json dynamicaly. Webpack was trying to convert this require which caused issue. Require has been removed and now the library can be bundled in webpack.

Comparaison of the dist folder size:
- Before: `6 MB` 
- After bundling `@azure-tools/extension`:  `9.0MB`
- Before migrating to webpack(Using static-link) -> `25MB` 

Even though those size are much smaller it was taking about 3 times longer to install the 6MB package than the bundled `25MB`, all of that due to the installing of additional dependencies which cascade

There is still the `jsonpath` library that can't be bundled. Bundling it would add less than `1MB` to the bundle size and would remove the last prod dependency. Will see if we can get rid of this library or switch to an alternate one without the issue.
