### PR TITLE
Internal: Add eslint jest plugin and fix issues

### DIFF
--- a/.default-eslintrc.yaml
+++ b/.default-eslintrc.yaml
@@ -15,6 +15,7 @@ extends:
   - eslint:recommended
   - plugin:@typescript-eslint/recommended
   - plugin:node/recommended
+  - plugin:jest/recommended
 
 globals:
   Atomics: readonly
@@ -67,6 +68,8 @@ rules:
   # =================================================
   # Jest plugin
   # =================================================
+  jest/no-deprecated-functions: off
+  jest/expect-expect: off
   jest/no-focused-tests: warn
   jest/no-identical-title: warn
 

--- a/.default-eslintrc.yaml
+++ b/.default-eslintrc.yaml
@@ -5,6 +5,7 @@ plugins:
   - prettier
   - unicorn
   - node
+  - jest
 
 env:
   es6: true
@@ -62,6 +63,12 @@ rules:
   node/no-unsupported-features/es-syntax: off # Disabling this one otherwise it will complain about typescript imports which get transpiled.
   node/no-missing-import: off
   node/shebang: off
+
+  # =================================================
+  # Jest plugin
+  # =================================================
+  jest/no-focused-tests: warn
+  jest/no-identical-title: warn
 
   # Basic config
   no-console: warn

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -63,6 +63,7 @@ dependencies:
   diff: 4.0.2
   eslint: 7.21.0
   eslint-plugin-import: 2.22.1_eslint@7.21.0
+  eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
   eslint-plugin-node: 11.1.0_eslint@7.21.0
   eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
   eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -3013,6 +3014,23 @@ packages:
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0
     resolution:
       integrity: sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==
+  /eslint-plugin-jest/24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045:
+    dependencies:
+      '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
+      '@typescript-eslint/experimental-utils': 4.17.0_eslint@7.21.0+typescript@4.2.3
+      eslint: 7.21.0
+    dev: false
+    engines:
+      node: '>=10'
+    peerDependencies:
+      '@typescript-eslint/eslint-plugin': '>= 4'
+      eslint: '>=5'
+      typescript: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/eslint-plugin':
+        optional: true
+    resolution:
+      integrity: sha512-cicWDr+RvTAOKS3Q/k03+Z3odt3VCiWamNUHWd6QWbVQWcYJyYgUTu8x0mx9GfeDEimawU5kQC+nQ3MFxIM6bw==
   /eslint-plugin-node/11.1.0_eslint@7.21.0:
     dependencies:
       eslint: 7.21.0
@@ -9044,6 +9062,7 @@ packages:
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
       jest: 26.6.3_ts-node@9.1.1
+      jsonpath: 1.0.0
       mkdirp: 0.5.5
       prettier: 2.2.1
       rimraf: 3.0.2
@@ -9053,6 +9072,7 @@ packages:
       ts-jest: 26.5.3_jest@26.6.3+typescript@4.2.3
       ts-loader: 8.0.18_typescript@4.2.3+webpack@5.18.0
       typescript: 4.2.3
+      untildify: 4.0.0
       webpack: 5.18.0_webpack-cli@4.4.0
     dev: false
     id: file:projects/autorest.tgz
@@ -9061,7 +9081,7 @@ packages:
       ts-node: '*'
       webpack-cli: '*'
     resolution:
-      integrity: sha512-QuC8csMGwk7MiCLuCbkfQI4cKxqo3jsjEs+lb9dQS1bGiTjvimv32o4SvJFxBr2GFuMAlEG7i8VP/B64PKky7g==
+      integrity: sha512-cw7NbhPZZ+PNqpQzZ8dluctGzv7sBuRLHf2Bbbayt5dBlgncS5AqPzgVl83/uuVoNunH8OSZBeD6v55e2XozoQ==
       tarball: file:projects/autorest.tgz
     version: 0.0.0
   file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9075,6 +9095,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9092,7 +9113,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-HfzoDoLX25Ac1uYlQN7o8AFZiLlpOMPGSj9kXQNdG97BkmUDy5FebpVqP//lanqX6DSCjGbWLrXTefZuG/TGSA==
+      integrity: sha512-XknqovtU+TyYJvK/sGSg5+wmj0qXf4wNPon013dXybfe0aYAcVCi+9QnTnUNdEoS68Crjf/eayc03rqoFVJ0dQ==
       tarball: file:projects/codegen.tgz
     version: 0.0.0
   file:projects/codemodel.tgz_prettier@2.2.1:
@@ -9103,6 +9124,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9117,7 +9139,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-9fAUXVYsHiYi8CGMX+MagSRN+kdVfQ/RgRMOac1+IyHbyjPiHzdNeLQiCikdolhIfVutRvBBL9stWHj6ZXXqCg==
+      integrity: sha512-t7yV4UXZ9LY0uBWM4tSY3CzjFXX/KZMh8BHBxavVW05S2Abcvdqg4fp9dg1ptv7zjhJe6b2hd8q7/qvV2TVD3g==
       tarball: file:projects/codemodel.tgz
     version: 0.0.0
   file:projects/common.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9130,6 +9152,7 @@ packages:
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       commonmark: 0.27.0
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9143,7 +9166,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-p+KK4sdEIQzhO2mfiXRQoFYvvlWFpJ1IbAkV5fJtv7Fpx9GYf3yOQUuDvfxXKCBokL7opvOkI6JV0oGF5usw5w==
+      integrity: sha512-QGIxd0ThHjWSq1lyPnSPhWqgb7hGME9G+HTNKMhcesWpylrActikzYtmHqrqf6lSCUM4Wl5GYRF1kpYoekV21g==
       tarball: file:projects/common.tgz
     version: 0.0.0
   file:projects/compare.tgz_prettier@2.2.1:
@@ -9158,6 +9181,7 @@ packages:
       chalk: 4.1.0
       diff: 4.0.2
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9176,7 +9200,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-MN/5BOPdjF3WRLdpWKfuSWORddarBDR0MEwozLpmNHyzyWUFXEDWe6jFIBhtvFwAsKExTzThDj/7RKmZxePafQ==
+      integrity: sha512-+eeQE+2YSOZGA4oPRRXyP3m2ZZBQyWSR6yXmpasERSvNQnVD/+cO1Owy2C0bVTTxU8xlReQDa4T4gHkcwPVWPg==
       tarball: file:projects/compare.tgz
     version: 0.0.0
   file:projects/configuration.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9189,6 +9213,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9204,7 +9229,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-s3kL3EbNMTlANrV2eaS4QE2bzF4aOnzYZTK74w2MpQ2Gk2pN7ZS5MIh4yfTB9O4+ZMgT63c/75Mff8Y1kFPHHA==
+      integrity: sha512-OHYaCRWfl4U2U+GN4Y2T+lYr+PUeA3p6dbituy4a4cIbMWlabgVvrfXbSzJc2ABvBRIbqBAagtDoDhKpgePoUg==
       tarball: file:projects/configuration.tgz
     version: 0.0.0
   file:projects/core.tgz_ts-node@9.1.1:
@@ -9231,6 +9256,7 @@ packages:
       copy-webpack-plugin: 7.0.0_webpack@5.18.0
       cpy-cli: 2.0.0
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9259,7 +9285,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-flxXp0py+T9inOrHW/93rIlyFEP59gr3OF33v+JDMWQO7vlNLDXgTgGxUL0HaR/NpduBr7GQraJlVtbGY1PWiw==
+      integrity: sha512-T8UlSiCf10EwLP/CbiR7+kcaQNq114NdrUVJ1ty6UKmQ8KKm3D/ITqarPWUmolIvIfDFCzNetQdN4s/NIiz72w==
       tarball: file:projects/core.tgz
     version: 0.0.0
   file:projects/datastore.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9275,6 +9301,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9293,7 +9320,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-uRL9MrUii4CK881JG7n2azamTk9z+zlQprbdEaU21zL04oXvSSyI3FHyOR+qGO+W4iYmphOlHVoRusRiiOCCUg==
+      integrity: sha512-JqP39zpy1qfqpya+rJm6rFiYhTGCb0ZNUQWBBS2nqpcDRAZcaXoempdObfO8sfZyuMkKzoGkkHQKNn3BuMofCw==
       tarball: file:projects/datastore.tgz
     version: 0.0.0
   file:projects/deduplication.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9307,6 +9334,7 @@ packages:
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       compare-versions: 3.6.0
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9320,7 +9348,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-+tExIQDYBZy1cZM9UQ1hVmMIjxh55dlXbsvhLhKk27i09pbEcoPXKPGB5EEPKnvvgJS1uXGrR9BAD5mKE4CX8Q==
+      integrity: sha512-2wJmtQljMza9eHf8DKXW4p1DzzTn6hpgUBw0cJwid+p9QqIVo12rFy2bSqal4jn8uXbJK6qCWkvCEHrFXACdmQ==
       tarball: file:projects/deduplication.tgz
     version: 0.0.0
   file:projects/extension-base.tgz_prettier@2.2.1:
