### PR TITLE
Swagger to OpenAPI3 converter should handle refs in enum values

### DIFF
--- a/common/changes/@azure-tools/oai2-to-oai3/fix-oai3-converter-enum-obj_2021-03-18-18-23.json
+++ b/common/changes/@azure-tools/oai2-to-oai3/fix-oai3-converter-enum-obj_2021-03-18-18-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/oai2-to-oai3",
+      "comment": "**Fix** enum with $ref inside not being processed",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/oai2-to-oai3",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/libs/oai2-to-oai3/src/converter.ts
+++ b/packages/libs/oai2-to-oai3/src/converter.ts
@@ -508,7 +508,6 @@ export class Oai2ToOai3 {
     for (const { key, value, pointer, childIterator } of schemaItemMemebers()) {
       switch (key) {
         case "$ref":
-          console.error("$ref", value);
           target.$ref = { value: await this.convertReferenceToOai3(value), pointer };
           break;
         case "additionalProperties":
@@ -595,7 +594,6 @@ export class Oai2ToOai3 {
 
   private async visitEnum(target: any, members: () => Iterable<Node>) {
     for (const { key: index, value, pointer, childIterator } of members()) {
-      console.error("ENUM BA", index, value);
       if (typeof value === "object") {
         const obj = this.newObject(pointer);
         await this.visitSchema(obj, value, childIterator);

--- a/packages/libs/oai2-to-oai3/src/converter.ts
+++ b/packages/libs/oai2-to-oai3/src/converter.ts
@@ -595,11 +595,10 @@ export class Oai2ToOai3 {
   private async visitEnum(target: any, members: () => Iterable<Node>) {
     for (const { key: index, value, pointer, childIterator } of members()) {
       if (typeof value === "object") {
-        const obj = this.newObject(pointer);
-        await this.visitSchema(obj, value, childIterator);
-        target.__push__(obj);
+        target.__push__(this.newObject(pointer));
+        await this.visitSchema(target[index], value, childIterator);
       } else {
-        target.__push__(value);
+        target.__push__({ value, pointer, recurse: true });
       }
     }
   }

--- a/packages/libs/oai2-to-oai3/test/scenarios/expected/enums/swagger.json
+++ b/packages/libs/oai2-to-oai3/test/scenarios/expected/enums/swagger.json
@@ -1,0 +1,45 @@
+{
+  "servers": [],
+  "openapi": "3.0.0",
+  "info": {
+    "version": "1.0",
+    "title": "test",
+    "description": "Test"
+  },
+  "paths": {},
+  "components": {
+    "schemas": {
+      "MyStringEnum": {
+        "type": "object",
+        "enum": [
+          "foo",
+          "bar"
+        ]
+      },
+      "MyNumberEnum": {
+        "type": "object",
+        "enum": [
+          7,
+          998,
+          12310
+        ]
+      },
+      "MyObjectEnum": {
+        "type": "object",
+        "enum": [
+          {
+            "$ref": "#/components/schemas/FrequencySingle"
+          }
+        ]
+      },
+      "MyEnumValue": {
+        "type": "object",
+        "properties": {
+          "age": {
+            "type": "integer"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/libs/oai2-to-oai3/test/scenarios/inputs/enums/swagger.json
+++ b/packages/libs/oai2-to-oai3/test/scenarios/inputs/enums/swagger.json
@@ -1,0 +1,38 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "1.0",
+    "title": "test",
+    "description": "Test"
+  },
+  "produces": ["application/json"],
+  "consumes": ["application/json"],
+  "paths": {},
+  "definitions": {
+    "MyStringEnum": {
+      "type": "object",
+      "enum": ["foo", "bar"]
+    },
+    "MyNumberEnum": {
+      "type": "object",
+      "enum": [7, 998, 12310]
+    },
+    "MyObjectEnum": {
+      "type": "object",
+      "enum": [
+        {
+          "$ref": "#/definitions/FrequencySingle"
+        }
+      ]
+    },
+    "MyEnumValue": {
+      "type": "object",
+      "properties": {
+        "age": {
+          "type": "integer"
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/packages/libs/oai2-to-oai3/test/scenarios/scenarios.test.ts
+++ b/packages/libs/oai2-to-oai3/test/scenarios/scenarios.test.ts
@@ -54,4 +54,9 @@ describe("Scenario testings", () => {
     // The expected result is the parmaeter to be included/expanded in the OpenAPI3 server property.
     await expectInputsMatchSnapshots("parameterized-host-parameters", ["swagger.json"]);
   });
+
+  fit("Convert enums using $ref object as values", async () => {
+    // The expected result is the $ref in `enum` has been updated to the openapi 3 format.
+    await expectInputsMatchSnapshots("enums", ["swagger.json"]);
+  });
 });


### PR DESCRIPTION
Even though modelerfour will not support object enums, this currently result in confusing error where an enum with `/definitions `$ref was not updated and was failing later in the pipeline

fix #3996