### PR TITLE
Ability to log in libraries with @azure/logger

### DIFF
--- a/common/changes/@autorest/common/feature-logger-improvements_2021-03-22-18-05.json
+++ b/common/changes/@autorest/common/feature-logger-improvements_2021-03-22-18-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/common",
+      "comment": "**Added** configuration for usage of @azure/logger in libraries",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/common",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/core/feature-logger-improvements_2021-03-22-18-05.json
+++ b/common/changes/@autorest/core/feature-logger-improvements_2021-03-22-18-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Added** configure @azure/logger according to debug/verbose flags",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/datastore/feature-logger-improvements_2021-03-22-18-05.json
+++ b/common/changes/@azure-tools/datastore/feature-logger-improvements_2021-03-22-18-05.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "**Update** Logging to use `@azure/logger` instead of `console`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/datastore",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -5,6 +5,7 @@ dependencies:
   '@azure-tools/object-comparison': 3.0.252
   '@azure-tools/tasks': 3.0.253
   '@azure-tools/uri': 3.1.1
+  '@azure/logger': 1.0.2
   '@rush-temp/autorest': file:projects/autorest.tgz_ts-node@9.1.1+webpack-cli@4.4.0
   '@rush-temp/codegen': file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/codemodel': file:projects/codemodel.tgz_prettier@2.2.1
@@ -157,6 +158,14 @@ packages:
       node: '>=10.12.0'
     resolution:
       integrity: sha512-UgPgD+qVtm4ASYqoTDazjowimrmMGGEQqPnNk9K/8CZdi2oSLtGqX9S1++2+NDaHlq74VyxbcNMKoxgO+2CCUQ==
+  /@azure/logger/1.0.2:
+    dependencies:
+      tslib: 2.1.0
+    dev: false
+    engines:
+      node: '>=8.0.0'
+    resolution:
+      integrity: sha512-YZNjNV0vL3nN2nedmcjQBcpCTo3oqceXmgiQtEm6fLpucjRZyQKAQruhCmCpRlB1iykqKJJ/Y8CDmT5rIE6IJw==
   /@babel/code-frame/7.12.11:
     dependencies:
       '@babel/highlight': 7.13.10
@@ -8217,6 +8226,10 @@ packages:
     dev: false
     resolution:
       integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+  /tslib/2.1.0:
+    dev: false
+    resolution:
+      integrity: sha512-hcVC3wYEziELGGmEEXue7D75zbwIIVUMWAVbHItGPx0ziyXxrOMQx4rQEVEV45Ut/1IotuEvwqPopzIOkDMf0A==
   /tsutils/3.21.0_typescript@4.2.3:
     dependencies:
       tslib: 1.14.1
@@ -9252,6 +9265,7 @@ packages:
       '@azure-tools/linq': 3.1.262
       '@azure-tools/tasks': 3.0.253
       '@azure-tools/uri': 3.1.1
+      '@azure/logger': 1.0.2
       '@types/jest': 26.0.20
       '@types/jsonpath': 0.2.0
       '@types/node': 14.14.34
@@ -9277,7 +9291,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-859pEc+p/6R9manmRzKkoj2igppVAgitUOSCVjjF1DfaFl5xcnjJWUV1PHsW6Ve9jazhI+sovI60hqZLVg0a6g==
+      integrity: sha512-uRL9MrUii4CK881JG7n2azamTk9z+zlQprbdEaU21zL04oXvSSyI3FHyOR+qGO+W4iYmphOlHVoRusRiiOCCUg==
       tarball: file:projects/datastore.tgz
     version: 0.0.0
   file:projects/deduplication.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9555,6 +9569,7 @@ specifiers:
   '@azure-tools/object-comparison': ~3.0.0
   '@azure-tools/tasks': ~3.0.0
   '@azure-tools/uri': ~3.1.1
+  '@azure/logger': ^1.0.2
   '@rush-temp/autorest': file:./projects/autorest.tgz
   '@rush-temp/codegen': file:./projects/codegen.tgz
   '@rush-temp/codemodel': file:./projects/codemodel.tgz

