### PR TITLE
Use a unique version for ci build

### DIFF
--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -24,6 +24,11 @@ jobs:
       - script: npx @microsoft/rush lint -v
         displayName: Lint
 
+      - script: |
+          commitId=$(git rev-parse --short HEAD)
+          npx @microsoft/rush publish --apply --prerelease-name="ci.$commitId"
+        displayName: Bump versions
+
       - script: npx @microsoft/rush publish --publish --pack --include-all
         displayName: Pack packages
 


### PR DESCRIPTION
Bump version with a suffix composed of the commit id `-ci.{commitId}` for packaged produced in the CI. This should solve the need for `autorest --reset` when using the tinyurl functionality