### PR TITLE
[WIP-POC] Migration to jsonpath-plus

### DIFF
--- a/common/changes/@azure-tools/datastore/feature-jsonpath-plus_2021-03-15-20-02.json
+++ b/common/changes/@azure-tools/datastore/feature-jsonpath-plus_2021-03-15-20-02.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "**Migrate** from jsonpath to jsonpath-plus",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/datastore",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -71,6 +71,7 @@ dependencies:
   jest-snapshot: 26.6.2
   js-yaml: 4.0.0
   jsonpath: 1.0.0
+  jsonpath-plus: 5.0.4
   linq-es2015: 2.5.1
   lodash: 4.17.21
   mkdirp: 0.5.5
@@ -928,6 +929,10 @@ packages:
     dev: false
     resolution:
       integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+  /@types/jsonpath-plus/5.0.1:
+    dev: false
+    resolution:
+      integrity: sha512-kdhqBgp6Wm5bDAvEg1iX/QQGwt7pfFp7XnGDi/ETuw1BMM6a1n/FwanCemzVocedXvTXJuOX0bPmu/WpMejHTA==
   /@types/jsonpath/0.2.0:
     dev: false
     resolution:
@@ -5232,6 +5237,12 @@ packages:
       '0': node >= 0.2.0
     resolution:
       integrity: sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+  /jsonpath-plus/5.0.4:
+    dev: false
+    engines:
+      node: '>=10.0.0'
+    resolution:
+      integrity: sha512-w3pI3PewtwIrrGRCFvTkCkKu8IrOwjsqoYRxvxuXQjPB0udEtAuBY0B6/SEztsxMmuIHVHGFQ0knVnTCPW9qYw==
   /jsonpath/1.0.0:
     dependencies:
       esprima: 1.2.2
@@ -9242,6 +9253,7 @@ packages:
       '@azure-tools/uri': 3.0.256
       '@types/jest': 26.0.20
       '@types/jsonpath': 0.2.0
+      '@types/jsonpath-plus': 5.0.1
       '@types/node': 14.14.34
       '@types/source-map': 0.5.0
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
@@ -9253,6 +9265,7 @@ packages:
       jest: 26.6.3_ts-node@9.1.1
       js-yaml: 4.0.0
       jsonpath: 1.0.0
+      jsonpath-plus: 5.0.4
       rimraf: 3.0.2
       source-map: 0.5.6
       ts-jest: 26.5.3_jest@26.6.3+typescript@4.2.3
@@ -9265,7 +9278,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-9XGDUEEt44VkCbJxFPjzskKfeqMLYcVn6zDGBYmBVz5ho+et0+iLR5oD3sMfJybn3dlQz0sGTmF7/XO0FZ4zqQ==
+      integrity: sha512-V3MwekQOa7HHZxr2pu9ubSasr9E9VS+V2fwhaQr72OZy6JaBjVJe6tO+n0CLGMIrrRZMjTLo358I+d5OjyVitg==
       tarball: file:projects/datastore.tgz
     version: 0.0.0
   file:projects/deduplication.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9535,6 +9548,7 @@ packages:
       integrity: sha512-avGo/LW8WilQ37XPpPHqyRVtrS6FS4Oxm2NnkvMKV6v3UA8sQMMLH4QglVnyVpZDP8ULsCZwWrc7kVe+iYlZKA==
       tarball: file:projects/test-utils.tgz
     version: 0.0.0
+registry: ''
 specifiers:
   '@azure-tools/async-io': ~3.0.0
   '@azure-tools/eventing': ~3.0.0
@@ -9608,6 +9622,7 @@ specifiers:
   jest-snapshot: ~26.6.2
   js-yaml: ~4.0.0
   jsonpath: 1.0.0
+  jsonpath-plus: 5.0.4
   linq-es2015: ^2.4.25
   lodash: ~4.17.20
   mkdirp: ~0.5.1

--- a/packages/libs/datastore/package.json
+++ b/packages/libs/datastore/package.json
@@ -37,7 +37,6 @@
   "readme": "https://github.com/Azure/perks/tree/master/datastore/readme.md",
   "devDependencies": {
     "@types/jest": "^26.0.20",
-    "@types/jsonpath": "^0.2.0",
     "@types/node": "~14.14.20",
     "@types/source-map": "0.5.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
@@ -57,7 +56,7 @@
     "@azure-tools/tasks": "~3.0.0",
     "@azure-tools/uri": "~3.0.0",
     "js-yaml": "~4.0.0",
-    "jsonpath": "1.0.0",
+    "jsonpath-plus": "5.0.4",
     "source-map": "0.5.6",
     "yaml-ast-parser": "0.0.43"
   }

--- a/packages/libs/datastore/src/json-path/index.ts
+++ b/packages/libs/datastore/src/json-path/index.ts
@@ -1,0 +1,1 @@
+export * from "./json-path";