--- a/packages/extensions/core/src/app.ts
+++ b/packages/extensions/core/src/app.ts
@@ -5,6 +5,7 @@
 /* eslint-disable no-console */
 import "source-map-support/register";
 import { omit } from "lodash";
+import { configureLibrariesLogger } from "@autorest/common";
 
 // https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd
@@ -242,6 +243,11 @@ async function currentMain(autorestArgs: Array<string>): Promise<number> {
   }
   verbose = verbose || args.rawSwitches["verbose"];
   debug = debug || args.rawSwitches["debug"];
+
+  // Only show library logs if in verbose or debug mode.
+  if (verbose || debug) {
+    configureLibrariesLogger("verbose", console.log);
+  }
 
   // identify where we are starting from.
   const currentDirUri = CreateFolderUri(currentDirectory());

--- a/packages/extensions/core/src/app.ts
+++ b/packages/extensions/core/src/app.ts
@@ -7,28 +7,9 @@ import "source-map-support/register";
 import { omit } from "lodash";
 import { configureLibrariesLogger } from "@autorest/common";
 
-// https://github.com/uxitten/polyfill/blob/master/string.polyfill.js
-// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd
-if (!String.prototype.padEnd) {
-  String.prototype.padEnd = function padEnd(targetLength, padString) {
-    targetLength = targetLength >> 0; // floor if number or convert non-number to 0;
-    padString = String(padString || " ");
-    if (this.length > targetLength) {
-      return String(this);
-    } else {
-      targetLength = targetLength - this.length;
-      if (targetLength > padString.length) {
-        padString += padString.repeat(targetLength / padString.length); // append to original to ensure we are longer than needed
-      }
-      return String(this) + padString.slice(0, targetLength);
-    }
-  };
-}
-
 require("events").EventEmitter.defaultMaxListeners = 100;
 process.env["ELECTRON_RUN_AS_NODE"] = "1";
 delete process.env["ELECTRON_NO_ATTACH_CONSOLE"];
-(<any>global).autorestVersion = require("../package.json").version;
 
 const color: (text: string) => string = (<any>global).color ? (<any>global).color : (p) => p;
 
@@ -53,6 +34,7 @@ import { mergeConfigurations } from "@autorest/configuration";
 import { Exception } from "@autorest/common";
 import { Channel, Message } from "./lib/message";
 import { homedir } from "os";
+import { VERSION } from "./lib/constants";
 
 let verbose = false;
 let debug = false;
