### PR TITLE
Fix max call stack issue when using very large swager file

### DIFF
--- a/common/changes/@autorest/common/fix-call-stack-mapping_2021-03-11-18-22.json
+++ b/common/changes/@autorest/common/fix-call-stack-mapping_2021-03-11-18-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/common",
+      "comment": "**Fix** Max call stack issue with loading very large swagger",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/common",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/libs/common/src/literate-yaml/literate-yaml.ts
+++ b/packages/libs/common/src/literate-yaml/literate-yaml.ts
@@ -3,7 +3,15 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DataHandle, DataSink, IndexToPosition, ParseNode, StrictJsonSyntaxCheck, Parse } from "@azure-tools/datastore";
+import {
+  DataHandle,
+  DataSink,
+  IndexToPosition,
+  ParseNode,
+  StrictJsonSyntaxCheck,
+  Parse,
+  Mapping,
+} from "@azure-tools/datastore";
 import { OperationAbortedException } from "../exceptions";
 import { AutorestLogger } from "../logging";
 import { identitySourceMapping, strictMerge } from "../merging";
@@ -103,7 +111,7 @@ export async function mergeYamls(
   sink: DataSink,
 ): Promise<DataHandle> {
   let mergedGraph: any = {};
-  const mappings = [];
+  const mappings: Mapping[] = [];
   const cancel = false;
   let failed = false;
 
@@ -125,7 +133,10 @@ export async function mergeYamls(
       }) || {};
 
     mergedGraph = strictMerge(mergedGraph, inputGraph);
-    mappings.push(...identitySourceMapping(yamlInputHandle.key, await yamlInputHandle.ReadYamlAst()));
+    const yaml = await yamlInputHandle.ReadYamlAst();
+    for (const mapping of identitySourceMapping(yamlInputHandle.key, yaml)) {
+      mappings.push(mapping);
+    }
   }
 
   if (failed) {


### PR DESCRIPTION
fix #3570

Issue is with using `array.push(...otherArray)` where otherArray is a very large value(which was the case for the mapping of  a large swagger spec) it will cause a max call stack expection due to how javascript spread arguments in a function