### PR TITLE
Feature: Autorest cli migration to webpack

### DIFF
--- a/common/changes/@autorest/core/feature-autorest-cli-webpack_2021-02-17-17-58.json
+++ b/common/changes/@autorest/core/feature-autorest-cli-webpack_2021-02-17-17-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/extension/feature-autorest-cli-webpack_2021-02-17-17-33.json
+++ b/common/changes/@azure-tools/extension/feature-autorest-cli-webpack_2021-02-17-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/extension",
+      "comment": "**Feature**: Add option to set the path to the yarn cli in the ExtensionManager. This enable webpack compatibility.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/extension",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/autorest/feature-autorest-cli-webpack_2021-02-17-17-33.json
+++ b/common/changes/autorest/feature-autorest-cli-webpack_2021-02-17-17-33.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "**Migrate** to using webpack for bundling.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -6,7 +6,7 @@ dependencies:
   '@azure-tools/tasks': 3.0.253
   '@azure-tools/uri': 3.0.255
   '@microsoft.azure/autorest.testserver': 2.10.68
-  '@rush-temp/autorest': file:projects/autorest.tgz_ts-node@9.1.1
+  '@rush-temp/autorest': file:projects/autorest.tgz_ts-node@9.1.1+webpack-cli@4.4.0
   '@rush-temp/codegen': file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/codemodel': file:projects/codemodel.tgz_prettier@2.2.1
   '@rush-temp/common': file:projects/common.tgz_prettier@2.2.1+ts-node@9.1.1
@@ -51,6 +51,7 @@ dependencies:
   chalk: 4.1.0
   commonmark: 0.27.0
   compare-versions: 3.6.0
+  copy-webpack-plugin: 7.0.0_webpack@5.18.0
   cpy-cli: 2.0.0
   deep-equal: 2.0.5
   diff: 4.0.2
@@ -2589,6 +2590,24 @@ packages:
       node: '>=0.10.0'
     resolution:
       integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+  /copy-webpack-plugin/7.0.0_webpack@5.18.0:
+    dependencies:
+      fast-glob: 3.2.5
+      glob-parent: 5.1.1
+      globby: 11.0.2
+      loader-utils: 2.0.0
+      normalize-path: 3.0.0
+      p-limit: 3.1.0
+      schema-utils: 3.0.0
+      serialize-javascript: 5.0.1
+      webpack: 5.18.0_webpack-cli@4.4.0
+    dev: false
+    engines:
+      node: '>= 10.13.0'
+    peerDependencies:
+      webpack: ^5.1.0
+    resolution:
+      integrity: sha512-SLjQNa5iE3BoCP76ESU9qYo9ZkEWtXoZxDurHoqPchAFRblJ9g96xTeC560UXBMre1Nx6ixIIUfiY3VcjpJw3g==
   /core-js/2.6.12:
     deprecated: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
     dev: false
@@ -9992,19 +10011,20 @@ packages:
       commander: 2.20.3
     resolution:
       integrity: sha512-58TxNEurHQEEgbrNbQnoUHXgh6tiplSvKb7D3o4K6KzICQk9vFyl8B0zycC/p3gW92qBZCmq5NJIhJODKrV7JQ==
-  file:projects/autorest.tgz_ts-node@9.1.1:
+  file:projects/autorest.tgz_ts-node@9.1.1+webpack-cli@4.4.0:
     dependencies:
       '@azure-tools/async-io': 3.0.253
-      '@azure-tools/extension': 3.1.272
       '@azure-tools/tasks': 3.0.253
       '@azure-tools/uri': 3.0.255
       '@types/commonmark': 0.27.4
       '@types/jest': 26.0.20
       '@types/node': 14.14.22
       '@types/semver': 5.5.0
+      '@types/webpack': 4.41.26
       '@typescript-eslint/eslint-plugin': 4.14.2_e5f964fa93e839b7a7927397f6cb9cb1
       '@typescript-eslint/parser': 4.14.2_eslint@7.19.0+typescript@4.1.3
       chalk: 4.1.0
+      copy-webpack-plugin: 7.0.0_webpack@5.18.0
       cpy-cli: 2.0.0
       eslint: 7.19.0
       eslint-plugin-prettier: 3.2.0_eslint@7.19.0+prettier@2.2.1
