### PR TITLE
Rethink modifiers test not to depend on csharp plugin

### DIFF
--- a/common/changes/@autorest/core/tests-modifiers-cleanup_2021-02-24-21-58.json
+++ b/common/changes/@autorest/core/tests-modifiers-cleanup_2021-02-24-21-58.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/lib/pipeline/plugins/quick-check.ts
+++ b/packages/extensions/core/src/lib/pipeline/plugins/quick-check.ts
@@ -22,7 +22,7 @@ async function quickCheck(config: AutorestContext, input: DataSource, sink: Data
     const models = new Map<string, Array<string>>();
     const enums = new Map<string, Array<string>>();
     // check to see if there are models with the same name
-    for (const { key, value } of items(oai.components.schemas)) {
+    for (const { key, value } of items(oai.components?.schemas)) {
       const schema = <AnyObject>value;
       const name = (<AnyObject>value)["x-ms-metadata"].name.toLowerCase();
 

--- a/packages/extensions/core/test/modifiers.test.ts
+++ b/packages/extensions/core/test/modifiers.test.ts
@@ -3,70 +3,109 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 import assert from "assert";
-
-import { AutoRest } from "../src/exports";
+import { AutoRest, Channel, Message } from "../src/exports";
 import { RealFileSystem } from "@azure-tools/datastore";
 import { join } from "path";
 import { AppRoot } from "../src/lib/constants";
+import oai3 from "@azure-tools/openapi";
 
-const generate = async (additionalConfig: any): Promise<{ [uri: string]: string }> => {
+const generate = async (additionalConfig: any): Promise<oai3.Model> => {
   const autoRest = new AutoRest(new RealFileSystem());
   autoRest.AddConfiguration({
     "input-file": join(AppRoot, "test", "resources", "tiny.yaml"),
-    "csharp": "true",
-    "v2": "true",
-    "output-artifact": ["swagger-document.yaml", "openapi-document.yaml"],
+    "use-extension": { "@autorest/modelerfour": join(AppRoot, "../modelerfour") },
+    "verbose": true,
+    "debug": true,
+    "output-artifact": ["openapi-document"],
   });
-  // for testing local changes:
-  /* if (false as any) {
-      PumpMessagesToConsole(autoRest);
-      autoRest.AddConfiguration({ 'use': 'C:\\work\\oneautorest\\autorest.modeler' });
-      autoRest.AddConfiguration({ 'use': 'C:\\work\\oneautorest\\autorest.csharp' });
-    } */
-
   autoRest.AddConfiguration(additionalConfig);
 
-  const result: { [uri: string]: string } = {};
+  let resolvedDocument: oai3.Model | undefined;
 
   autoRest.GeneratedFile.Subscribe((sender, args) => {
-    if (args.type === "source-file-csharp") {
-      result[args.uri.slice("file:///generated/".length)] = args.content;
-    }
-    if (args.type === "swagger-document.yaml" || args.type === "openapi-document.yaml") {
-      // console.warn(args.content);
+    if (args.type === "openapi-document") {
+      resolvedDocument = JSON.parse(args.content);
     }
   });
-  const success = await autoRest.Process().finish;
-  assert.strictEqual(success, true);
 
-  return result;
+  const messages: Message[] = [];
+  const channels = new Set([
+    Channel.Information,
+    Channel.Warning,
+    Channel.Error,
+    Channel.Fatal,
+    Channel.Debug,
+    Channel.Verbose,
+  ]);
+
+  autoRest.Message.Subscribe((_, message) => {
+    if (channels.has(message.Channel)) {
+      messages.push(message);
+    }
+  });
+
+  const success = await autoRest.Process().finish;
+
+  if (!success) {
+    // eslint-disable-next-line no-console
+    console.log("Messages", messages);
+    fail("Autorest didn't complete with success.");
+  }
+
+  assert(resolvedDocument);
+  return resolvedDocument;
+};
+
+const findModel = (spec: oai3.Model, name: string): oai3.Schema | undefined => {
+  return Object.values(spec.components?.schemas ?? [])
+    .filter((x) => !("$ref" in x))
+    .find((schema: oai3.Schema) => schema["x-ms-metadata"].name === name);
+};
+
+const findOperation = (spec: oai3.Model, name: string): oai3.HttpOperation | undefined => {
+  for (const pathItem of Object.values(spec.paths)) {
+    for (const operation of Object.values(pathItem)) {
+      if (operation.operationId === name) {
+        return operation;
+      }
+    }
+  }
+
+  for (const pathItem of Object.values(spec["x-ms-paths"] ?? [])) {
+    for (const operation of Object.values(pathItem as object)) {
+      if (operation.operationId === name) {
+        return operation;
+      }
+    }
+  }
+  return undefined;
 };
 
 describe("Modifiers", () => {
-  it("Reference", async () => {
+  it("Doesn't modify the input if no directives are passed", async () => {
     const code = await generate({});
-    assert.ok(code["CowbellOperationsExtensions.cs"].includes(" Get("));
-    assert.ok(!code["CowbellOperationsExtensions.cs"].includes(" Retrieve("));
-    assert.ok(!code["CowbellOperations.cs"].includes(".GetWith"));
-    assert.ok(code["Models/Cowbell.cs"]);
-    assert.ok(code["Models/Cowbell.cs"].includes("string Name"));
-    assert.ok(!code["Models/Cowbell.cs"].includes("string FirstName"));
-    assert.ok(code["Models/Cowbell.cs"].includes("JsonProperty"));
-    assert.ok(!code["Models/Cowbell.cs"].includes("JsonIgnore"));
-    assert.ok(!code["Models/SuperCowbell.cs"]);
+
+    expect(findOperation(code, "Cowbell_Get")).toBeDefined();
+    expect(findOperation(code, "Cowbell_Retrieve")).toBe(undefined);
+
+    const model = findModel(code, "Cowbell");
+    expect(model).toBeDefined();
+    expect(model?.properties?.name).toBeDefined();
+
+    expect(findModel(code, "SuperCowbell")).toBe(undefined);
   });
 
-  it("RemoveOperation", async () => {
+  it("remove an operation", async () => {
     const code = await generate({
       directive: {
         "remove-operation": "Cowbell_Get",
       },
     });
-    assert.ok(!code["CowbellOperationsExtensions.cs"].includes(" Get("));
-    assert.ok(!code["CowbellOperationsExtensions.cs"].includes(" Retrieve("));
+
+    expect(findOperation(code, "Cowbell_Get")).toBe(undefined);
   });
 
-  it("RenameOperation", async () => {
+  it("rename an operation", async () => {
     const code = await generate({
       directive: {
         "rename-operation": {
@@ -75,11 +114,12 @@ describe("Modifiers", () => {
         },
       },
     });
-    assert.ok(!code["CowbellOperationsExtensions.cs"].includes(" Get("));
-    assert.ok(code["CowbellOperationsExtensions.cs"].includes(" Retrieve("));
+
+    expect(findOperation(code, "Cowbell_Get")).toBe(undefined);
+    expect(findOperation(code, "Cowbell_Retrieve")).toBeDefined();
   });
 
-  it("AddOperationForward", async () => {
+  it("add operation forward", async () => {
     const code = await generate({
       components: {
         operations: [
@@ -90,30 +130,13 @@ describe("Modifiers", () => {
         ],
       },
     });
-    assert.ok(code["CowbellOperationsExtensions.cs"].includes(" Get("));
-    assert.ok(code["CowbellOperationsExtensions.cs"].includes(" Retrieve("));
-    assert.ok(code["CowbellOperations.cs"].includes(".GetWith"));
+    expect(findOperation(code, "Cowbell_Get")).toBeDefined();
+    const retrieveOperation = findOperation(code, "Cowbell_Retrieve");
+    expect(retrieveOperation).toBeDefined();
+    expect(retrieveOperation?.["x-ms-forward-to"]).toEqual("Cowbell_Get");
   });
 
-  it("AddOperationImpl", async () => {
-    const implementation = "// implement me " + Math.random();
-    const code = await generate({
-      components: {
-        operations: [
-          {
-            operationId: "Cowbell_Retrieve",
-            implementation: implementation,
-          },
-        ],
-      },
-    });
-    assert.ok(code["CowbellOperationsExtensions.cs"].includes(" Get("));
-    assert.ok(code["CowbellOperationsExtensions.cs"].includes(" Retrieve("));
-    assert.ok(!code["CowbellOperations.cs"].includes(".GetWith"));
-    assert.ok(code["CowbellOperations.cs"].includes(implementation));
-  });
-
-  it("RemoveModel", async () => {
+  it("remove a model", async () => {
     const code = await generate({
       directive: [
         { "remove-model": "Cowbell" },
@@ -121,11 +144,10 @@ describe("Modifiers", () => {
         { "remove-operation": "Cowbell_Add" }, // broken references
       ],
     });
-    assert.ok(!code["Models/Cowbell.cs"]);
-    assert.ok(!code["Models/SuperCowbell.cs"]);
+    expect(findModel(code, "Cowbell")).toBe(undefined);
   });
 
-  it("RenameModel", async () => {
+  it("rename a model", async () => {
     const code = await generate({
       directive: {
         "rename-model": {
@@ -134,23 +156,24 @@ describe("Modifiers", () => {
         },
       },
     });
-    assert.ok(!code["Models/Cowbell.cs"]);
-    assert.ok(code["Models/SuperCowbell.cs"]);
-    assert.ok(code["Models/SuperCowbell.cs"].includes("string Name"));
+
+    expect(findModel(code, "Cowbell")).toBe(undefined);
+    expect(findModel(code, "SuperCowbell")).toBeDefined();
   });
 
-  it("RemoveProperty", async () => {
+  it("remove a property", async () => {
     const code = await generate({
       directive: {
         "where-model": "Cowbell",
         "remove-property": "name",
       },
     });
-    assert.ok(code["Models/Cowbell.cs"]);
-    assert.ok(!code["Models/Cowbell.cs"].includes("string Name"));
+
+    const model = findModel(code, "Cowbell");
+    expect(model?.properties?.name).toBe(undefined);
   });
 
-  it("RenameProperty", async () => {
+  it("rename a property", async () => {
     const code = await generate({
       directive: {
         "where-model": "Cowbell",
@@ -160,57 +183,9 @@ describe("Modifiers", () => {
         },
       },
     });
-    assert.ok(code["Models/Cowbell.cs"]);
-    assert.ok(!code["Models/Cowbell.cs"].includes("string Name"));
-    assert.ok(code["Models/Cowbell.cs"].includes("string FirstName"));
-  });
 
-  // GS01 / Nelson -- this fails because the deduplicator assumes that we have xms metadata on paths
-  xit("AddPropertyForward", async () => {
-    const code = await generate({
-      components: {
-        schemas: {
-          Cowbell: {
-            properties: {
-              firstName: {
-                "type": "string",
-                "forward-to": "name",
-              },
-            },
-          },
-        },
-      },
-    });
-    assert.ok(code["Models/Cowbell.cs"]);
-    assert.ok(code["Models/Cowbell.cs"].includes("string Name"));
-    assert.ok(code["Models/Cowbell.cs"].includes("string FirstName"));
-    assert.ok(code["Models/Cowbell.cs"].includes("= value;"));
-    assert.ok(code["Models/Cowbell.cs"].includes("JsonProperty"));
-    assert.ok(code["Models/Cowbell.cs"].includes("JsonIgnore"));
-  });
-
-  // GS01 / Nelson -- this fails because the deduplicator assumes that we have xms metadata on paths
-  xit("AddPropertyImpl", async () => {
-    const implementation = "get; set; // implement me " + Math.random();
-    const code = await generate({
-      components: {
-        schemas: {
-          Cowbell: {
-            properties: {
-              firstName: {
-                type: "string",
-                implementation: implementation,
-              },
-            },
-          },
-        },
-      },
-    });
-    assert.ok(code["Models/Cowbell.cs"]);
-    assert.ok(code["Models/Cowbell.cs"].includes("string Name"));
-    assert.ok(code["Models/Cowbell.cs"].includes("string FirstName"));
-    assert.ok(code["Models/Cowbell.cs"].includes(implementation));
-    assert.ok(code["Models/Cowbell.cs"].includes("JsonProperty"));
-    assert.ok(code["Models/Cowbell.cs"].includes("JsonIgnore"));
+    const model = findModel(code, "Cowbell");
+    expect(model?.properties?.name).toBe(undefined);
+    expect(model?.properties?.firstName).toBeDefined();
   });
 });


### PR DESCRIPTION
For some reason the `modifiers.test.ts` has been failing in the CI today. Can't seem to reproduce but it seems to be crashing inside the csharp extension without additional info.

This removes the dependency on the chsarp extension and instead has a more solid testing mechanism:  verifying the processed openapi document instead of what the csharp code "contains"