### PR TITLE
Fix: OpenAPI3 Validation of additional properties support boolean

### DIFF
--- a/common/changes/@autorest/schemas/fix-additional-props-oai3-validation_2021-03-23-17-44.json
+++ b/common/changes/@autorest/schemas/fix-additional-props-oai3-validation_2021-03-23-17-44.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/schemas",
+      "comment": "**Fix**: OpenAPI3 Validation of additional properties support boolean",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/schemas",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/libs/autorest-schemas/openapi3-schema.json
+++ b/packages/libs/autorest-schemas/openapi3-schema.json
@@ -383,16 +383,16 @@
         "additionalProperties": {
           "allOf": [
             {
-              "if": { "required": ["$ref"] },
+              "if": { "type": "object", "required": ["$ref"] },
               "then": { "$ref": "#/definitions/Reference" }
             },
             {
               "if": { "type": "object" },
-              "then": { "$ref": "#/definitions/Schema" }
-            },
-            {
-              "if": { "type": "boolean" },
-              "then": { "type": "boolean" }
+              "then": { "$ref": "#/definitions/Schema" },
+              "else": {
+                "type": "boolean",
+                "errorMessage": "should be a Reference Object, Schema Object, or boolean value"
+              }
             }
           ],
           "default": true


### PR DESCRIPTION
From  #3497

when converting to the if, then else system for better error, seems like the additionalProperties: boolean wasn't implemented correctly which prevented it from being used