@@ -239,7 +221,7 @@ async function currentMain(autorestArgs: Array<string>): Promise<number> {
   args = parseArgs([...autorestArgs, ...more]);
 
   if (!args.rawSwitches["message-format"] || args.rawSwitches["message-format"] === "regular") {
-    console.log(color(`> Loading AutoRest core      '${__dirname}' (${(<any>global).autorestVersion})`));
+    console.log(color(`> Loading AutoRest core      '${__dirname}' (${VERSION})`));
   }
   verbose = verbose || args.rawSwitches["verbose"];
   debug = debug || args.rawSwitches["debug"];
@@ -565,7 +547,3 @@ void main();
 process.on("exit", () => {
   void Shutdown();
 });
-
-async function showHelp(): Promise<void> {
-  await currentMain(["--help"]);
-}

--- a/packages/extensions/core/src/lib/configuration/autorest-context.ts
+++ b/packages/extensions/core/src/lib/configuration/autorest-context.ts
@@ -16,6 +16,7 @@ import {
 import { AutorestError, AutorestLogger, AutorestWarning } from "@autorest/common";
 import { Message } from "../message";
 import { AutorestCoreLogger } from "./logger";
+import { VERSION } from "../constants";
 
 export class AutorestContext implements AutorestLogger {
   public config: AutorestConfiguration;
@@ -110,14 +111,12 @@ export class AutorestContext implements AutorestLogger {
 
   public get HeaderText(): string {
     const h = this.config["header-definitions"];
-    const version = (<any>global).autorestVersion;
-
     switch (this.config["license-header"]?.toLowerCase()) {
       case "microsoft_mit":
-        return `${h.microsoft}\n${h.mit}\n${h.default.replace("{core}", version)}\n${h.warning}`;
+        return `${h.microsoft}\n${h.mit}\n${h.default.replace("{core}", VERSION)}\n${h.warning}`;
 
       case "microsoft_apache":
-        return `${h.microsoft}\n${h.apache}\n${h.default.replace("{core}", version)}\n${h.warning}`;
+        return `${h.microsoft}\n${h.apache}\n${h.default.replace("{core}", VERSION)}\n${h.warning}`;
 
       case "microsoft_mit_no_version":
         return `${h.microsoft}\n${h.mit}\n${h["no-version"]}\n${h.warning}`;
@@ -132,14 +131,14 @@ export class AutorestContext implements AutorestLogger {
         return "";
 
       case "microsoft_mit_small":
-        return `${h.microsoft}\n${h["mit-small"]}\n${h.default.replace("{core}", version)}\n${h.warning}`;
+        return `${h.microsoft}\n${h["mit-small"]}\n${h.default.replace("{core}", VERSION)}\n${h.warning}`;
 
       case "microsoft_mit_small_no_codegen":
         return `${h.microsoft}\n${h["mit-small"]}\n${h["no-version"]}`;
 
       case null:
       case undefined:
-        return `${h.default.replace("{core}", version)}\n${h.warning}`;
+        return `${h.default.replace("{core}", VERSION)}\n${h.warning}`;
 
       default:
         return `${this.config["license-header"]}`;

--- a/packages/extensions/core/src/lib/constants.ts
+++ b/packages/extensions/core/src/lib/constants.ts
@@ -17,3 +17,8 @@ const resolveAppRoot = () => {
  * Root of autorest core(i.e core folder)
  */
 export const AppRoot = resolveAppRoot();
+
+/**
+ * Version of this package.
+ */
+export const VERSION = require("../../package.json").version;

--- a/packages/libs/common/package.json
+++ b/packages/libs/common/package.json
@@ -43,6 +43,7 @@
   },
   "dependencies": {
     "@azure-tools/datastore": "~4.2.1",
+    "@azure/logger": "^1.0.2",
     "commonmark": "^0.27.0"
   }
 }

--- a/packages/libs/common/src/logging/configure.ts
+++ b/packages/libs/common/src/logging/configure.ts
@@ -1,0 +1,10 @@
+import { AzureLogger, AzureLogLevel, setLogLevel } from "@azure/logger";
+
+/**
+ * Configure Autorest Logger.
+ * @param level
+ */
+export function configureLibrariesLogger(level: AzureLogLevel, log: (...args: unknown[]) => void): void {
+  setLogLevel(level);
+  AzureLogger.log = log;
+}

--- a/packages/libs/common/src/logging/index.ts
+++ b/packages/libs/common/src/logging/index.ts
@@ -1,1 +1,2 @@
 export * from "./logger";
+export * from "./configure";

--- a/packages/libs/datastore/package.json
+++ b/packages/libs/datastore/package.json
@@ -56,6 +56,7 @@
     "@azure-tools/linq": "~3.1.0",
     "@azure-tools/tasks": "~3.0.0",
     "@azure-tools/uri": "~3.1.1",
+    "@azure/logger": "^1.0.2",
     "js-yaml": "~4.0.0",
     "jsonpath": "1.0.0",
     "source-map": "0.5.6",

--- a/packages/libs/datastore/src/data-store/data-store.ts
+++ b/packages/libs/datastore/src/data-store/data-store.ts
@@ -17,6 +17,7 @@ import { join } from "path";
 
 import { createHash } from "crypto";
 import { LineIndices } from "../main";
+import { logger } from "../logger";
 const md5 = (content: any) => (content ? createHash("md5").update(JSON.stringify(content)).digest("hex") : null);
 
 const FALLBACK_DEFAULT_OUTPUT_ARTIFACT = "";
@@ -152,10 +153,7 @@ class ReadThroughDataSource extends DataSource {
             data = data.replace(/\$\(this-folder\)\/*/g, parent);
           }
         } catch (e) {
-          // TODO-TIM: Reeenable this log with new logging system https://github.com/Azure/autorest/issues/3988
-          // Disabled this as it creates too much noise for some expected failure(Cannot find samples)
-          // eslint-disable-next-line no-console
-          // console.error("Unexpected error trying to read file", e);
+          logger.error("Unexpected error trying to read file", e);
         } finally {
           if (!data) {
             // eslint-disable-next-line no-unsafe-finally

--- a/packages/libs/datastore/src/file-system/enhanced-file-system.ts
+++ b/packages/libs/datastore/src/file-system/enhanced-file-system.ts
@@ -1,4 +1,5 @@
-import { WriteString } from "@azure-tools/uri";
+import { writeString } from "@azure-tools/uri";
+import { logger } from "../logger";
 import { RealFileSystem } from "./real-file-system";
 
 // handles:
@@ -17,7 +18,7 @@ export class EnhancedFileSystem extends RealFileSystem {
   }
 
   public async write(uri: string, content: string): Promise<void> {
-    return WriteString(uri, content);
+    return writeString(uri, content);
   }
 
   private getHeaders(uri: string) {
@@ -28,8 +29,7 @@ export class EnhancedFileSystem extends RealFileSystem {
       this.githubAuthToken &&
       (uri.startsWith("https://raw.githubusercontent.com") || uri.startsWith("https://github.com"))
     ) {
-      // eslint-disable-next-line no-console
-      console.error(`Used GitHub authentication token to request '${uri}'.`);
+      logger.info(`Used GitHub authentication token to request '${uri}'.`);
       headers.authorization = `Bearer ${this.githubAuthToken}`;
     }
 

--- a/packages/libs/datastore/src/file-system/real-file-system.ts
+++ b/packages/libs/datastore/src/file-system/real-file-system.ts
@@ -1,13 +1,14 @@
-import { EnumerateFiles, ReadUri, WriteString } from "@azure-tools/uri";
+import { enumerateFiles, readUri, writeString } from "@azure-tools/uri";
 import { IFileSystem } from "./file-system";
 import * as Constants from "../constants";
 import { UriNotFoundError } from "./errors";
+import { logger } from "../logger";
 
 export class RealFileSystem implements IFileSystem {
   public constructor() {}
 
   public list(folderUri: string): Promise<Array<string>> {
-    return EnumerateFiles(folderUri, [Constants.DefaultConfiguration]);
+    return enumerateFiles(folderUri, [Constants.DefaultConfiguration]);
   }
 
   public async read(uri: string, headers: { [name: string]: string } = {}): Promise<string> {
@@ -15,7 +16,7 @@ export class RealFileSystem implements IFileSystem {
   }
 
   public async write(uri: string, content: string): Promise<void> {
-    return WriteString(uri, content);
+    return writeString(uri, content);
   }
 
   /**
@@ -43,12 +44,12 @@ export async function readUriWithRetries(uri: string, headers: { [name: string]:
   let tryed = 1;
   for (;;) {
     try {
-      return await ReadUri(uri, headers);
+      return await readUri(uri, headers);
     } catch (e) {
       tryed++;
       if (isRetryableStatusCode(e.statusCode) && tryed <= MAX_RETRY_COUNT) {
         // eslint-disable-next-line no-console
-        console.error(`Failed to load uri ${uri}, trying again (${tryed}/${MAX_RETRY_COUNT})`, e);
+        logger.error(`Failed to load uri ${uri}, trying again (${tryed}/${MAX_RETRY_COUNT})`, e);
       } else {
         throw processError(uri, e);
       }

--- a/packages/libs/datastore/src/logger.ts
+++ b/packages/libs/datastore/src/logger.ts
@@ -1,0 +1,3 @@
+import { createClientLogger } from "@azure/logger";
+
+export const logger = createClientLogger("datastore");


### PR DESCRIPTION
fix #3988

Making use of `azure-sdk-for-js` `@azure/logger` in the library and then autorest and core plugs into it if `--debug` or `--verbose` is passed