@@ -9330,6 +9358,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9343,7 +9372,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-1vj2h0KUiNi0YGtfqyIWH/AasDFIThlzxeN0uhLCtGeld4wDs6fAP7vY9fyurVVNn+VGvqTjH0r5nnD3ZRPomg==
+      integrity: sha512-ykGM/5YZStuGK2kh5XqYc/BnHQdzy6pEG7tMl958CTYTqSrVqdP2H4svY7PgKqg8L3CgxjuaGtxqSLCP6lFGmw==
       tarball: file:projects/extension-base.tgz
     version: 0.0.0
   file:projects/extension.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9361,6 +9390,7 @@ packages:
       command-exists: 1.2.9
       cpy-cli: 2.0.0
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9383,7 +9413,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-he5P0rfZ8IwYSBCZwqfXDAjdB9xCeqK4LXhmIhNOphJshMkGtEILKrTAj0VD9KM1f85qAOq5ViHqVHfiuGFctw==
+      integrity: sha512-CjjPfn9SpeBwsmy8lBa/FntLhU1OanWMdPG2UAM5IikNdNgij5AM47nMyR9SRX46y1GcOGAS/eOWcWRkVoI6dQ==
       tarball: file:projects/extension.tgz
     version: 0.0.0
   file:projects/jsonschema.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9393,6 +9423,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9406,7 +9437,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-5XpiqTOFShmnk47wRywTCH8st0HpKkXv1liw1jZLM+4ofb13HzAoWnxnAUvAW9mppk346Y6pXCnnVIaDuL6HZQ==
+      integrity: sha512-YmPlGDkC11FFJ69Wv4DPeD3sS/InaKnTi6WbMxJzTh/1kNF9naF5CX1tKOcvdrThJjeTE7d3JZG60vfwm+lbiA==
       tarball: file:projects/jsonschema.tgz
     version: 0.0.0
   file:projects/md-mock-api.tgz_ts-node@9.1.1:
@@ -9430,6 +9461,7 @@ packages:
       deep-equal: 2.0.5
       eslint: 7.21.0
       eslint-plugin-import: 2.22.1_eslint@7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9451,7 +9483,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-0NibRDQ41o+fV8VL/cxqVpFInjOZ04DpteP4JMpqnLjyPtbdoEk0BpZt9IRVFhBSNYoGNzfKDIqQl4GKPIICww==
+      integrity: sha512-FmxmZG8Uw1IYP3fKkicSveB/FHtuRoXFE/GDYmbmyPgTc02lUsxZL7TP2p++3T/6/vg58o9+W9Y7wI2WK2OChQ==
       tarball: file:projects/md-mock-api.tgz
     version: 0.0.0
   file:projects/modelerfour.tgz_ts-node@9.1.1:
@@ -9468,6 +9500,7 @@ packages:
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       chalk: 4.1.0
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9488,7 +9521,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-UfFx10YqK50UO8F+0uRdwyjEamSoV8lMSAfRfPuSweS8SYmnlKbZMFMKQNrzLm34TC1QwH1tRpXypC6krUPUlg==
+      integrity: sha512-u2p4mI+uw0HfrOM26fbJNx8Lbmjjpuo/iz/DrcXQvxtKM8dScmni+sb+gti+HSnxmNAvV3UfR4CJvs3/S3fhNA==
       tarball: file:projects/modelerfour.tgz
     version: 0.0.0
   file:projects/oai2-to-oai3.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9500,6 +9533,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9516,7 +9550,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-ZDOC+4FN9X8JUwPJADzORKc5VY5OgpoQSt45HFdW2lEJnUhKEu25q94yaYk91/SnohJ4y9AaIW+rUCksRCUcPg==
+      integrity: sha512-BeIoiIVS/JbfG5NZriUvqknI2mCvK4Q2I/jLaVjNDZPkuSK8eEn0prpqlTspJPDwChY/0AqS7gdLYlDnatpHhA==
       tarball: file:projects/oai2-to-oai3.tgz
     version: 0.0.0
   file:projects/openapi.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9526,6 +9560,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
       '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
       eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
       eslint-plugin-node: 11.1.0_eslint@7.21.0
       eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
       eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
@@ -9539,7 +9574,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-dZAxxLJefnLHADnmUpAx2bvJcPEoGNzvsRsn1Hc1+sMVRa9H1OlldqBbCRK3G1QauxXX2tGRx+WzmnLxREqwew==
+      integrity: sha512-pKuMQTYp1GXNWnsau6a/ZwtQhVRPtICH/ShWCEL60fq7XOw6F42O+byMajKFDvhdRkECy4fIGAM3tu//gjQ01Q==
       tarball: file:projects/openapi.tgz
     version: 0.0.0
   file:projects/schemas.tgz:
@@ -9654,6 +9689,7 @@ specifiers:
   diff: ^4.0.1
   eslint: ^7.17.0
   eslint-plugin-import: ~2.22.1
