### PR TITLE
Cleanup use of node require

### DIFF
--- a/common/changes/@autorest/core/cleanup-require_2021-03-23-22-07.json
+++ b/common/changes/@autorest/core/cleanup-require_2021-03-23-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Cleanup** Migrated use of require -> es6 imports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/modelerfour/cleanup-require_2021-03-23-22-07.json
+++ b/common/changes/@autorest/modelerfour/cleanup-require_2021-03-23-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "**Cleanup** Migrated use of require -> es6 imports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/autorest/cleanup-require_2021-03-23-22-07.json
+++ b/common/changes/autorest/cleanup-require_2021-03-23-22-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "**Cleanup** Migrated use of require -> es6 imports",
+      "type": "patch"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/apps/autorest/src/actions/check-autorest-update.ts
+++ b/packages/apps/autorest/src/actions/check-autorest-update.ts
@@ -1,8 +1,9 @@
 import { Package } from "@azure-tools/extension";
 import { gt } from "semver";
 import { AutorestArgs } from "../args";
-import { extensionManager, networkEnabled, pkgVersion } from "../autorest-as-a-service";
+import { extensionManager, networkEnabled } from "../autorest-as-a-service";
 import { color } from "../coloring";
+import { VERSION } from "../constants";
 
 /**
  * Check if there is any updates to the autorest package and display message to use if there is.
@@ -29,5 +30,5 @@ export const checkForAutoRestUpdate = async (args: AutorestArgs) => {
 
 const isAutorestUpdateAvailable = async (npmTag: string): Promise<Package | undefined> => {
   const pkg = await (await extensionManager).findPackage("autorest", npmTag);
-  return gt(pkg.version, pkgVersion) ? pkg : undefined;
+  return gt(pkg.version, VERSION) ? pkg : undefined;
 };

--- a/packages/apps/autorest/src/app.ts
+++ b/packages/apps/autorest/src/app.ts
@@ -10,12 +10,13 @@ declare const isDebuggerEnabled: boolean;
 const cwd = process.cwd();
 
 import chalk from "chalk";
-import { newCorePackage, ensureAutorestHome, pkgVersion, tryRequire, runCoreOutOfProc } from "./autorest-as-a-service";
+import { newCorePackage, ensureAutorestHome, tryRequire, runCoreOutOfProc } from "./autorest-as-a-service";
 import { color } from "./coloring";
 import { parseArgs } from "./args";
 import { resetAutorest, showAvailableCoreVersions, showInstalledExtensions } from "./commands";
 import { clearTempData } from "./actions";
 import { resolveCoreVersion } from "./core-version-utils";
+import { VERSION } from "./constants";
 
 const launchCore = isDebuggerEnabled ? tryRequire : runCoreOutOfProc;
 
@@ -47,7 +48,7 @@ if (args["v3"] && !args["version"]) {
 if (!args["message-format"] || args["message-format"] === "regular") {
   console.log(
     chalk.green.bold.underline(
-      `AutoRest code generation utility [cli version: ${chalk.white.bold(pkgVersion)}; node: ${chalk.white.bold(
+      `AutoRest code generation utility [cli version: ${chalk.white.bold(VERSION)}; node: ${chalk.white.bold(
         process.version,
       )}, max-memory: ${
         Math.round(require("v8").getHeapStatistics().heap_size_limit / (1024 * 1024)) & 0xffffffff00

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -14,11 +14,11 @@ import { mkdtempSync, rmdirSync } from "fs";
 import { tmpdir } from "os";
 import { spawn } from "child_process";
 import { AutorestArgs } from "./args";
+import { VERSION } from "./constants";
 
 const inWebpack = typeof __webpack_require__ === "function";
 const nodeRequire = inWebpack ? __non_webpack_require__ : require;
 
-export const pkgVersion: string = require(`../package.json`).version;
 process.env["autorest.home"] = process.env["AUTOREST_HOME"] || process.env["autorest.home"] || homedir();
 
 try {
@@ -37,9 +37,7 @@ export const extensionManager: Promise<ExtensionManager> = ExtensionManager.Crea
 export const oldCorePackage = "@microsoft.azure/autorest-core";
 export const newCorePackage = "@autorest/core";
 
-const basePkgVersion = semver.parse(
-  pkgVersion.indexOf("-") > -1 ? pkgVersion.substring(0, pkgVersion.indexOf("-")) : pkgVersion,
-);
+const basePkgVersion = semver.parse(VERSION.indexOf("-") > -1 ? VERSION.substring(0, VERSION.indexOf("-")) : VERSION);
 
 /**
  * The version range of the core package required.

--- a/packages/apps/autorest/src/constants.ts
+++ b/packages/apps/autorest/src/constants.ts
@@ -17,3 +17,8 @@ const resolveAppRoot = () => {
  * Root of autorest core(i.e core folder)
  */
 export const AppRoot = resolveAppRoot();
