### PR TITLE
Fix: Cannot read property 'pass-thru' of undefined crash

### DIFF
--- a/common/changes/@autorest/core/patch-1_2021-03-14-18-45.json
+++ b/common/changes/@autorest/core/patch-1_2021-03-14-18-45.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "kant2002@gmail.com"
+}

--- a/common/changes/@autorest/core/patch-1_2021-03-14-18-45.json
+++ b/common/changes/@autorest/core/patch-1_2021-03-14-18-45.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@autorest/core",
-      "comment": "",
-      "type": "none"
+      "comment": "**Fix** Cannot read property 'pass-thru' of undefined crash",
+      "type": "patch"
     }
   ],
   "packageName": "@autorest/core",

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -359,7 +359,7 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
 
     // you can have --pass-thru:FOO on the command line
     // or add pass-thru: true in a pipline configuration step.
-    const configEntry = config.GetEntry(node.configScope.last.toString());
+    const configEntry = context.GetEntry(node.configScope.last.toString());
     const passthru =
       (configEntry && configEntry["pass-thru"] === true) ||
       values(configView.GetEntry("pass-thru")).any((each) => each === pluginName);

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -364,8 +364,7 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
       configEntry?.["pass-thru"] === true ||
       values(configView.GetEntry("pass-thru")).any((each) => each === pluginName);
     const usenull =
-      configEntry?.["null"] === true ||
-      values(configView.GetEntry("null")).any((each) => each === pluginName);
+      configEntry?.["null"] === true || values(configView.GetEntry("null")).any((each) => each === pluginName);
 
     const plugin = usenull ? plugins.null : passthru ? plugins.identity : plugins[pluginName];
 

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -359,11 +359,12 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
 
     // you can have --pass-thru:FOO on the command line
     // or add pass-thru: true in a pipline configuration step.
+    const configEntry = config.GetEntry(node.configScope.last.toString());
     const passthru =
-      context.GetEntry(node.configScope.last.toString())["pass-thru"] === true ||
+      (configEntry && configEntry["pass-thru"] === true) ||
       values(configView.GetEntry("pass-thru")).any((each) => each === pluginName);
     const usenull =
-      context.GetEntry(node.configScope.last.toString())["null"] === true ||
+      (configEntry && configEntry["null"] === true) ||
       values(configView.GetEntry("null")).any((each) => each === pluginName);
 
     const plugin = usenull ? plugins.null : passthru ? plugins.identity : plugins[pluginName];

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -361,10 +361,10 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
     // or add pass-thru: true in a pipline configuration step.
     const configEntry = context.GetEntry(node.configScope.last.toString());
     const passthru =
-      (configEntry && configEntry["pass-thru"] === true) ||
+      configEntry?.["pass-thru"] === true ||
       values(configView.GetEntry("pass-thru")).any((each) => each === pluginName);
     const usenull =
-      (configEntry && configEntry["null"] === true) ||
+      configEntry?.["null"] === true ||
       values(configView.GetEntry("null")).any((each) => each === pluginName);
 
     const plugin = usenull ? plugins.null : passthru ? plugins.identity : plugins[pluginName];


### PR DESCRIPTION
Validate that value is available before reading configuration.

Offending plugin in my case with `imodeler1`
Fixes #3908