### PR TITLE
HotFix: @azure-tools/extension bug introduced breaking @autorest/python installation

### DIFF
--- a/packages/libs/extension/CHANGELOG.json
+++ b/packages/libs/extension/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@azure-tools/extension",
   "entries": [
     {
+      "version": "3.2.1",
+      "tag": "@azure-tools/extension_v3.2.1",
+      "date": "Wed, 24 Feb 2021 00:33:50 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "**Fix** updatePythonPath wasn't patching array inplace."
+          }
+        ]
+      }
+    },
+    {
       "version": "3.2.0",
       "tag": "@azure-tools/extension_v3.2.0",
       "date": "Fri, 19 Feb 2021 21:42:09 GMT",

--- a/packages/libs/extension/CHANGELOG.md
+++ b/packages/libs/extension/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @azure-tools/extension
 
-This log was last generated on Fri, 19 Feb 2021 21:42:09 GMT and should not be manually modified.
+This log was last generated on Wed, 24 Feb 2021 00:33:50 GMT and should not be manually modified.
+
+## 3.2.1
+Wed, 24 Feb 2021 00:33:50 GMT
+
+### Patches
+
+- **Fix** updatePythonPath wasn't patching array inplace.
 
 ## 3.2.0
 Fri, 19 Feb 2021 21:42:09 GMT

--- a/packages/libs/extension/package.json
+++ b/packages/libs/extension/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/extension",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Yarn-Based extension aquisition (for Azure Open Source Projects)",
   "engines": {
     "node": ">=10.13.0"

--- a/packages/libs/extension/src/system-requirements/python.test.ts
+++ b/packages/libs/extension/src/system-requirements/python.test.ts
@@ -1,4 +1,4 @@
-import { resolvePythonRequirement } from "./python";
+import { patchPythonPath, PythonCommandLine, resolvePythonRequirement, updatePythonPath } from "./python";
 import { execute } from "../exec-cmd";
 
 jest.mock("../exec-cmd");
@@ -80,6 +80,73 @@ describe("Python system requirement", () => {
     expect(result).toEqual({
       name: "python",
       command: "python3",
+    });
+  });
+
+  describe("updatePythonPath", () => {
+    it("stub with the only compatible python version", async () => {
+      mockInstalledPython({
+        python3: "3.7.0",
+        python: "2.7.0",
+      });
+      const input: PythonCommandLine = ["python", "-c", "print();"];
+      const result = await patchPythonPath(input, { version: ">=3.6" });
+      expect(result).toEqual(["python3", "-c", "print();"]);
+    });
+
+    it("stub with the first compatible python version", async () => {
+      mockInstalledPython({
+        python3: "3.7.0",
+        python: "3.9.0",
+      });
+      const input: PythonCommandLine = ["python", "-c", "print();"];
+      const result = await patchPythonPath(input, { version: ">=3.6" });
+      expect(result).toEqual(["python3", "-c", "print();"]);
+    });
+
+    it("stub with the first compatible python version", async () => {
+      mockInstalledPython({
+        python3: "2.0.0",
+        python: "3.9.0",
+      });
+      const input: PythonCommandLine = ["python", "-c", "print();"];
+      const result = await patchPythonPath(input, { version: ">=3.6" });
+      expect(result).toEqual(["python", "-c", "print();"]);
+    });
+  });
+
+  describe("updatePythonPath (Deprecated)", () => {
+    it("stub with the only compatible python version", async () => {
+      mockInstalledPython({
+        python3: "3.7.0",
+        python: "2.7.0",
+      });
+      const input: PythonCommandLine = ["python", "-c", "print();"];
+      const result = await updatePythonPath(input);
+      expect(input).toEqual(["python3", "-c", "print();"]);
+      expect(result).toEqual(["python3", "-c", "print();"]);
+    });
+
+    it("stub with the first compatible python version", async () => {
+      mockInstalledPython({
+        python3: "3.7.0",
+        python: "3.9.0",
+      });
+      const input: PythonCommandLine = ["python", "-c", "print();"];
+      const result = await updatePythonPath(input);
+      expect(input).toEqual(["python3", "-c", "print();"]);
+      expect(result).toEqual(["python3", "-c", "print();"]);
+    });
+
+    it("stub with the first compatible python version", async () => {
+      mockInstalledPython({
+        python3: "2.0.0",
+        python: "3.9.0",
+      });
+      const input: PythonCommandLine = ["python", "-c", "print();"];
+      const result = await updatePythonPath(input);
+      expect(input).toEqual(["python", "-c", "print();"]);
+      expect(result).toEqual(["python", "-c", "print();"]);
     });
   });
 });

--- a/packages/libs/extension/src/system-requirements/python.test.ts
+++ b/packages/libs/extension/src/system-requirements/python.test.ts
@@ -83,7 +83,7 @@ describe("Python system requirement", () => {
     });
   });
 
-  describe("updatePythonPath", () => {
+  describe("patchPythonPath", () => {
     it("stub with the only compatible python version", async () => {
       mockInstalledPython({
         python3: "3.7.0",

--- a/packages/libs/extension/src/system-requirements/python.ts
+++ b/packages/libs/extension/src/system-requirements/python.ts
@@ -59,7 +59,9 @@ export type PythonCommandLine = [KnownPythonExe, ...string[]];
  * @deprecated Please use patchPythonPath(command, requirement) instead.
  */
 export const updatePythonPath = async (command: PythonCommandLine): Promise<string[]> => {
-  return patchPythonPath(command, { version: ">=3.6", environmentVariable: "AUTOREST_PYTHON_EXE" });
+  const newCommand = await patchPythonPath(command, { version: ">=3.6", environmentVariable: "AUTOREST_PYTHON_EXE" });
+  (command as string[])[0] = newCommand[0];
+  return newCommand;
 };
 
 /**
@@ -75,7 +77,7 @@ export const patchPythonPath = async (
   if ("error" in resolution) {
     throw new Error(`Failed to find compatible python version. ${resolution.message}`);
   }
-  return [resolution.command, ...(resolution.additionalArgs ?? [], args)];
+  return [resolution.command, ...(resolution.additionalArgs ?? []), ...args];
 };
 
 const tryPython = async (

--- a/packages/libs/extension/src/system-requirements/python.ts
+++ b/packages/libs/extension/src/system-requirements/python.ts
@@ -72,7 +72,7 @@ export const patchPythonPath = async (
   command: PythonCommandLine,
   requirement: SystemRequirement,
 ): Promise<string[]> => {
-  const [_, args] = command;
+  const [_, ...args] = command;
   const resolution = await resolvePythonRequirement(requirement);
   if ("error" in resolution) {
     throw new Error(`Failed to find compatible python version. ${resolution.message}`);


### PR DESCRIPTION
When moving the `updatePythonPath` method to consume the new system requirement resolver it stopped patching the command in place which the @autorest/python startup/install script depended on.

This means that if the `python` command wasn't 3.6 but `python3` was failing instead of uing `python3`