### PR TITLE
Fix: Prevent single-file yarn from loading user config and changing version

### DIFF
--- a/common/changes/@azure-tools/extension/fix-yarn-global-config_2021-02-24-16-01.json
+++ b/common/changes/@azure-tools/extension/fix-yarn-global-config_2021-02-24-16-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/extension",
+      "comment": "Prevent single-file yarn from loading user config and changing version",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/extension",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/autorest/fix-yarn-global-config_2021-02-24-16-01.json
+++ b/common/changes/autorest/fix-yarn-global-config_2021-02-24-16-01.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "Always load sourcemaps",
+      "type": "patch"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/apps/autorest/entrypoints/app.js
+++ b/packages/apps/autorest/entrypoints/app.js
@@ -29,15 +29,6 @@ if (
       process.exit(code);
     });
 } else {
-  // load modules from static linker filesystem.
-  if (isDebuggerEnabled) {
-    try {
-      // try to let source maps resolve
-      require("source-map-support").install();
-    } catch (e) {
-      // no worries
-    }
-  }
   try {
     const v = process.versions.node.split(".");
     if (v[0] < 10 || (v[0] === 10 && v[1] < 12)) {

--- a/packages/apps/autorest/src/app.ts
+++ b/packages/apps/autorest/src/app.ts
@@ -4,6 +4,8 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 /* eslint-disable no-console */
+import "source-map-support/register";
+
 declare const isDebuggerEnabled: boolean;
 const cwd = process.cwd();
 

--- a/packages/libs/extension/src/yarn.ts
+++ b/packages/libs/extension/src/yarn.ts
@@ -67,6 +67,7 @@ export class Yarn implements PackageManager {
   public async execYarn(cwd: string, ...args: string[]) {
     const procArgs = [
       this.pathToYarnCli ?? (await getPathToYarnCli()),
+      "--no-default-rc", // Prevent yarn from loading ~/.yarnrc.yml
       "--no-node-version-check",
       "--no-lockfile",
       "--json",


### PR DESCRIPTION
fix #3925

As part of `yarn/cli.js` it would load `~/.yarn.yml` and if the user used `yarn set version berry`(for yarn v2) it would then loadup yarn v2 which would in turn fail due to a different cli 