### PR TITLE
Fixes from latest release: Node 10 breaking with use of `flatMap` & autorest requiring core version ~3.1.0 which doesn't exists

### DIFF
--- a/.default-eslintrc.yaml
+++ b/.default-eslintrc.yaml
@@ -13,6 +13,7 @@ env:
 extends:
   - eslint:recommended
   - plugin:@typescript-eslint/recommended
+  - plugin:node/recommended
 
 globals:
   Atomics: readonly
@@ -55,6 +56,9 @@ rules:
   # Prevent from using method that are not yet availalbe in the supported version of node.(see engines field of package.json)
   node/no-unsupported-features/node-builtins: [error, { "ignores": ["fs.promises"] }]
   node/no-unsupported-features/es-builtins: error
+  node/no-unsupported-features/es-syntax: off # Disabling this one otherwise it will complain about typescript imports which get transpiled.
+  node/no-missing-import: off
+  node/shebang: off
 
   # Basic config
   no-console: warn

--- a/.default-eslintrc.yaml
+++ b/.default-eslintrc.yaml
@@ -4,11 +4,12 @@ plugins:
   - "@typescript-eslint"
   - prettier
   - unicorn
+  - node
 
 env:
   es6: true
   node: true
-  
+
 extends:
   - eslint:recommended
   - plugin:@typescript-eslint/recommended
@@ -39,14 +40,21 @@ rules:
   "@typescript-eslint/consistent-type-assertions": "off"
 
   "require-atomic-updates": "off"
-  
+
   # Prettier config https://github.com/prettier/eslint-plugin-prettier#recommended-configuration
   prettier/prettier: "warn"
   arrow-body-style: "off"
   prefer-arrow-callback: "off"
 
-  # Unicorn plugin config 
+  # Unicorn plugin config
   unicorn/filename-case: warn
+
+  # =================================================
+  # Node plugin
+  # =================================================
+  # Prevent from using method that are not yet availalbe in the supported version of node.(see engines field of package.json)
+  node/no-unsupported-features/node-builtins: [error, { "ignores": ["fs.promises"] }]
+  node/no-unsupported-features/es-builtins: error
 
   # Basic config
   no-console: warn

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -59,6 +59,7 @@ dependencies:
   diff: 4.0.2
   eslint: 7.19.0
   eslint-plugin-import: 2.22.1_eslint@7.19.0
+  eslint-plugin-node: 11.1.0_eslint@7.19.0
   eslint-plugin-prettier: 3.2.0_eslint@7.19.0+prettier@2.2.1
   eslint-plugin-unicorn: 27.0.0_eslint@7.19.0
   expect: 26.6.2
@@ -85,7 +86,6 @@ dependencies:
   semver: 5.7.1
   source-map: 0.5.6
   source-map-support: 0.5.19
-  static-link: 0.3.0
   supertest: 6.1.3
   tree-sitter: 0.17.1
   tree-sitter-python: 0.16.1
@@ -3271,6 +3271,18 @@ packages:
       node: '>=4'
     resolution:
       integrity: sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==
+  /eslint-plugin-es/3.0.1_eslint@7.19.0:
+    dependencies:
+      eslint: 7.19.0
+      eslint-utils: 2.1.0
+      regexpp: 3.1.0
+    dev: false
+    engines:
+      node: '>=8.10.0'
+    peerDependencies:
+      eslint: '>=4.19.1'
+    resolution:
+      integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
   /eslint-plugin-import/2.22.1_eslint@7.19.0:
     dependencies:
       array-includes: 3.1.2
@@ -3294,6 +3306,22 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
     resolution:
       integrity: sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
+  /eslint-plugin-node/11.1.0_eslint@7.19.0:
+    dependencies:
+      eslint: 7.19.0
+      eslint-plugin-es: 3.0.1_eslint@7.19.0
+      eslint-utils: 2.1.0
+      ignore: 5.1.8
+      minimatch: 3.0.4
+      resolve: 1.19.0
+      semver: 6.3.0
+    dev: false
+    engines:
+      node: '>=8.10.0'
+    peerDependencies:
+      eslint: '>=5.16.0'
+    resolution:
+      integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
   /eslint-plugin-prettier/3.2.0_eslint@7.19.0+prettier@2.2.1:
     dependencies:
       eslint: 7.19.0