@@ -10018,14 +10038,17 @@ packages:
       source-map-support: 0.5.19
       static-link: 0.3.0
       ts-jest: 26.5.0_jest@26.6.3+typescript@4.1.3
+      ts-loader: 8.0.14_typescript@4.1.3+webpack@5.18.0
       typescript: 4.1.3
+      webpack: 5.18.0_webpack-cli@4.4.0
     dev: false
     id: file:projects/autorest.tgz
     name: '@rush-temp/autorest'
     peerDependencies:
       ts-node: '*'
+      webpack-cli: '*'
     resolution:
-      integrity: sha512-jpTf1H5/3b+sWAOxRlKYLXX8OIBMIcXHEXMYLFJexQQ2htN8PfAaKFufcAz3bUM2SsbyOiyPo6+p42eG9c2SQw==
+      integrity: sha512-ACuGPhIdPEll6vkp5TFiNNIImxsrxGjIaZ8eEZ55p3tCLRT2iqvlP/vWNdkOZ4AeprsOl4zmN6ggbZaaCamXbA==
       tarball: file:projects/autorest.tgz
     version: 0.0.0
   file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -10562,6 +10585,7 @@ specifiers:
   chalk: ^4.1.0
   commonmark: ^0.27.0
   compare-versions: ^3.4.0
+  copy-webpack-plugin: ^7.0.0
   cpy-cli: ~2.0.0
   deep-equal: ^2.0.5
   diff: ^4.0.1

--- a/packages/apps/autorest/definitions/index.d.ts
+++ b/packages/apps/autorest/definitions/index.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Represent the NodeJs require when in a webpack bundle.
+ * https://webpack.js.org/api/module-variables/#__non_webpack_require__-webpack-specific
+ */
+declare let __non_webpack_require__: NodeJS.Require | undefined;
+declare let __webpack_require__: NodeJS.Require | undefined;

--- a/packages/apps/autorest/entrypoints/app.js
+++ b/packages/apps/autorest/entrypoints/app.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+/* eslint-disable no-console */
 
 global.isDebuggerEnabled =
   !!require("inspector").url() || global.v8debug || /--debug|--inspect/.test(process.execArgv.join(" "));
@@ -46,17 +47,7 @@ if (
       process.exit(1);
     }
 
-    if (v[0] > 14) {
-      console.error("\nWARNING: AutoRest has not been tested with Node versions greater than v14.\n");
-    }
-    if (
-      process.argv.indexOf("--no-static-loader") === -1 &&
-      process.env["no-static-loader"] === undefined &&
-      require("fs").existsSync(`${__dirname}/../dist/static-loader.js`)
-    ) {
-      require(`${__dirname}/../dist/static-loader.js`).load(`${__dirname}/../dist/static_modules.fs`);
-    }
-    require(`${__dirname}/../dist/src/app.js`);
+    require(`${__dirname}/../dist/app.js`);
   } catch (e) {
     console.error(e);
   }

--- a/packages/apps/autorest/entrypoints/app.js
+++ b/packages/apps/autorest/entrypoints/app.js
@@ -47,6 +47,10 @@ if (
       process.exit(1);
     }
 
+    if (v[0] > 14) {
+      console.error("\nWARNING: AutoRest has not been tested with Node versions greater than v14.\n");
+    }
+
     require(`${__dirname}/../dist/app.js`);
   } catch (e) {
     console.error(e);

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -65,21 +65,9 @@
     "safe-buffer": "5.2.0",
     "semver": "^5.5.1",
     "source-map-support": "^0.5.19",
-    "static-link": "^0.3.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "~8.0.14",
     "typescript": "~4.1.3",
     "webpack": "~5.18.0"
-  },
-  "static-link": {
-    "entrypoints": [],
-    "dependencies": {
-      "@azure-tools/async-io": "~3.0.0",
-      "@azure-tools/uri": "~3.0.0",
-      "@azure-tools/extension": "~3.1.272",
-      "@azure-tools/tasks": "~3.0.0",
-      "semver": "^5.5.1",
-      "chalk": "2.3.0"
-    }
   }
 }

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -30,12 +30,12 @@
     "test": "jest --coverage=false",
     "test:ci": "jest --ci",
     "build": "tsc -p .",