+  eslint-plugin-jest: ~24.3.2
   eslint-plugin-node: ~11.1.0
   eslint-plugin-prettier: ~3.2.0
   eslint-plugin-unicorn: ~27.0.0

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -71,6 +71,7 @@
     "compare-versions": "^3.4.0",
     "copy-webpack-plugin": "^7.0.0",
     "cpy-cli": "~2.0.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/extensions/core/src/lib/pipeline/plugins/tree-shaker/tree-shaker.test.ts
+++ b/packages/extensions/core/src/lib/pipeline/plugins/tree-shaker/tree-shaker.test.ts
@@ -59,7 +59,7 @@ describe("Tree shaker", () => {
       expect(param["x-ms-client-name"]).toEqual("SomeParamClient");
     });
 
-    it("it removes x-ms-client-name on shaked model when used on property with inline model definition", async () => {
+    it("removes x-ms-client-name on shaked model when used on property with inline model definition", async () => {
       const result = await shake({
         components: {
           schemas: {

--- a/packages/extensions/modelerfour/package.json
+++ b/packages/extensions/modelerfour/package.json
@@ -56,6 +56,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "chalk": "^4.1.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/codegen/package.json
+++ b/packages/libs/codegen/package.json
@@ -42,6 +42,7 @@
     "@types/semver": "5.5.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/codegen/src/apiversion/apiversion.test.ts
+++ b/packages/libs/codegen/src/apiversion/apiversion.test.ts
@@ -1,46 +1,45 @@
-import * as assert from "assert";
 import { toSemver } from "./apiversion";
 
 describe("ApiVersion", () => {
   it("to semver conversion", () => {
     const actual1 = toSemver("6.2.0.9");
     const expected1 = "6.2.0";
-    assert.strictEqual(actual1, expected1);
+    expect(actual1).toEqual(expected1);
 
     const actual2 = toSemver("2017-10-12");
     const expected2 = "2017.10.12";
-    assert.strictEqual(actual2, expected2);
+    expect(actual2).toEqual(expected2);
 
     const actual3 = toSemver("2017-10-12-preview");
     const expected3 = "2017.10.12-preview";
-    assert.strictEqual(actual3, expected3);
+    expect(actual3).toEqual(expected3);
 
     const actual4 = toSemver("v2.1");
     const expected4 = "2.1.0";
-    assert.strictEqual(actual4, expected4);
+    expect(actual4).toEqual(expected4);
 
     const actual5 = toSemver("1.1");
     const expected5 = "1.1.0";
-    assert.strictEqual(actual5, expected5);
+    expect(actual5).toEqual(expected5);
 
     const actual6 = toSemver("2016-07-01.3.1");
     const expected6 = "1467331200000.3.1";
-    assert.strictEqual(actual6, expected6);
+    expect(actual6).toEqual(expected6);
 
     const actual7 = toSemver("1.3.1");
     const expected7 = "1.3.1";
-    assert.strictEqual(actual7, expected7);
+    expect(actual7).toEqual(expected7);
 
     const actual8 = toSemver("2020-09");
     const expected8 = "2020.9.0";
-    assert.strictEqual(actual8, expected8);
+    expect(actual8).toEqual(expected8);
 
     const actual9 = toSemver("2020-09-preview");
     const expected9 = "2020.9.0-preview";
-    assert.strictEqual(actual9, expected9);
+    expect(actual9).toEqual(expected9);
 
-    assert.strictEqual(toSemver("v1"), "1.0.0");
+    expect(toSemver("v1")).toEqual("1.0.0");
 
-    assert.strictEqual(toSemver("3.0-preview.1"), "3.0.0-preview.1");
+    expect(toSemver("3.0-preview.1")).toEqual("3.0.0-preview.1");
   });
 });

--- a/packages/libs/codemodel/package.json
+++ b/packages/libs/codemodel/package.json
@@ -42,6 +42,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/common/package.json
+++ b/packages/libs/common/package.json
@@ -32,6 +32,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/configuration/package.json
+++ b/packages/libs/configuration/package.json
@@ -33,6 +33,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/configuration/src/configuration-loader/configuration-require-resolver.test.ts
+++ b/packages/libs/configuration/src/configuration-loader/configuration-require-resolver.test.ts
@@ -33,12 +33,12 @@ describe("getIncludedConfigurationFiles", () => {
       expect(result).toEqual(["file://./foo.md", "file://./bar.md"]);
     });
 
-    it("it still resolve file path if they don't exists", async () => {
+    it("still resolve file path if they don't exists", async () => {
       const result = await getRequiredFiles({ require: ["doesnot-exists.md"] });
       expect(result).toEqual(["file://./doesnot-exists.md"]);
     });
 
-    it("it resolve duplicate require only once", async () => {
+    it("resolve duplicate require only once", async () => {
       const result = await getRequiredFiles({ require: ["foo.md", "bar.md", "foo.md", "bar.md"] });
       expect(result).toEqual(["file://./foo.md", "file://./bar.md"]);
     });

--- a/packages/libs/configuration/src/configuration-manager/configuration-manager.test.ts
+++ b/packages/libs/configuration/src/configuration-manager/configuration-manager.test.ts
@@ -222,7 +222,7 @@ describe("ConfigurationManager", () => {
       expect(output["namespace"]).toEqual("FooBarOverride.Client");
     });
 
-    it("interpolate with higher priority value(defined before) instead of the one in the same block", async () => {
+    it("interpolate with higher priority value(defined in previous config) instead of the one in the same block", async () => {
       await manager.addConfig({
         name: "FooBarOverride",
       });
@@ -265,7 +265,7 @@ describe("ConfigurationManager", () => {
       expect(output["namespace"]).toEqual("FooBarOverride.Client");
     });
 
-    it("interpolate from the last block", async () => {
+    it("interpolate from the previous config", async () => {
       await manager.addConfig({
         name: "FooBarCLIOverride",
       });

--- a/packages/libs/datastore/package.json
+++ b/packages/libs/datastore/package.json
@@ -42,6 +42,7 @@
     "@types/source-map": "0.5.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/datastore/src/json-path/json-path.test.ts
+++ b/packages/libs/datastore/src/json-path/json-path.test.ts
@@ -7,61 +7,61 @@ const roundTrip = (s: string): string => {
 
 describe("JsonPath", () => {
   it("IsPrefix", () => {
-    assert.strictEqual(jp.IsPrefix(jp.parse("$.a.b.c"), jp.parse("$.a.b.c.d")), true);
-    assert.strictEqual(jp.IsPrefix(jp.parse("$.a.b.c"), jp.parse("$.a.b.c")), true);
-    assert.strictEqual(jp.IsPrefix(jp.parse("$.a.b.c"), jp.parse("$.a.b")), false);
+    expect(jp.IsPrefix(jp.parse("$.a.b.c"), jp.parse("$.a.b.c.d"))).toEqual(true);
+    expect(jp.IsPrefix(jp.parse("$.a.b.c"), jp.parse("$.a.b.c"))).toEqual(true);
+    expect(jp.IsPrefix(jp.parse("$.a.b.c"), jp.parse("$.a.b"))).toEqual(false);
   });
 
   it("matches", async () => {
-    assert.strictEqual(jp.matches("$..*", jp.parse("$.a.b.c")), true);
-    assert.strictEqual(jp.matches("$..c", jp.parse("$.a.b.c")), true);
-    assert.strictEqual(jp.matches("$..b", jp.parse("$.a.b.c")), false);
-    assert.strictEqual(jp.matches("$.a.b.c", jp.parse("$.a.b.c")), true);
-    assert.strictEqual(jp.matches("$.a.b", jp.parse("$.a.b.c")), false);
-    assert.strictEqual(jp.matches("$.a..*", jp.parse("$.a.b.c")), true);
-    assert.strictEqual(jp.matches("$.a.b.c.d", jp.parse("$.a.b.c")), false);
+    expect(jp.matches("$..*", jp.parse("$.a.b.c"))).toEqual(true);
+    expect(jp.matches("$..c", jp.parse("$.a.b.c"))).toEqual(true);
+    expect(jp.matches("$..b", jp.parse("$.a.b.c"))).toEqual(false);
+    expect(jp.matches("$.a.b.c", jp.parse("$.a.b.c"))).toEqual(true);
+    expect(jp.matches("$.a.b", jp.parse("$.a.b.c"))).toEqual(false);
+    expect(jp.matches("$.a..*", jp.parse("$.a.b.c"))).toEqual(true);
+    expect(jp.matches("$.a.b.c.d", jp.parse("$.a.b.c"))).toEqual(false);
   });
 
   it("querying", () => {
-    assert.strictEqual(jp.nodes({ a: 1, b: 2, c: 3 }, "$..*").length, 3);
-    assert.strictEqual(jp.nodes({ a: 1, b: 2, c: 3 }, "$..a").length, 1);
-    assert.strictEqual(jp.nodes({ a: 1, b: 2, c: 3 }, "$.a").length, 1);
-    assert.strictEqual(jp.nodes({ a: 1, b: 2, c: 3 }, "$.d").length, 0);
+    expect(jp.nodes({ a: 1, b: 2, c: 3 }, "$..*").length).toEqual(3);
+    expect(jp.nodes({ a: 1, b: 2, c: 3 }, "$..a").length).toEqual(1);
+    expect(jp.nodes({ a: 1, b: 2, c: 3 }, "$.a").length).toEqual(1);
+    expect(jp.nodes({ a: 1, b: 2, c: 3 }, "$.d").length).toEqual(0);
 
-    assert.strictEqual(jp.paths({ a: 1, b: 2, c: 3 }, "$..*").length, 3);
-    assert.strictEqual(jp.paths({ a: 1, b: 2, c: 3 }, "$..a").length, 1);
-    assert.strictEqual(jp.paths({ a: 1, b: 2, c: 3 }, "$.a").length, 1);
-    assert.strictEqual(jp.paths({ a: 1, b: 2, c: 3 }, "$.d").length, 0);
+    expect(jp.paths({ a: 1, b: 2, c: 3 }, "$..*").length).toEqual(3);
+    expect(jp.paths({ a: 1, b: 2, c: 3 }, "$..a").length).toEqual(1);
+    expect(jp.paths({ a: 1, b: 2, c: 3 }, "$.a").length).toEqual(1);
+    expect(jp.paths({ a: 1, b: 2, c: 3 }, "$.d").length).toEqual(0);
 
-    assert.strictEqual(jp.paths({ x: { $ref: "x" }, y: { $re: "x" } }, "$[?(@.$ref)]").length, 1);
-    assert.strictEqual(jp.paths({ a: { x: { $ref: "x" } }, b: { x: { $re: "x" } } }, "$..*[?(@.$ref)]").length, 1);
+    expect(jp.paths({ x: { $ref: "x" }, y: { $re: "x" } }, "$[?(@.$ref)]").length).toEqual(1);
+    expect(jp.paths({ a: { x: { $ref: "x" } }, b: { x: { $re: "x" } } }, "$..*[?(@.$ref)]").length).toEqual(1);
   });
 
   it("querying features", () => {
     const obj = { a: 1, b: 2, c: 3, d: { a: [1, 2, 3], b: 2, c: 3 } };
-    assert.strictEqual(jp.nodes(obj, "$.*").length, 4);
-    assert.strictEqual(jp.nodes(obj, "$.*.*").length, 3);
-    assert.strictEqual(jp.nodes(obj, "$..*.*").length, 6);
-    assert.strictEqual(jp.nodes(obj, "$..*").length, 10);
-    assert.strictEqual(jp.nodes(obj, "$..[*]").length, 10);
-    assert.strictEqual(jp.nodes(obj, "$..['d']").length, 1);
-    assert.strictEqual(jp.nodes(obj, "$..d").length, 1);
-    assert.strictEqual(jp.nodes(obj, "$..[2]").length, 1);
-    assert.strictEqual(jp.nodes(obj, "$..[?(@.a[2] === 3)]").length, 1);
-    assert.strictEqual(jp.nodes(obj, "$..[?(@.a.reduce((x,y) => x+y, 0) === 6)]").length, 1);
-    //assert.strictEqual(jp.nodes(obj, "$..[(@.length - 1)]").length, 1);
-    //assert.strictEqual(jp.nodes(obj, "$..[(1 + 1)]").length, 1);
+    expect(jp.nodes(obj, "$.*").length).toEqual(4);
+    expect(jp.nodes(obj, "$.*.*").length).toEqual(3);
+    expect(jp.nodes(obj, "$..*.*").length).toEqual(6);
+    expect(jp.nodes(obj, "$..*").length).toEqual(10);
+    expect(jp.nodes(obj, "$..[*]").length).toEqual(10);
+    expect(jp.nodes(obj, "$..['d']").length).toEqual(1);
+    expect(jp.nodes(obj, "$..d").length).toEqual(1);
+    expect(jp.nodes(obj, "$..[2]").length).toEqual(1);
+    expect(jp.nodes(obj, "$..[?(@.a[2] === 3)]").length).toEqual(1);
+    expect(jp.nodes(obj, "$..[?(@.a.reduce((x,y) => x+y, 0) === 6)]").length).toEqual(1);
+    //expect(jp.nodes(obj, "$..[(@.length - 1)]").length).toEqual( 1);
+    //expect(jp.nodes(obj, "$..[(1 + 1)]").length).toEqual( 1);
   });
 
   it("round trip identity", () => {
-    const roundTrips = (s: string) => assert.equal(roundTrip(s), s);
+    const roundTrips = (s: string) => expect(roundTrip(s)).toEqual(s);
     roundTrips("$.asd.qwe[1].zxc");
     roundTrips('$[1][42]["asd qwe"]');
     roundTrips('$[1]["1"]');
   });
 
   it("round trip simplification", () => {
-    assert.equal(roundTrip('$["definitely"]["add"]["more"]["cowbell"]'), "$.definitely.add.more.cowbell");
-    assert.equal(roundTrip('$[1]["even"]["more cowbell"]'), '$[1].even["more cowbell"]');
+    expect(roundTrip('$["definitely"]["add"]["more"]["cowbell"]')).toEqual("$.definitely.add.more.cowbell");
+    expect(roundTrip('$[1]["even"]["more cowbell"]')).toEqual('$[1].even["more cowbell"]');
   });
 });

--- a/packages/libs/datastore/src/json-pointer/json-pointer.test.ts
+++ b/packages/libs/datastore/src/json-pointer/json-pointer.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-conditional-expect */
 import { keys } from "@azure-tools/linq";
 import * as pointer from "./json-pointer";
 
@@ -189,7 +190,6 @@ describe("JsonPointer", () => {
         },
       },
     };
-
     for (const each of pointer.visit(obj)) {
       switch (each.key) {
         case "foo":

--- a/packages/libs/deduplication/package.json
+++ b/packages/libs/deduplication/package.json
@@ -40,6 +40,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/extension-base/package.json
+++ b/packages/libs/extension-base/package.json
@@ -31,6 +31,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/extension/package.json
+++ b/packages/libs/extension/package.json
@@ -62,6 +62,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "cpy-cli": "~2.0.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/extension/src/system-requirements/python.test.ts
+++ b/packages/libs/extension/src/system-requirements/python.test.ts
@@ -94,7 +94,7 @@ describe("Python system requirement", () => {
       expect(result).toEqual(["python3", "-c", "print();"]);
     });
 
-    it("stub with the first compatible python version", async () => {
+    it("stub with the first compatible python version(python3 is 3.7)", async () => {
       mockInstalledPython({
         python3: "3.7.0",
         python: "3.9.0",
@@ -104,7 +104,7 @@ describe("Python system requirement", () => {
       expect(result).toEqual(["python3", "-c", "print();"]);
     });
 
-    it("stub with the first compatible python version", async () => {
+    it("stub with the first compatible python version(python3 is 2.0)", async () => {
       mockInstalledPython({
         python3: "2.0.0",
         python: "3.9.0",
@@ -116,7 +116,7 @@ describe("Python system requirement", () => {
   });
 
   describe("updatePythonPath (Deprecated)", () => {
-    it("stub with the only compatible python version", async () => {
+    it("stub with the only compatible python version(python3 is 3.7)", async () => {
       mockInstalledPython({
         python3: "3.7.0",
         python: "2.7.0",
@@ -127,7 +127,7 @@ describe("Python system requirement", () => {
       expect(result).toEqual(["python3", "-c", "print();"]);
     });
 
-    it("stub with the first compatible python version", async () => {
+    it("stub with the first compatible python version(python3 is 3.7, python is 3.9)", async () => {
       mockInstalledPython({
         python3: "3.7.0",
         python: "3.9.0",
@@ -138,7 +138,7 @@ describe("Python system requirement", () => {
       expect(result).toEqual(["python3", "-c", "print();"]);
     });
 
-    it("stub with the first compatible python version", async () => {
+    it("stub with the first compatible python version(python3 is 2.0)", async () => {
       mockInstalledPython({
         python3: "2.0.0",
         python: "3.9.0",

--- a/packages/libs/jsonschema/package.json
+++ b/packages/libs/jsonschema/package.json
@@ -32,6 +32,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/oai2-to-oai3/package.json
+++ b/packages/libs/oai2-to-oai3/package.json
@@ -43,6 +43,7 @@
     "@types/source-map": "0.5.0",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/libs/oai2-to-oai3/test/conversion.test.ts
+++ b/packages/libs/oai2-to-oai3/test/conversion.test.ts
@@ -4,7 +4,7 @@ import { OpenAPI2Document } from "../src/oai2";
 import { join } from "path";
 import fs from "fs";
 
-const testConvertingOpenAPI2 = async (openAPI2Name: string, openAPI3Name: string) => {
+const expectConvertingOpenAPI2 = async (openAPI2Name: string, openAPI3Name: string) => {
   const swaggerUri = "mem://swagger.yaml";
   const oai3Uri = "mem://oai3.yaml";
 
@@ -43,70 +43,70 @@ const testConvertingOpenAPI2 = async (openAPI2Name: string, openAPI3Name: string
 
 describe("OpenAPI2 -> OpenAPI3 Conversion", () => {
   it("test conversion - simple", async () => {
-    await testConvertingOpenAPI2("swagger.yaml", "openapi.yaml");
+    await expectConvertingOpenAPI2("swagger.yaml", "openapi.yaml");
   });
 
   it("test conversion - tiny", async () => {
-    await testConvertingOpenAPI2("tiny-swagger.yaml", "tiny-openapi.yaml");
+    await expectConvertingOpenAPI2("tiny-swagger.yaml", "tiny-openapi.yaml");
   });
 
   it("test conversion - ApiManagementClient", async () => {
-    await testConvertingOpenAPI2("ApiManagementClient-swagger.json", "ApiManagementClient-openapi.json");
+    await expectConvertingOpenAPI2("ApiManagementClient-swagger.json", "ApiManagementClient-openapi.json");
   });
 
   it("request body - copying extensions", async () => {
-    await testConvertingOpenAPI2("request-body-swagger.yaml", "request-body-openapi.yaml");
+    await expectConvertingOpenAPI2("request-body-swagger.yaml", "request-body-openapi.yaml");
   });
 
   it("headers", async () => {
-    await testConvertingOpenAPI2("header.json", "header.json");
+    await expectConvertingOpenAPI2("header.json", "header.json");
   });
 
   it("additionalProperties", async () => {
-    await testConvertingOpenAPI2("additionalProperties.json", "additionalProperties.json");
+    await expectConvertingOpenAPI2("additionalProperties.json", "additionalProperties.json");
   });
 
   it("xml-service", async () => {
-    await testConvertingOpenAPI2("xml-service.json", "xml-service.json");
+    await expectConvertingOpenAPI2("xml-service.json", "xml-service.json");
   });
 
   it("xms-error-responses", async () => {
-    await testConvertingOpenAPI2("xms-error-responses.json", "xms-error-responses.json");
+    await expectConvertingOpenAPI2("xms-error-responses.json", "xms-error-responses.json");
   });
 
   it("validation", async () => {
-    await testConvertingOpenAPI2("validation.json", "validation.json");
+    await expectConvertingOpenAPI2("validation.json", "validation.json");
   });
 
   it("storage", async () => {
-    await testConvertingOpenAPI2("storage.json", "storage.json");
+    await expectConvertingOpenAPI2("storage.json", "storage.json");
   });
 
   it("url", async () => {
-    await testConvertingOpenAPI2("url.json", "url.json");
+    await expectConvertingOpenAPI2("url.json", "url.json");
   });
 
   it("url-multi-collectionFormat", async () => {
-    await testConvertingOpenAPI2("url-multi-collectionFormat.json", "url-multi-collectionFormat.json");
+    await expectConvertingOpenAPI2("url-multi-collectionFormat.json", "url-multi-collectionFormat.json");
   });
 
   it("complex-model", async () => {
-    await testConvertingOpenAPI2("complex-model.json", "complex-model.json");
+    await expectConvertingOpenAPI2("complex-model.json", "complex-model.json");
   });
 
   it("extensible-enums-swagger", async () => {
-    await testConvertingOpenAPI2("extensible-enums-swagger.json", "extensible-enums-swagger.json");
+    await expectConvertingOpenAPI2("extensible-enums-swagger.json", "extensible-enums-swagger.json");
   });
 
   it("lro", async () => {
-    await testConvertingOpenAPI2("lro.json", "lro.json");
+    await expectConvertingOpenAPI2("lro.json", "lro.json");
   });
 
   it("exec-service", async () => {
-    await testConvertingOpenAPI2("exec-service.json", "exec-service.json");
+    await expectConvertingOpenAPI2("exec-service.json", "exec-service.json");
   });
 
   it("LUIS runtime", async () => {
-    await testConvertingOpenAPI2("luis.json", "luis.json");
+    await expectConvertingOpenAPI2("luis.json", "luis.json");
   });
 });

--- a/packages/libs/oai2-to-oai3/test/scenarios/scenarios.test.ts
+++ b/packages/libs/oai2-to-oai3/test/scenarios/scenarios.test.ts
@@ -55,7 +55,7 @@ describe("Scenario testings", () => {
     await expectInputsMatchSnapshots("parameterized-host-parameters", ["swagger.json"]);
   });
 
-  fit("Convert enums using $ref object as values", async () => {
+  it("Convert enums using $ref object as values", async () => {
     // The expected result is the $ref in `enum` has been updated to the openapi 3 format.
     await expectInputsMatchSnapshots("enums", ["swagger.json"]);
   });

--- a/packages/libs/openapi/package.json
+++ b/packages/libs/openapi/package.json
@@ -40,6 +40,7 @@
     "@types/node": "~14.14.20",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/tools/compare/package.json
+++ b/packages/tools/compare/package.json
@@ -49,6 +49,7 @@
     "@types/source-map-support": "^0.5.3",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-prettier": "~3.2.0",
     "eslint-plugin-unicorn": "~27.0.0",

--- a/packages/tools/md-mock-api/package.json
+++ b/packages/tools/md-mock-api/package.json
@@ -36,6 +36,7 @@
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "eslint": "^7.17.0",
+    "eslint-plugin-jest": "~24.3.2",
     "eslint-plugin-node": "~11.1.0",
     "eslint-plugin-import": "~2.22.1",
     "eslint-plugin-prettier": "~3.2.0",


### PR DESCRIPTION
This is mainly to prevent leaving `fit` or `it.only` in the code but also provide some other linting rules to have better tests.