@@ -9923,7 +9951,7 @@ packages:
       ts-node: '*'
       webpack-cli: '*'
     resolution:
-      integrity: sha512-ACuGPhIdPEll6vkp5TFiNNIImxsrxGjIaZ8eEZ55p3tCLRT2iqvlP/vWNdkOZ4AeprsOl4zmN6ggbZaaCamXbA==
+      integrity: sha512-7Bz86dLfn4/e5zIwqkNU/aY5LvNqxOsUUyqhoVuHmL815iUGyGGa+6/VC5/2aPsYtzH3XJ+sXL0Op0DM0S+nzA==
       tarball: file:projects/autorest.tgz
     version: 0.0.0
   file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -10033,7 +10061,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-t4azGXIcHAol0HLkcV8wuR2d1oI6RcE+Ai1N1MwN+gOof5SIMw/MKxdO643tvOND//MQNRiKRX9LMil0ir4Ahg==
+      integrity: sha512-NLBS7taKQrqj3mOGag9tNEHM96NUe2v7y84pafIJcCk3CCJf8SR2bod/OBWl9yMSQWoLSUJ7FOjYzmqs18GeDQ==
       tarball: file:projects/compare.tgz
     version: 0.0.0
   file:projects/configuration.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -10077,8 +10105,10 @@ packages:
       '@typescript-eslint/parser': 4.14.2_eslint@7.19.0+typescript@4.1.3
       commonmark: 0.27.0
       compare-versions: 3.6.0
+      copy-webpack-plugin: 7.0.0_webpack@5.18.0
       cpy-cli: 2.0.0
       eslint: 7.19.0
+      eslint-plugin-node: 11.1.0_eslint@7.19.0
       eslint-plugin-prettier: 3.2.0_eslint@7.19.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.19.0
       jest: 26.6.3_ts-node@9.1.1
@@ -10109,7 +10139,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-+4rTtSdQpQCAaIAlnbYo6aex4H0LIgLjnKkxJH/o4gXz7jlEwq+gt+gk+sVR1n+0cpBbO4vvu+W9ylFzYO3MfA==
+      integrity: sha512-U4K6Wps2b4Tnq1HsDH0ETEaADpjSA+EEaU6fQitH995efai4Ub7IPjUL6olAo48yisWjoG6LSgXMGwS7PaA05g==
       tarball: file:projects/core.tgz
     version: 0.0.0
   file:projects/datastore.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -10307,7 +10337,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-koUPSSFR2IW2NXM7npqRl4CHXo5dm01TAERurx8mvO6zMGgY91ke/UQqE0Jh6JctdjXJenytbDmdjyV2NhO6TQ==
+      integrity: sha512-uQb+aXA/NVchdEWWeQfScxyA6KcNSwtOS8ywwsBa24/On5JKTlvvWh4rXbqZAHQKAeodOFPLXEuJbAf8QtZ1OQ==
       tarball: file:projects/modelerfour.tgz
     version: 0.0.0
   file:projects/oai2-to-oai3.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -10385,7 +10415,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-Vg5USU9s+ETvgGPbMtFyQmbgxU1WY2yRIP5x4smSIYGXwhrYXH89mbHG3KgIA7yos7rL2j6EvH2RAqmmfEifhg==
+      integrity: sha512-qAOu8My8DYGINySqgtz3vCktWY8KpSlQh8Dh97QlR/7CeYn3bVJE98aBR79HgPB3b7FmdVSewa3TriFE5naGFQ==
       tarball: file:projects/test-public-packages.tgz
     version: 0.0.0
   file:projects/test-utils.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -10470,6 +10500,7 @@ specifiers:
   diff: ^4.0.1
   eslint: ^7.17.0
   eslint-plugin-import: ~2.22.1
