### PR TITLE
Reresolve all nested config for each extension to see if it needs any other extensions

### DIFF
--- a/common/changes/@autorest/configuration/fix-extension-other-ext_2021-02-23-06-38.json
+++ b/common/changes/@autorest/configuration/fix-extension-other-ext_2021-02-23-06-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "**Fix** Plugins with nested configuration file requiring other plugins wasn't loading those plugins",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
+++ b/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
@@ -153,6 +153,8 @@ export class ConfigurationLoader {
           const data = await inputView.ReadStrict(extensionConfigurationUri);
           manager.addConfigFile(await readConfigurationFile(data, this.logger, this.dataStore.getDataSink()));
 
+          await resolveRequiredConfigs(fsLocal);
+
           viewsToHandle.push(await resolveConfig());
         } catch (e) {
           this.logger.fatal(

--- a/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
+++ b/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
@@ -63,6 +63,15 @@ export class ConfigurationLoader {
     const manager = new ConfigurationManager(configFileFolderUri, this.fileSystem);
 
     const resolveConfig = () => manager.resolveConfig();
+    const addedConfigs = new Set<string>();
+
+    const loadConfigFile = async (fileUri: string, fsToUse: IFileSystem) => {
+      return this.loadConfigFile(fileUri, fsToUse, manager, addedConfigs);
+    };
+
+    const resolveRequiredConfigs = async (fsToUse: IFileSystem) => {
+      return this.resolveRequiredConfigs(manager, fsToUse, addedConfigs);
+    };
 
     // 1. overrides (CLI, ...)
     // await addSegments(configs, false);
@@ -74,31 +83,16 @@ export class ConfigurationLoader {
     if (configFileUri != null && configFileUri !== undefined) {
       // add loaded files to the input files.
       this.logger.verbose(`> Initial configuration file '${configFileUri}'`);
-      const data = await this.dataStore.GetReadThroughScope(this.fileSystem).ReadStrict(configFileUri);
-      const file = await readConfigurationFile(data, this.logger, this.dataStore.getDataSink());
-      manager.addConfigFile(file);
+      await loadConfigFile(configFileUri, this.fileSystem);
     }
 
-    // 3. resolve 'require'd configuration
-    const addedConfigs = new Set<string>();
-
-    const resolveRequiredConfigs = async (fsToUse: IFileSystem) => {
-      return this.resolveRequiredConfigs(manager, fsToUse, addedConfigs);
-    };
-
-    await resolveRequiredConfigs(this.fileSystem);
-
-    // 4. default configuration
+    // 3. default configuration
     const fsLocal = new RealFileSystem();
     if (includeDefault) {
-      const inputView = this.dataStore.GetReadThroughScope(fsLocal);
-      const data = await inputView.ReadStrict(this.defaultConfigUri);
-      manager.addConfigFile(await readConfigurationFile(data, this.logger, this.dataStore.getDataSink()));
+      await loadConfigFile(this.defaultConfigUri, fsLocal);
     }
 
-    await resolveRequiredConfigs(fsLocal);
-
-    // 5. resolve extensions
+    // 4. resolve extensions
     const addedExtensions = new Set<string>();
     const extensions: ResolvedExtension[] = [];
 
@@ -120,18 +114,11 @@ export class ConfigurationLoader {
 
           const extension = await this.resolveExtension(additionalExtension);
           extensions.push({ extension, definition: additionalExtension });
-          await resolveRequiredConfigs(fsLocal);
 
           // merge config from extension
-          const inputView = this.dataStore.GetReadThroughScope(new RealFileSystem());
-
           const extensionConfigurationUri = simplifyUri(CreateFileUri(await extension.configurationPath));
           this.logger.verbose(`> Including extension configuration file '${extensionConfigurationUri}'`);
-
-          const data = await inputView.ReadStrict(extensionConfigurationUri);
-          manager.addConfigFile(await readConfigurationFile(data, this.logger, this.dataStore.getDataSink()));
-
-          await resolveRequiredConfigs(fsLocal);
+          await loadConfigFile(extensionConfigurationUri, fsLocal);
 
           viewsToHandle.push(await resolveConfig());
         } catch (e) {
@@ -156,6 +143,26 @@ export class ConfigurationLoader {
     } else {
       return { config, extensions };
     }
+  }
+
+  /**
+   * Load the given configuration file and recursively load all required configs.
+   * @param fileUri Uri to the configuration file to load.
+   * @param fsToUse File system to use to load the configuration files.
+   * @param manager Configuration manager
+   * @param alreadyAddedConfigs Set of already loaded configuration files.
+   */
+  private async loadConfigFile(
+    fileUri: string,
+    fsToUse: IFileSystem,
+    manager: ConfigurationManager,
+    alreadyAddedConfigs: Set<string>,
+  ) {
+    const data = await this.dataStore.GetReadThroughScope(fsToUse).ReadStrict(fileUri);
+    const file = await readConfigurationFile(data, this.logger, this.dataStore.getDataSink());
+    manager.addConfigFile(file);
+
+    await this.resolveRequiredConfigs(manager, fsToUse, alreadyAddedConfigs);
   }
 
   /**


### PR DESCRIPTION
Configuration refactor seems to have missed trying to resolve all the required configuration after loading each plugin which made it that it only resolve all the config file after it was done resolving plugins
fix #3911 

PR is composed of multiple iteration:
- [Fix commit](https://github.com/Azure/autorest/pull/3912/commits/23ab400ed78a30c4f36f9dfbe8117d401b6cb1b0)
- Add changelog
- Extract the file loading into its own function 