### PR TITLE
Fix: Interpolating with value from the same block couldn't be overwritten

### DIFF
--- a/common/changes/@autorest/common/fix-interpolate-same-block_2021-03-04-16-37.json
+++ b/common/changes/@autorest/common/fix-interpolate-same-block_2021-03-04-16-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/common",
+      "comment": "**Update** merge functionality to be able to take interpolation context. Default to the higher priority element otherwise",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/common",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/configuration/fix-interpolate-same-block_2021-03-04-16-37.json
+++ b/common/changes/@autorest/configuration/fix-interpolate-same-block_2021-03-04-16-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "**Fix** issue where interpolating a value defined in the same block wouldn't be able to be overwritten by previous configs",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/libs/common/src/merging/merging.ts
+++ b/packages/libs/common/src/merging/merging.ts
@@ -126,14 +126,10 @@ export function resolveRValue(
 
     // resolve macro values for array values
     if (value instanceof Array) {
-      const result = new Array<any>();
-      for (const each of value) {
-        // since we're not naming the parameter,
-        // if there isn't a higher priority,
-        // we can fall back to a wide-lookup in lowerPriority.
-        result.push(resolveRValue(each, "", higherPriority || lowerPriority, null));
-      }
-      return result;
+      // since we're not naming the parameter,
+      // if there isn't a higher priority,
+      // we can fall back to a wide-lookup in lowerPriority.
+      return value.map((x) => resolveRValue(x, "", higherPriority || lowerPriority, null));
     }
   }
 

--- a/packages/libs/common/src/merging/merging.ts
+++ b/packages/libs/common/src/merging/merging.ts
@@ -196,14 +196,19 @@ export function mergeOverwriteOrAppend(
       continue;
     }
     if (lowerPriority[key] === undefined) {
-      result[key] = resolveRValue(computedOptions.interpolationContext[key], key, null, higherPriority);
+      result[key] = resolveRValue(higherPriority[key], key, null, computedOptions.interpolationContext);
       continue;
     }
 
     // try merge objects otherwise
     const aMember = resolveRValue(higherPriority[key], key, lowerPriority, computedOptions.interpolationContext);
     const bMember = resolveRValue(lowerPriority[key], key, computedOptions.interpolationContext, lowerPriority);
-    result[key] = mergeOverwriteOrAppend(aMember, bMember, computedOptions, subpath);
+    result[key] = mergeOverwriteOrAppend(
+      aMember,
+      bMember,
+      { ...computedOptions, interpolationContext: computedOptions.interpolationContext[key] },
+      subpath,
+    );
   }
   return result;
 }

--- a/packages/libs/configuration/src/configuration-manager/configuration-manager.test.ts
+++ b/packages/libs/configuration/src/configuration-manager/configuration-manager.test.ts
@@ -50,6 +50,25 @@ describe("ConfigurationManager", () => {
     it("adds value from 2nd config if not present in 1st", async () => {
       expect(output["base-folder"]).toEqual("base-folder-2");
     });
+
+    it("combine nested objects", async () => {
+      await manager.addConfig({
+        "use-extension": {
+          "@autorest/csharp": "latest",
+        },
+      });
+      await manager.addConfig({
+        "use-extension": {
+          "@autorest/modelerfour": "latest",
+        },
+      });
+
+      const output = await manager.resolveConfig();
+      expect(output["use-extension"]).toEqual({
+        "@autorest/csharp": "latest",
+        "@autorest/modelerfour": "latest",
+      });
+    });
   });
 
   describe("adding a single file with multiple blocks", () => {

--- a/packages/libs/configuration/src/configuration-manager/configuration-manager.ts
+++ b/packages/libs/configuration/src/configuration-manager/configuration-manager.ts
@@ -107,6 +107,7 @@ export class ConfigurationManager {
       if (shouldInclude) {
         currentFileResolution = mergeOverwriteOrAppend(configBlock.config, currentFileResolution, {
           arrayMergeStrategy: "low-pri-first", // We want arrays to be merged in the order of definition within the same file(First defined first in the array)
+          interpolationContext: mergeOverwriteOrAppend(config, configBlock.config),
         });
       }
     }


### PR DESCRIPTION
When having for example

In the main readme
```yaml
branch: feature1
```

and this in a required readme
```yaml
branch: master
repo: https://github.com/Azure/autorest/$(branch)
```

you would end up with this config
```yaml
branch: feature1 # Branch picked the main readme value correctly
repo: https://github.com/Azure/autorest/master # But here it interpolated the local value instead.
```

This resolve the problem so the result is 
```yaml
branch: feature1 
repo: https://github.com/Azure/autorest/feature1
```


Added a bunch of tests regarding interpolation as well.