+  eslint-plugin-node: ~11.1.0
   eslint-plugin-prettier: ~3.2.0
   eslint-plugin-unicorn: ~27.0.0
   expect: ~26.6.2
@@ -10496,7 +10527,6 @@ specifiers:
   semver: ^5.5.1
   source-map: 0.5.6
   source-map-support: ^0.5.19
-  static-link: ^0.3.0
   supertest: ^6.0.1
   tree-sitter: ^0.17.0
   tree-sitter-python: ^0.16.0

--- a/packages/apps/autorest/CHANGELOG.json
+++ b/packages/apps/autorest/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "autorest",
   "entries": [
     {
+      "version": "3.1.1",
+      "tag": "autorest_v3.1.1",
+      "date": "Sun, 21 Feb 2021 05:37:47 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "**Fix**: Loosen default version requirement for @autorest/core to only be the same major version as the cli."
+          }
+        ]
+      }
+    },
+    {
       "version": "3.1.0",
       "tag": "autorest_v3.1.0",
       "date": "Fri, 19 Feb 2021 21:42:09 GMT",

--- a/packages/apps/autorest/CHANGELOG.md
+++ b/packages/apps/autorest/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - autorest
 
-This log was last generated on Fri, 19 Feb 2021 21:42:09 GMT and should not be manually modified.
+This log was last generated on Sun, 21 Feb 2021 05:37:47 GMT and should not be manually modified.
+
+## 3.1.1
+Sun, 21 Feb 2021 05:37:47 GMT
+
+### Patches
+
+- **Fix**: Loosen default version requirement for @autorest/core to only be the same major version as the cli.
 
 ## 3.1.0
 Fri, 19 Feb 2021 21:42:09 GMT

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -55,6 +55,7 @@
     "chalk": "^4.1.0",
     "copy-webpack-plugin": "^7.0.0",
     "cpy-cli": "~2.0.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autorest",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "The AutoRest tool generates client libraries for accessing RESTful web services. Input to AutoRest is an OpenAPI spec that describes the REST API.",
   "engines": {
     "node": ">=10.13.0"

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -40,7 +40,7 @@
   },
   "typings": "./dist/exports.d.ts",
   "devDependencies": {
-    "@autorest/core": "~3.0.6374",
+    "@autorest/core": "~3.0.6375",
     "@azure-tools/async-io": "~3.0.0",
     "@azure-tools/extension": "~3.2.0",
     "@azure-tools/tasks": "~3.0.0",

--- a/packages/apps/autorest/src/app.ts
+++ b/packages/apps/autorest/src/app.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-exit */
 /*---------------------------------------------------------------------------------------------
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -40,7 +40,12 @@ export const newCorePackage = "@autorest/core";
 const basePkgVersion = semver.parse(
   pkgVersion.indexOf("-") > -1 ? pkgVersion.substring(0, pkgVersion.indexOf("-")) : pkgVersion,
 );
-const versionRange = `~${basePkgVersion.major}.${basePkgVersion.minor}.0`; // the version range of the core package required.
+
+/**
+ * The version range of the core package required.
+ * Require @autorest/core to have the same major version as autorest.
+ */
+const versionRange = `~${basePkgVersion.major}.0.0`;
 
 export const networkEnabled: Promise<boolean> = new Promise<boolean>((r, j) => {
   lookup("8.8.8.8", 4, (err, address, family) => {

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -45,7 +45,7 @@ const basePkgVersion = semver.parse(
  * The version range of the core package required.
  * Require @autorest/core to have the same major version as autorest.
  */
-const versionRange = `~${basePkgVersion.major}.0.0`;
+const versionRange = `^${basePkgVersion.major}.0.0`;
 
 export const networkEnabled: Promise<boolean> = new Promise<boolean>((r, j) => {
   lookup("8.8.8.8", 4, (err, address, family) => {

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-process-exit */
 /* eslint-disable no-console */
 import { lookup } from "dns";
 import { Extension, ExtensionManager, Package } from "@azure-tools/extension";
@@ -91,6 +92,7 @@ export function resolvePathForLocalVersion(requestedVersion: string | null): str
   } catch (e) {
     // fallback to old-core name
     try {
+      // eslint-disable-next-line node/no-missing-require
       return dirname(nodeRequire.resolve("@microsoft.azure/autorest-core/package.json"));
     } catch {
       // no dice

--- a/packages/extensions/core/CHANGELOG.json
+++ b/packages/extensions/core/CHANGELOG.json
@@ -2,6 +2,23 @@
   "name": "@autorest/core",
   "entries": [
     {
+      "version": "3.0.6375",
+      "tag": "@autorest/core_v3.0.6375",
+      "date": "Sat, 20 Feb 2021 17:49:35 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "**Fix** Revert use of flatMap which is not available on node 10"
+          }
+        ],
+        "dependency": [
+          {
+            "comment": "Updating dependency \"@autorest/common\" from `~1.0.1` to `~1.0.2`"
+          }
+        ]
+      }
+    },
+    {
       "version": "3.0.6374",
       "tag": "@autorest/core_v3.0.6374",
       "date": "Fri, 19 Feb 2021 21:42:09 GMT",

--- a/packages/extensions/core/CHANGELOG.md
+++ b/packages/extensions/core/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/core
 
-This log was last generated on Fri, 19 Feb 2021 21:42:09 GMT and should not be manually modified.
+This log was last generated on Sat, 20 Feb 2021 17:49:35 GMT and should not be manually modified.
+
+## 3.0.6375
+Sat, 20 Feb 2021 17:49:35 GMT
+
+### Patches
+
+- **Fix** Revert use of flatMap which is not available on node 10
 
 ## 3.0.6374
 Fri, 19 Feb 2021 21:42:09 GMT

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -67,6 +67,7 @@
     "compare-versions": "^3.4.0",
     "copy-webpack-plugin": "^7.0.0",
     "cpy-cli": "~2.0.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/core",
-  "version": "3.0.6374",
+  "version": "3.0.6375",
   "description": "AutoRest core module",
   "engines": {
     "node": ">=10.13.0"
@@ -39,7 +39,7 @@
   },
   "typings": "./dist/exports.d.ts",
   "devDependencies": {
-    "@autorest/common": "~1.0.1",
+    "@autorest/common": "~1.0.2",
     "@autorest/configuration": "~1.0.1",
     "@autorest/schemas": "~1.0.1",
     "@autorest/test-utils": "~0.1.0",

--- a/packages/extensions/core/src/app.ts
+++ b/packages/extensions/core/src/app.ts
@@ -682,6 +682,7 @@ async function main() {
       timestampDebugLog("Shutting Down: (trouble?)");
     } finally {
       timestampDebugLog("Exiting.");
+      // eslint-disable-next-line no-process-exit
       process.exit(exitcode);
     }
   }

--- a/packages/extensions/core/src/lib/pipeline/plugins/tree-shaker/tree-shaker.test.ts
+++ b/packages/extensions/core/src/lib/pipeline/plugins/tree-shaker/tree-shaker.test.ts
@@ -1,6 +1,5 @@
 import { Source } from "@azure-tools/datastore";
 import { JsonType, Model } from "@azure-tools/openapi";
-import { create } from "domain";
 import { OAI3Shaker } from "./tree-shaker";
 
 const createTestModel = (model: Partial<Model>): Model => {

--- a/packages/extensions/modelerfour/package.json
+++ b/packages/extensions/modelerfour/package.json
@@ -6,7 +6,7 @@
     "doc": "docs"
   },
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=10.13.0"
   },
   "main": "dist/main.js",
   "typings": "dist/main.d.ts",
@@ -56,6 +56,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "chalk": "^4.1.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/codegen/package.json
+++ b/packages/libs/codegen/package.json
@@ -7,6 +7,9 @@
   },
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",
     "watch": "tsc -p ./tsconfig.build.json --watch",
@@ -39,6 +42,7 @@
     "@types/semver": "5.5.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/codemodel/package.json
+++ b/packages/libs/codemodel/package.json
@@ -7,6 +7,9 @@
   },
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
@@ -39,6 +42,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/common/CHANGELOG.json
+++ b/packages/libs/common/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/common",
   "entries": [
     {
+      "version": "1.0.2",
+      "tag": "@autorest/common_v1.0.2",
+      "date": "Sat, 20 Feb 2021 17:49:35 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "**Fix** Revert use of flatMap which is not available on node 10"
+          }
+        ]
+      }
+    },
+    {
       "version": "1.0.1",
       "tag": "@autorest/common_v1.0.1",
       "date": "Fri, 19 Feb 2021 21:42:09 GMT",

--- a/packages/libs/common/CHANGELOG.md
+++ b/packages/libs/common/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/common
 
-This log was last generated on Fri, 19 Feb 2021 21:42:09 GMT and should not be manually modified.
+This log was last generated on Sat, 20 Feb 2021 17:49:35 GMT and should not be manually modified.
+
+## 1.0.2
+Sat, 20 Feb 2021 17:49:35 GMT
+
+### Patches
+
+- **Fix** Revert use of flatMap which is not available on node 10
 
 ## 1.0.1
 Fri, 19 Feb 2021 21:42:09 GMT

--- a/packages/libs/common/package.json
+++ b/packages/libs/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/common",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Autorest common utilities",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/libs/common/package.json
+++ b/packages/libs/common/package.json
@@ -4,6 +4,9 @@
   "description": "Autorest common utilities",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",
     "watch": "tsc -p ./tsconfig.build.json --watch",
@@ -29,6 +32,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/common/src/literate-yaml/literate-yaml.ts
+++ b/packages/libs/common/src/literate-yaml/literate-yaml.ts
@@ -107,7 +107,8 @@ export async function mergeYamls(
   const cancel = false;
   let failed = false;
 
-  const newIdentity = yamlInputHandles.flatMap((x) => x.identity);
+  //  ([] as string[]).concat(...x.map()) as an alternative for flatMap which is not availalbe on node 10.
+  const newIdentity = ([] as string[]).concat(...yamlInputHandles.map((x) => x.identity));
 
   for (const yamlInputHandle of yamlInputHandles) {
     const rawYaml = await yamlInputHandle.ReadData();

--- a/packages/libs/configuration/package.json
+++ b/packages/libs/configuration/package.json
@@ -4,6 +4,9 @@
   "description": "Autorest configuration",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",
     "watch": "tsc -p ./tsconfig.build.json --watch",
@@ -29,6 +32,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/datastore/package.json
+++ b/packages/libs/datastore/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/main.js",
   "typings": "./dist/main.d.ts",
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=10.13.0"
   },
   "repository": {
     "type": "git",
@@ -42,6 +42,7 @@
     "@types/source-map": "0.5.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/deduplication/package.json
+++ b/packages/libs/deduplication/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/main.js",
   "typings": "./dist/main.d.ts",
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=10.13.0"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/extension-base/package.json
+++ b/packages/libs/extension-base/package.json
@@ -3,6 +3,10 @@
   "version": "3.2.0",
   "description": "Library for creating AutoRest extensions",
   "main": "dist/exports.js",
+  "typings": "./dist/exports.d.ts",
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
@@ -12,7 +16,6 @@
     "test:ci": "echo 'No tests'",
     "clean": "rimraf ./dist"
   },
-  "typings": "./dist/exports.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/azure/perks.git"
@@ -28,6 +31,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/extension/package.json
+++ b/packages/libs/extension/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.0",
   "description": "Yarn-Based extension aquisition (for Azure Open Source Projects)",
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=10.13.0"
   },
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",
@@ -62,6 +62,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "cpy-cli": "~2.0.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/oai2-to-oai3/package.json
+++ b/packages/libs/oai2-to-oai3/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=10.13.0"
   },
   "repository": {
     "type": "git",
@@ -43,6 +43,7 @@
     "@types/source-map": "0.5.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/libs/oai2-to-oai3/src/oai2/parameter.ts
+++ b/packages/libs/oai2-to-oai3/src/oai2/parameter.ts
@@ -1,4 +1,3 @@
-import { Schema } from "inspector";
 import { OpenAPI2Definition } from "./definition";
 import { OpenAPI2HeaderDefinition } from "./header";
 

--- a/packages/libs/openapi/package.json
+++ b/packages/libs/openapi/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "engines": {
-    "node": ">=10.12.0"
+    "node": ">=10.13.0"
   },
   "repository": {
     "type": "git",
@@ -40,6 +40,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/testing/test-public-packages/package.json
+++ b/packages/testing/test-public-packages/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Azure/autorest#readme",
   "dependencies": {
-    "@autorest/core": "~3.0.6374",
+    "@autorest/core": "~3.0.6375",
     "autorest": "~3.1.0",
     "source-map-support": "^0.5.19"
   },

--- a/packages/testing/test-public-packages/package.json
+++ b/packages/testing/test-public-packages/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/Azure/autorest#readme",
   "dependencies": {
     "@autorest/core": "~3.0.6375",
-    "autorest": "~3.1.0",
+    "autorest": "~3.1.1",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/packages/tools/compare/package.json
+++ b/packages/tools/compare/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "autorest-compare": "dist/index.js"
   },
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "start": "ts-node src/index.ts",
     "test": "ts-mocha -p tsconfig.json test/**/*.spec.ts",
@@ -46,6 +49,7 @@
     "@types/source-map-support": "^0.5.3",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",
     "eslint": "^7.17.0",

--- a/packages/tools/compare/package.json
+++ b/packages/tools/compare/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
-    "autorest": "~3.1.0",
+    "autorest": "~3.1.1",
     "chalk": "^4.1.0",
     "diff": "^4.0.1",
     "js-yaml": "~4.0.0",

--- a/packages/tools/compare/src/index.ts
+++ b/packages/tools/compare/src/index.ts
@@ -75,11 +75,13 @@ Comparison Arguments
     const [operation, runConfig] = getOperationFromArgs(args);
     await runOperation(operation, runConfig);
 
+    // eslint-disable-next-line no-process-exit
     process.exit(operation.getExitCode());
   }
 }
 
 main().catch((err) => {
   console.error("\nAn error occurred during execution:\n\n", err);
+  // eslint-disable-next-line no-process-exit
   process.exit(1);
 });

--- a/packages/tools/md-mock-api/package.json
+++ b/packages/tools/md-mock-api/package.json
@@ -7,6 +7,9 @@
   "bin": {
     "md-mock-api": "./dist/cli/cli.js"
   },
+  "engines": {
+    "node": ">=10.13.0"
+  },
   "scripts": {
     "lint:fix": "eslint  . --fix --ext .ts",
     "lint": "eslint  ./src --ext .ts --max-warnings=0",
@@ -33,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "eslint": "^7.17.0",
+    "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/tools/md-mock-api/src/cli/cli.ts
+++ b/packages/tools/md-mock-api/src/cli/cli.ts
@@ -25,5 +25,6 @@ const run = async () => {
 
 run().catch((e) => {
   logger.error("Error", e);
+  // eslint-disable-next-line no-process-exit
   process.exit(1);
 });


### PR DESCRIPTION
Previous change included the use of `flatMap` which is not availalbe yet in node 10(was introduced in node 11).
Actual place where this happened is 
`packages/libs/common/src/literate-yaml/literate-yaml.ts `: https://github.com/Azure/autorest/pull/3902/files#diff-b46c3430b34fe276bd31c6af9ea3453b86af936cc7b0a5716442c373d302091a


Also added `eslint-plugin-node` to validate use of non supported apis to prevent this from happening in the future.
All the changes to the other package are:
- Adding the `eslint-plugin-node` package
- Adding or updating `engines` to be consistent. Set to `10.13.0` which was `@autorest/core` current value
- Disabled any rule other rule broke(Mainly don't do process.exit) without changing anything.


Also loosen the requirement for `autorest` which required `@autorest/core` to have the same major and minor version
fix #3899