+    "build:prod": "webpack",
     "watch": "tsc -p . --watch",
     "lint:fix": "eslint ./src --fix --ext .ts",
     "lint": "eslint ./src --ext .ts --max-warnings=0",
-    "static-link": "static-link --force --no-node-modules",
     "preinstall": "node ./.scripts/preinstall-check",
-    "prepack": "npm run static-link && npm run build",
+    "prepack": "npm run clean && npm run build:prod",
     "clean": "rimraf ./dist"
   },
   "typings": "./dist/src/exports.d.ts",
@@ -49,6 +49,7 @@
     "@types/jest": "^26.0.20",
     "@types/node": "~14.14.20",
     "@types/semver": "5.5.0",
+    "@types/webpack": "~4.41.26",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "chalk": "^4.1.0",
@@ -65,7 +66,9 @@
     "source-map-support": "^0.5.19",
     "static-link": "^0.3.0",
     "ts-jest": "^26.4.4",
-    "typescript": "~4.1.3"
+    "ts-loader": "~8.0.14",
+    "typescript": "~4.1.3",
+    "webpack": "~5.18.0"
   },
   "static-link": {
     "entrypoints": [],

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -53,6 +53,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "chalk": "^4.1.0",
+    "copy-webpack-plugin": "^7.0.0",
     "cpy-cli": "~2.0.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -21,7 +21,7 @@
   "bugs": {
     "url": "https://github.com/Azure/autorest/issues"
   },
-  "main": "./dist/src/exports.js",
+  "main": "./dist/exports.js",
   "bin": {
     "autorest": "./entrypoints/app.js"
   },
@@ -29,16 +29,16 @@
     "start": "node ./dist/src/app.js",
     "test": "jest --coverage=false",
     "test:ci": "jest --ci",
-    "build": "tsc -p .",
+    "build": "tsc -p tsconfig.build.json",
     "build:prod": "webpack",
-    "watch": "tsc -p . --watch",
+    "watch": "tsc -p tsconfig.build.json --watch",
     "lint:fix": "eslint ./src --fix --ext .ts",
     "lint": "eslint ./src --ext .ts --max-warnings=0",
     "preinstall": "node ./.scripts/preinstall-check",
     "prepack": "npm run clean && npm run build:prod",
     "clean": "rimraf ./dist"
   },
