### PR TITLE
Fix: Load default config in autorest cli to resolve core version

### DIFF
--- a/common/changes/autorest/fix-default-config-version_2021-03-24-17-38.json
+++ b/common/changes/autorest/fix-default-config-version_2021-03-24-17-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "**Fix** Load default configuration when resolving core version",
+      "type": "patch"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/apps/autorest/src/core-version-utils.ts
+++ b/packages/apps/autorest/src/core-version-utils.ts
@@ -47,7 +47,7 @@ export const findCoreVersionUsingConfiguration = async (args: AutorestArgs): Pro
   const loader = new ConfigurationLoader(logger, defaultConfigUri, configFileOrFolder, {
     extensionManager: await extensionManager,
   });
-  const { config } = await loader.load([args], false);
+  const { config } = await loader.load([args], true);
   if (config.version) {
     // eslint-disable-next-line no-console
     console.log(


### PR DESCRIPTION
Flag was set to false which prevented default config from being loaded and then the autorest core version from being selected
fix #4010