--- a/packages/libs/datastore/src/json-path/json-path.test.ts
+++ b/packages/libs/datastore/src/json-path/json-path.test.ts
@@ -54,13 +54,17 @@ describe("JsonPath", () => {
   });
 
   it("round trip identity", () => {
-    const roundTrips = (s: string) => assert.equal(roundTrip(s), s);
-    roundTrips("$.asd.qwe[1].zxc");
-    roundTrips('$[1][42]["asd qwe"]');
-    roundTrips('$[1]["1"]');
+    const roundTrips = (s: string) => expect(roundTrip(s)).toEqual(s);
+    roundTrips("$['asd']['qwe'][1]['zxc']");
+    roundTrips("$[1][42]['asd qwe']");
+    roundTrips("$[1]");
   });
 
-  it("round trip simplification", () => {
+  it("accept number in paths", () => {
+    expect(jp.stringify(["foo", 123 as any, "other"])).toEqual("$['foo'][123]['other']");
+  });
+
+  xit("round trip simplification", () => {
     assert.equal(roundTrip('$["definitely"]["add"]["more"]["cowbell"]'), "$.definitely.add.more.cowbell");
     assert.equal(roundTrip('$[1]["even"]["more cowbell"]'), '$[1].even["more cowbell"]');
   });

--- a/packages/libs/datastore/src/json-path/json-path.ts
+++ b/packages/libs/datastore/src/json-path/json-path.ts
@@ -5,15 +5,15 @@
 import { JSONPath } from "jsonpath-plus";
 import { createSandbox } from "@azure-tools/codegen";
 
+export type JsonPath = JsonPathComponent[];
 export type JsonPathComponent = string | number;
 
-const safeEval = createSandbox();
 interface JSONPathExt {
   toPathArray: (path: string) => string[];
   toPathString: (path: JsonPathComponent[]) => string;
 }
 
-export interface JsonPathResult {
+interface JsonPathResult {
   path: string;
   value: any;
   parent: any;
@@ -22,6 +22,8 @@ export interface JsonPathResult {
   pointer: string;
 }
 
+// Override the vm used in jsonpath to use our safeEval and ignore errors.
+const safeEval = createSandbox();
 JSONPath.prototype.vm = {
   runInNewContext: (code: string, context: Record<string, any>) => {
     try {
@@ -32,38 +34,6 @@ JSONPath.prototype.vm = {
     }
   },
 };
-
-// patch in smart filter expressions
-// const handlers = (<any>jsonpath).handlers;
-// handlers.register("subscript-descendant-filter_expression", function (component: any, partial: any, count: any) {
-//   const src = component.expression.value.slice(1);
-
-//   const passable = function (key: any, value: any) {
-//     try {
-//       return safeEval(src.replace(/@/g, "$$$$"), { $$: value });
-//     } catch (e) {
-//       return false;
-//     }
-//   };
-
-//   return eval("this").traverse(partial, null, passable, count);
-// });
-// handlers.register("subscript-child-filter_expression", function (component: any, partial: any, count: any) {
-//   const src = component.expression.value.slice(1);
-
-//   const passable = function (key: any, value: any) {
-//     try {
-//       return safeEval(src.replace(/@/g, "$$$$"), { $$: value });
-//     } catch (e) {
-//       return false;
-//     }
-//   };
-
-//   return eval("this").descend(partial, null, passable, count);
-// });
-// patch end
-
-export type JsonPath = (string | number)[];
 
 export function parse(jsonPath: string): JsonPath {
   return ((JSONPath as any) as JSONPathExt).toPathArray(jsonPath).slice(1);

--- a/packages/libs/datastore/src/json-path/json-path.ts
+++ b/packages/libs/datastore/src/json-path/json-path.ts
@@ -2,83 +2,110 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import jsonpath from "jsonpath";
+import { JSONPath } from "jsonpath-plus";
 import { createSandbox } from "@azure-tools/codegen";
 
+export type JsonPathComponent = string | number;
+
 const safeEval = createSandbox();
+interface JSONPathExt {
+  toPathArray: (path: string) => string[];
+  toPathString: (path: JsonPathComponent[]) => string;
+}
+
+export interface JsonPathResult {
+  path: string;
+  value: any;
+  parent: any;
+  parentProperty: string;
+  hasArrExpr: boolean;
+  pointer: string;
+}
+
+JSONPath.prototype.vm = {
+  runInNewContext: (code: string, context: Record<string, any>) => {
+    try {
+      return safeEval(code, context);
+    } catch (e) {
+      // We just ignore javascript errors.
+      return false;
+    }
+  },
+};
 
 // patch in smart filter expressions
-const handlers = (<any>jsonpath).handlers;
-handlers.register("subscript-descendant-filter_expression", function (component: any, partial: any, count: any) {
-  const src = component.expression.value.slice(1);
+// const handlers = (<any>jsonpath).handlers;
+// handlers.register("subscript-descendant-filter_expression", function (component: any, partial: any, count: any) {
+//   const src = component.expression.value.slice(1);
 
-  const passable = function (key: any, value: any) {
-    try {
-      return safeEval(src.replace(/@/g, "$$$$"), { $$: value });
-    } catch (e) {
-      return false;
-    }
-  };
+//   const passable = function (key: any, value: any) {
+//     try {
+//       return safeEval(src.replace(/@/g, "$$$$"), { $$: value });
+//     } catch (e) {
+//       return false;
+//     }
+//   };
 
-  return eval("this").traverse(partial, null, passable, count);
-});
-handlers.register("subscript-child-filter_expression", function (component: any, partial: any, count: any) {
-  const src = component.expression.value.slice(1);
+//   return eval("this").traverse(partial, null, passable, count);
+// });
+// handlers.register("subscript-child-filter_expression", function (component: any, partial: any, count: any) {
+//   const src = component.expression.value.slice(1);
 
-  const passable = function (key: any, value: any) {
-    try {
-      return safeEval(src.replace(/@/g, "$$$$"), { $$: value });
-    } catch (e) {
-      return false;
-    }
-  };
+//   const passable = function (key: any, value: any) {
+//     try {
+//       return safeEval(src.replace(/@/g, "$$$$"), { $$: value });
+//     } catch (e) {
+//       return false;
+//     }
+//   };
 
-  return eval("this").descend(partial, null, passable, count);
-});
+//   return eval("this").descend(partial, null, passable, count);
+// });
 // patch end
 
-export type JsonPathComponent = jsonpath.PathComponent;
-export type JsonPath = Array<JsonPathComponent>;
+export type JsonPath = (string | number)[];
 
 export function parse(jsonPath: string): JsonPath {
-  return jsonpath
-    .parse(jsonPath)
-    .map((part) => part.expression.value)
-    .slice(1);
+  return ((JSONPath as any) as JSONPathExt).toPathArray(jsonPath).slice(1);
 }
 
 export function stringify(jsonPath: JsonPath): string {
-  return jsonpath.stringify(["$" as JsonPathComponent].concat(jsonPath));
+  return ((JSONPath as any) as JSONPathExt).toPathString(["$", ...jsonPath]);
 }
 
 export function paths<T>(obj: T, jsonQuery: string): Array<JsonPath> {
   return nodes(obj, jsonQuery).map((x) => x.path);
 }
 
-export function nodes<T>(obj: T, jsonQuery: string): Array<{ path: JsonPath; value: any }> {
+function run(obj: any, query: string): JsonPathResult[] {
+  return JSONPath({ path: query, json: obj as any, resultType: "all" });
+}
+
+export function nodes<T>(obj: T, query: string): Array<{ path: JsonPath; value: any }> {
   // jsonpath only accepts objects
   if (obj instanceof Object) {
-    let result = jsonpath.nodes(obj, jsonQuery).map((x) => ({ path: x.path.slice(1), value: x.value }));
-    const comp = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
-    result = result.sort((a, b) => comp(JSON.stringify(a.path), JSON.stringify(b.path)));
-    result = result.filter((x, i) => i === 0 || JSON.stringify(x.path) !== JSON.stringify(result[i - 1].path));
-    return result;
+    const compare = (a: string, b: string) => (a < b ? -1 : a > b ? 1 : 0);
+    const result = run(obj, query);
+    return result
+      .map((x) => ({ path: parse(x.path), value: x.value }))
+      .sort((a, b) => compare(JSON.stringify(a.path), JSON.stringify(b.path)))
+      .filter((x, i) => i === 0 || JSON.stringify(x.path) !== JSON.stringify(result[i - 1].path));
   } else {
-    return matches(jsonQuery, []) ? [{ path: [], value: obj }] : [];
+    return matches(query, []) ? [{ path: [], value: obj }] : [];
   }
 }
 
 export function selectNodes<T>(obj: T, jsonQuery: string): Array<{ path: JsonPath; value: any; parent: any }> {
   // jsonpath only accepts objects
   if (obj instanceof Object) {
-    const result = new Array<{ path: JsonPath; value: any; parent: any }>();
+    const result: { path: JsonPath; value: any; parent: any }[] = [];
     const keys = new Set<string>();
 
-    for (const node of jsonpath.nodes(obj, jsonQuery)) {
-      const p = jsonpath.stringify(node.path);
+    for (const node of run(obj, jsonQuery)) {
+      const p = node.path;
       if (!keys.has(p)) {
         keys.add(p);
-        result.push({ path: node.path.slice(1), value: node.value, parent: jsonpath.parent(obj, p) });
+        result.push({ path: parse(node.path), value: node.value, parent: node.parent });
       }
     }
     return result;


### PR DESCRIPTION
This is a tentative PR to see if this library make more sense.

Migrate from using [jsonpath](https://www.npmjs.com/package/jsonpath) to [jsonpath-plus](https://www.npmjs.com/package/jsonpath-plus)

Pros:
- Compatible with webpack, no need for the workaround with `jsonpath`
- Additional functionalities

Cons:
- Does not  serialize a jsonpath to a simple format(Always wrap segements in `[]` and `''`

Problems:
- Doesn't like double quotes`""` which I think will cause issues

fix #3580