+
+/**
+ * Version of this package(autorest).
+ */
+export const VERSION = require("../package.json").version;

--- a/packages/extensions/core/src/app.ts
+++ b/packages/extensions/core/src/app.ts
@@ -6,8 +6,9 @@
 import "source-map-support/register";
 import { omit } from "lodash";
 import { configureLibrariesLogger } from "@autorest/common";
+import { EventEmitter } from "events";
 
-require("events").EventEmitter.defaultMaxListeners = 100;
+EventEmitter.defaultMaxListeners = 100;
 process.env["ELECTRON_RUN_AS_NODE"] = "1";
 delete process.env["ELECTRON_NO_ATTACH_CONSOLE"];
 

--- a/packages/extensions/core/src/lib/configuration/autorest-context-loader.ts
+++ b/packages/extensions/core/src/lib/configuration/autorest-context-loader.ts
@@ -19,16 +19,17 @@ import { AutorestContext } from "./autorest-context";
 import { MessageEmitter } from "./message-emitter";
 import { AutorestLogger } from "@autorest/common";
 import { AutorestCoreLogger } from "./logger";
-import { CreateFileOrFolderUri, CreateFolderUri, ResolveUri } from "@azure-tools/uri";
+import { createFileOrFolderUri, createFolderUri, resolveUri } from "@azure-tools/uri";
 import { AppRoot } from "../constants";
+import { homedir } from "os";
 
 const inWebpack = typeof __webpack_require__ === "function";
 // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
 const nodeRequire = inWebpack ? __non_webpack_require__! : require;
 const pathToYarnCli = inWebpack ? `${__dirname}/yarn/cli.js` : undefined;
 const defaultConfigUri = inWebpack
-  ? ResolveUri(CreateFolderUri(AppRoot), `dist/resources/default-configuration.md`)
-  : CreateFileOrFolderUri(nodeRequire.resolve("@autorest/configuration/resources/default-configuration.md"));
+  ? resolveUri(createFolderUri(AppRoot), `dist/resources/default-configuration.md`)
+  : createFileOrFolderUri(nodeRequire.resolve("@autorest/configuration/resources/default-configuration.md"));
 
 const loadedExtensions: {
   [fullyQualified: string]: { extension: Extension; autorestExtension: LazyPromise<AutoRestExtension> };
@@ -54,7 +55,7 @@ export class AutorestContextLoader {
 
   private static extensionManager: LazyPromise<ExtensionManager> = new LazyPromise<ExtensionManager>(() =>
     ExtensionManager.Create(
-      join(process.env["AUTOREST_HOME"] || process.env["autorest.home"] || require("os").homedir(), ".autorest"),
+      join(process.env["AUTOREST_HOME"] || process.env["autorest.home"] || homedir(), ".autorest"),
       "yarn",
       pathToYarnCli,
     ),
@@ -71,7 +72,7 @@ export class AutorestContextLoader {
       // but if someone goes to use that, we're going to need a new instance (since the shared lock will be gone in the one we disposed.)
       AutorestContextLoader.extensionManager = new LazyPromise<ExtensionManager>(() =>
         ExtensionManager.Create(
-          join(process.env["AUTOREST_HOME"] || process.env["autorest.home"] || require("os").homedir(), ".autorest"),
+          join(process.env["AUTOREST_HOME"] || process.env["autorest.home"] || homedir(), ".autorest"),
         ),
       );
 

--- a/packages/extensions/modelerfour/src/main.ts
+++ b/packages/extensions/modelerfour/src/main.ts
@@ -1,5 +1,4 @@
-require("source-map-support").install();
-
+import "source-map-support/register";
 import { AutoRestExtension } from "@autorest/extension-base";
 import { processRequest as modelerfour } from "./modeler/plugin-modelerfour";
 import { processRequest as preNamer } from "./prenamer/plugin-prenamer";

--- a/packages/tools/md-mock-api/src/cli/cli.ts
+++ b/packages/tools/md-mock-api/src/cli/cli.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
-require("source-map-support").install();
+import "source-map-support/register";
 
 import { hideBin } from "yargs/helpers";
 import { ApiMockApp, ApiMockAppConfig } from "../app";


### PR DESCRIPTION
With move to webpack misusing require could cause issue. Updated all reequire that could be es6 imports and checked no require should be switched to a `nodeRequire` that webpack doesn't inject

fix #3853 