-  "typings": "./dist/src/exports.d.ts",
+  "typings": "./dist/exports.d.ts",
   "devDependencies": {
     "@autorest/core": "~3.0.6373",
     "@azure-tools/async-io": "~3.0.0",

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -169,12 +169,10 @@ export async function runCoreOutOfProc(localPath: string | null, entrypoint: str
     if (ep) {
       // Creates the nodejs command to load the target core
       // - copies the argv parameters
-      // - loads our static loader (so the newer loader is used, and we can get to 'chalk' in our static fs) - For backward compatibility.
       // - loads the js file with coloring (core expects a global function called 'color' )
       // - loads the actual entrypoint that we expect is there.
       const cmd = `
         process.argv = ${JSON.stringify(process.argv)};
-        if (require('fs').existsSync('${__dirname}/../static-loader.js')) { require('${__dirname}/../static-loader.js').load('${__dirname}/../static_modules.fs'); }
         const { color } = require('${__dirname}/exports');
         global.color = color;
         require('${ep}')

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -14,7 +14,8 @@ import { tmpdir } from "os";
 import { spawn } from "child_process";
 import { AutorestArgs } from "./args";
 
-const nodeRequire = typeof __webpack_require__ === "function" ? __non_webpack_require__ : require;
+const inWebpack = typeof __webpack_require__ === "function";
+const nodeRequire = inWebpack ? __non_webpack_require__ : require;
 
 export const pkgVersion: string = require(`../package.json`).version;
 process.env["autorest.home"] = process.env["autorest.home"] || homedir();
@@ -29,7 +30,9 @@ try {
 export const rootFolder = join(process.env["autorest.home"], ".autorest");
 const args: AutorestArgs = (<any>global).__args || {};
 
-export const extensionManager: Promise<ExtensionManager> = ExtensionManager.Create(rootFolder);
+const pathToYarnCli = inWebpack ? `${__dirname}/yarn/cli.js` : undefined;
+
+export const extensionManager: Promise<ExtensionManager> = ExtensionManager.Create(rootFolder, "yarn", pathToYarnCli);
 export const oldCorePackage = "@microsoft.azure/autorest-core";
 export const newCorePackage = "@autorest/core";
 

--- a/packages/apps/autorest/src/coloring.ts
+++ b/packages/apps/autorest/src/coloring.ts
@@ -62,4 +62,3 @@ export function color(text: string): string {
       .replace(/'(.*?)'/gm, addStyle("gray", "'$1'")),
   );
 }
-(<any>global).color = color;

--- a/packages/apps/autorest/src/core-version-utils.ts
+++ b/packages/apps/autorest/src/core-version-utils.ts
@@ -7,6 +7,9 @@ import { resolveEntrypoint, selectVersion } from "./autorest-as-a-service";
 import * as vm from "vm";
 import { Extension } from "@azure-tools/extension";
 
+const inWebpack = typeof __webpack_require__ === "function";
+const nodeRequire = inWebpack ? __non_webpack_require__ : require;
+
 /**
  * Return the version requested of the core extension.
  * @param args ClI args.
@@ -33,7 +36,7 @@ export const configurationSpecifiedVersion = async (args: AutorestArgs, selected
 
     // things we need in the sandbox.
     const sandbox = {
-      require: __non_webpack_require__,
+      require: nodeRequire,
       console,
       rfs: {
         EnumerateFileUris: async (folderUri: string): Promise<Array<string>> => {

--- a/packages/apps/autorest/src/core-version-utils.ts
+++ b/packages/apps/autorest/src/core-version-utils.ts
@@ -33,7 +33,7 @@ export const configurationSpecifiedVersion = async (args: AutorestArgs, selected
 
     // things we need in the sandbox.
     const sandbox = {
-      require,
+      require: __non_webpack_require__,
       console,
       rfs: {
         EnumerateFileUris: async (folderUri: string): Promise<Array<string>> => {

--- a/packages/apps/autorest/src/exports.ts
+++ b/packages/apps/autorest/src/exports.ts
@@ -6,19 +6,6 @@
 /// <reference path="../definitions/core.d.ts" />
 /// <reference path="../definitions/vscode.d.ts" />
 
-// if this is being run directly, call the app entrypoint (we're probably running the local folder)
-if (require.main === module) {
-  require("../../entrypoints/app");
-}
-
-// load modules from static linker filesystem.
-if (
-  process.argv.indexOf("--no-static-loader") === -1 &&
-  process.env["no-static-loader"] === undefined &&
-  require("fs").existsSync(`${__dirname}/../static-loader.js`)
-) {
-  require("../static-loader.js").load(`${__dirname}/../static_modules.fs`);
-}
 // everything else.
 import { tryRequire, resolveEntrypoint, ensureAutorestHome, selectVersion } from "./autorest-as-a-service";
 import { resolve } from "path";
@@ -28,6 +15,7 @@ import { LanguageClient } from "vscode-languageclient";
 // exports the public AutoRest definitions
 import { GenerationResults, IFileSystem, AutoRest as IAutoRest } from "autorest-core";
 export { Message, Artifact, GenerationResults, IFileSystem } from "autorest-core";
+export { color } from "./coloring";
 
 /**
  * The Channel that a message is registered with.

--- a/packages/apps/autorest/tsconfig.build.json
+++ b/packages/apps/autorest/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.*", "test/**/*"]
+}

--- a/packages/apps/autorest/webpack.config.js
+++ b/packages/apps/autorest/webpack.config.js
@@ -2,7 +2,7 @@
 
 const path = require("path");
 const baseWebpackConfig = require("../../../common/config/webpack.base.config");
-
+const CopyPlugin = require("copy-webpack-plugin");
 /**
  * @type {import("webpack").Configuration}
  */
@@ -17,6 +17,12 @@ module.exports = {
     path: path.resolve(__dirname, "dist"),
     libraryTarget: "commonjs2",
   },
+  plugins: [
+    // We need to copy the yarn cli.js so @azure-tools/extensions can call the file as it is.(Not bundled in the webpack bundle.)
+    new CopyPlugin({
+      patterns: [{ from: "node_modules/@azure-tools/extension/dist/yarn/cli.js", to: "yarn/cli.js" }],
+    }),
+  ],
   optimization: {
     ...baseWebpackConfig.optimization,
     // Makes sure the different endpoints don't duplicate share common code.

--- a/packages/apps/autorest/webpack.config.js
+++ b/packages/apps/autorest/webpack.config.js
@@ -1,0 +1,27 @@
+// @ts-check
+
+const path = require("path");
+const baseWebpackConfig = require("../../../common/config/webpack.base.config");
+
+/**
+ * @type {import("webpack").Configuration}
+ */
+module.exports = {
+  ...baseWebpackConfig,
+  entry: {
+    app: "./src/app.ts",
+    exports: "./src/exports.ts",
+  },
+  output: {
+    ...baseWebpackConfig.output,
+    path: path.resolve(__dirname, "dist"),
+    libraryTarget: "commonjs2",
+  },
+  optimization: {
+    ...baseWebpackConfig.optimization,
+    // Makes sure the different endpoints don't duplicate share common code.
+    splitChunks: {
+      chunks: "all",
+    },
+  },
+};

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -78,7 +78,6 @@
     "safe-buffer": "5.2.0",
     "source-map-support": "^0.5.19",
     "source-map": "0.5.6",
-    "static-link": "^0.3.0",
     "ts-jest": "^26.4.4",
     "ts-loader": "~8.0.14",
     "typescript": "~4.1.3",

--- a/packages/libs/extension/src/main.ts
+++ b/packages/libs/extension/src/main.ts
@@ -385,6 +385,7 @@ export class ExtensionManager {
   public static async Create(
     installationPath: string,
     packageManagerType: PackageManagerType = "yarn",
+    packageManagerPath: string | undefined = undefined,
   ): Promise<ExtensionManager> {
     if (!(await exists(installationPath))) {
       await mkdir(installationPath);
@@ -393,7 +394,7 @@ export class ExtensionManager {
       throw new Exception(`Extension folder '${installationPath}' is not a valid directory`);
     }
     const lock = new SharedLock(installationPath);
-    const packageManager = packageManagerType === "yarn" ? new Yarn() : new Npm();
+    const packageManager = packageManagerType === "yarn" ? new Yarn(packageManagerPath) : new Npm();
     return new ExtensionManager(installationPath, lock, await lock.acquire(), packageManager);
   }
 

--- a/packages/libs/extension/src/yarn.ts
+++ b/packages/libs/extension/src/yarn.ts
@@ -26,23 +26,11 @@ const getPathToYarnCli = async () => {
   return _cli;
 };
 
-export const execYarn = async (cwd: string, ...args: string[]) => {
-  const procArgs = [
-    await getPathToYarnCli(),
-    "--no-node-version-check",
-    "--no-lockfile",
-    "--json",
-    "--registry",
-    process.env.autorest_registry || DEFAULT_NPM_REGISTRY,
-    ...args,
-  ];
-
-  return await execute(process.execPath, procArgs, { cwd });
-};
-
 export class Yarn implements PackageManager {
+  public constructor(private pathToYarnCli: string | undefined = undefined) {}
+
   public async install(directory: string, packages: string[], options?: InstallOptions) {
-    const output = await execYarn(
+    const output = await this.execYarn(
       directory,
       "add",
       "--global-folder",
@@ -62,11 +50,25 @@ export class Yarn implements PackageManager {
   }
 
   public async clean(directory: string): Promise<void> {
-    await execYarn(directory, "cache", "clean", "--force");
+    await this.execYarn(directory, "cache", "clean", "--force");
   }
 
   public async getPackageVersions(directory: string, packageName: string): Promise<string[]> {
-    const result = await execYarn(directory, "info", packageName, "versions", "--json");
+    const result = await this.execYarn(directory, "info", packageName, "versions", "--json");
     return JSON.parse(result.stdout).data;
+  }
+
+  public async execYarn(cwd: string, ...args: string[]) {
+    const procArgs = [
+      this.pathToYarnCli ?? (await getPathToYarnCli()),
+      "--no-node-version-check",
+      "--no-lockfile",
+      "--json",
+      "--registry",
+      process.env.autorest_registry || DEFAULT_NPM_REGISTRY,
+      ...args,
+    ];
+
+    return await execute(process.execPath, procArgs, { cwd });
   }
 }


### PR DESCRIPTION
Last package using `static-link`

Changes:
- Migration to webpack
- Updated some requires to be compatible with webpack
- Added a way for extension to call yarn cli from webpack bundle.