### PR TITLE
Feature: Add support for deprecation

### DIFF
--- a/common/changes/@autorest/codemodel/feature-deprecated_2021-04-02-17-49.json
+++ b/common/changes/@autorest/codemodel/feature-deprecated_2021-04-02-17-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/codemodel",
+      "comment": "**Updated** deprecation model",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/codemodel",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/modelerfour/feature-deprecated_2021-04-02-17-49.json
+++ b/common/changes/@autorest/modelerfour/feature-deprecated_2021-04-02-17-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "**Added** Support for openapi deprecation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/openapi/feature-deprecated_2021-04-02-17-49.json
+++ b/common/changes/@azure-tools/openapi/feature-deprecated_2021-04-02-17-49.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/openapi",
+      "comment": "**Update** deprecatable models",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/openapi",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/modelerfour/src/modeler/interpretations.ts
+++ b/packages/extensions/modelerfour/src/modeler/interpretations.ts
@@ -260,11 +260,14 @@ export class Interpretations {
     }
     return [];
   }
-  getDeprecation(schema: OpenAPI.Schema): Deprecation | undefined {
-    if (schema.deprecated) {
-      // todo
+
+  public getDeprecation(schema: OpenAPI.Deprecatable): Deprecation | undefined {
+    if (!schema.deprecated) {
+      return undefined;
     }
-    return undefined;
+
+    // We don't have any additional information at this time. Just returning an empty object saying this is deprecated.
+    return {};
   }
 
   constructor(private session: Session<OpenAPI.Model>) {}
@@ -357,11 +360,11 @@ export class Interpretations {
 
   /*
     /** creates server entries that are kept in the codeModel.protocol.http, and then referenced in each operation
-     * 
+     *
      * @note - this is where deduplication of server entries happens.
       * /
     getServers(operation: OpenAPI.HttpOperation): Array<HttpServer> {
-  
+
       return values(operation.servers).select(server => {
         const p = <HttpModel>this.codeModel.protocol.http;
         const f = p && p.servers.find(each => each.url === server.url);
@@ -372,13 +375,13 @@ export class Interpretations {
         if (server.variables && length(server.variables) > 0) {
           s.variables = items(server.variables).where(each => !!each.key).select(each => {
             const description = this.getDescription('MISSING-SERVER_VARIABLE-DESCRIPTION', each.value);
-  
+
             const variable = each.value;
-  
+
             const schema = variable.enum ?
               this.getEnumSchemaForVarible(each.key, variable) :
               this.codeModel.schemas.add(new StringSchema(`ServerVariable/${each.key}`, description));
-  
+
             const serverVariable = new ServerVariable(
               each.key,
               this.getDescription('MISSING-SERVER_VARIABLE-DESCRIPTION', variable),
@@ -390,10 +393,10 @@ export class Interpretations {
             return serverVariable;
           }).toArray();
         }
-  
+
         (<HttpModel>this.codeModel.protocol.http).servers.push(s);
         return s;
-  
+
       }).toArray();
     }
   */

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -2177,7 +2177,6 @@ export class ModelerFour {
         headers.push(
           new HttpHeader(headerName, hsch, {
             extensions: this.interpret.getExtensionProperties(header),
-            deprecated: this.interpret.getDeprecation(header),
             language: {
               default: {
                 name: header["x-ms-client-name"] || headerName,

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -1608,6 +1608,7 @@ export class ModelerFour {
       new Operation(memberName, this.interpret.getDescription("", httpOperation), {
         extensions: this.interpret.getExtensionProperties(httpOperation),
         apiVersions: this.interpret.getApiVersions(pathItem),
+        deprecated: this.interpret.getDeprecation(httpOperation),
         language: {
           default: {
             summary: httpOperation.summary,
@@ -1977,6 +1978,7 @@ export class ModelerFour {
               required: parameter.required ? true : undefined,
               implementation,
               extensions: this.interpret.getExtensionProperties(parameter),
+              deprecated: this.interpret.getDeprecation(parameter),
               nullable: parameter.nullable || schema.nullable,
               protocol: {
                 http: new HttpParameter(
@@ -2175,6 +2177,7 @@ export class ModelerFour {
         headers.push(
           new HttpHeader(headerName, hsch, {
             extensions: this.interpret.getExtensionProperties(header),
+            deprecated: this.interpret.getDeprecation(header),
             language: {
               default: {
                 name: header["x-ms-client-name"] || headerName,

--- a/packages/extensions/modelerfour/test/modeler/modelerfour.requests.test.ts
+++ b/packages/extensions/modelerfour/test/modeler/modelerfour.requests.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable jest/no-standalone-expect */
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { CodeModel, DictionarySchema, HttpHeader, Operation, Parameter, SealedChoiceSchema } from "@autorest/codemodel";
@@ -7,23 +8,32 @@ import { runModeler } from "./modelerfour-utils";
 import * as oai3 from "@azure-tools/openapi";
 import assert from "assert";
 
+async function runModelerWithOperation(
+  method: string,
+  path: string,
+  operation: oai3.HttpOperation,
+): Promise<Operation> {
+  const spec = createTestSpec();
+
+  addOperation(spec, path, {
+    [method]: operation,
+  });
+
+  const codeModel = await runModeler(spec);
+  const m4Operation = codeModel.operationGroups[0]?.operations[0];
+  assert(m4Operation);
+  return m4Operation;
+}
+
 describe("Modelerfour.Request", () => {
   describe("Body", () => {
     const runModelerWithBody = async (body: RequestBody): Promise<Operation> => {
-      const spec = createTestSpec();
-
-      addOperation(spec, "/test", {
-        post: {
-          requestBody: {
-            ...body,
-          },
+      return runModelerWithOperation("post", "/test", {
+        requestBody: {
+          ...body,
         },
+        responses: {},
       });
-
-      const codeModel = await runModeler(spec);
-      const operation = codeModel.operationGroups[0]?.operations[0];
-      assert(operation);
-      return operation;
     };
 
     describe("Required attribute", () => {
@@ -62,7 +72,7 @@ describe("Modelerfour.Request", () => {
       });
     });
 
-    fdescribe("multiple binary content-types", () => {
+    describe("multiple binary content-types", () => {
       let operation: Operation;
 
       beforeEach(async () => {
@@ -299,6 +309,59 @@ describe("Modelerfour.Request", () => {
         // It should be the exact same object
         expect(parameter.schema).toBe(parameter2.schema);
       });
+    });
+  });
+
+  describe("deprecation", () => {
+    it("doesn't set deprecated property by default", async () => {
+      const operation = await runModelerWithOperation("get", "/depreacted", {
+        responses: {},
+      });
+
+      expect(operation.deprecated).toEqual(undefined);
+    });
+
+    it("mark request as deprecated if deprecated: true", async () => {
+      const operation = await runModelerWithOperation("get", "/depreacted", {
+        deprecated: true,
+        responses: {},
+      });
+
+      expect(operation.deprecated).toEqual({});
+    });
+
+    it("mark query parameter as deprecated", async () => {
+      const operation = await runModelerWithOperation("get", "/depreacted", {
+        responses: {},
+        parameters: [
+          {
+            name: "deprecatedQueryParam",
+            in: ParameterLocation.Query,
+            schema: { type: JsonType.String },
+            deprecated: true,
+          },
+        ],
+      });
+
+      const parameter = findByName("deprecatedQueryParam", operation.parameters);
+      expect(parameter?.deprecated).toEqual({});
+    });
+
+    it("mark header parameter as deprecated", async () => {
+      const operation = await runModelerWithOperation("get", "/depreacted", {
+        responses: {},
+        parameters: [
+          {
+            name: "deprecatedHeaderParam",
+            in: ParameterLocation.Header,
+            schema: { type: JsonType.String },
+            deprecated: true,
+          },
+        ],
+      });
+
+      const parameter = findByName("deprecatedHeaderParam", operation.parameters);
+      expect(parameter?.deprecated).toEqual({});
     });
   });
 });

--- a/packages/extensions/modelerfour/test/modeler/modelerfour.schemas.test.ts
+++ b/packages/extensions/modelerfour/test/modeler/modelerfour.schemas.test.ts
@@ -1,3 +1,4 @@
+import { JsonType } from "@azure-tools/openapi";
 import { addSchema, createTestSpec, findByName } from "../utils";
 import { runModeler } from "./modelerfour-utils";
 
@@ -144,6 +145,35 @@ describe("Modelerfour.Schemas", () => {
         const foo = findByName("Foo", codeModel.schemas.choices);
         expect(foo).toBeDefined();
         expect(foo?.choices.map((x) => x.value)).toEqual(["one", "two"]);
+      });
+    });
+
+    describe("Deprecation", () => {
+      it("doesn't set deprecated info by default", async () => {
+        const spec = createTestSpec();
+
+        addSchema(spec, "RegularModel", {
+          type: "object",
+          properties: { name: { type: JsonType.String } },
+        });
+
+        const codeModel = await runModeler(spec);
+        const model = findByName("RegularModel", codeModel.schemas.objects);
+        expect(model?.deprecated).toEqual(undefined);
+      });
+
+      it("mark model as deprecated if deprecated:true", async () => {
+        const spec = createTestSpec();
+
+        addSchema(spec, "DeprecatedModel", {
+          type: "object",
+          deprecated: true,
+          properties: { name: { type: JsonType.String } },
+        });
+
+        const codeModel = await runModeler(spec);
+        const model = findByName("DeprecatedModel", codeModel.schemas.objects);
+        expect(model?.deprecated).toEqual({});
       });
     });
   });

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -31,27 +31,16 @@
       }
     },
     "Deprecation": {
-      "description": "represents  deprecation information for a given aspect",
+      "description": "Represent information about a deprecation",
       "type": "object",
       "properties": {
-        "message": {
-          "description": "the reason why this aspect",
+        "reason": {
+          "description": "Reason why this was deprecated.",
           "type": "string"
-        },
-        "apiVersions": {
-          "description": "the api versions that this deprecation is applicable to.",
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/ApiVersion"
-          }
         }
       },
       "defaultProperties": [],
-      "additionalProperties": false,
-      "required": [
-        "apiVersions",
-        "message"
-      ]
+      "additionalProperties": false
     },
     "Extensions": {
       "description": "A dictionary of open-ended 'x-*' extensions propogated from the original source document.",
@@ -103,7 +92,8 @@
         },
         "deprecated": {
           "$ref": "#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",
@@ -949,7 +939,8 @@
         },
         "deprecated": {
           "$ref": "#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",
@@ -2096,7 +2087,8 @@
         },
         "deprecated": {
           "$ref": "#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",
@@ -3060,7 +3052,8 @@
         },
         "deprecated": {
           "$ref": "#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",

--- a/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -395,7 +395,8 @@ definitions:
       defaultValue:
         description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: '#/definitions/Deprecation'
       example:
         description: example information
@@ -509,20 +510,12 @@ definitions:
       - default
   Deprecation:
     type: object
-    description: represents  deprecation information for a given aspect
+    description: Represent information about a deprecation
     additionalProperties: false
     properties:
-      apiVersions:
-        type: array
-        description: the api versions that this deprecation is applicable to.
-        items:
-          $ref: '#/definitions/ApiVersion'
-      message:
+      reason:
         type: string
-        description: the reason why this aspect
-    required:
-      - apiVersions
-      - message
+        description: Reason why this was deprecated.
   Dictionary<ApiVersion>:
     type: object
     additionalProperties:
@@ -1261,7 +1254,8 @@ definitions:
         items:
           $ref: '#/definitions/ApiVersion'
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: '#/definitions/Deprecation'
       exceptions:
         type: array
@@ -1545,7 +1539,8 @@ definitions:
       defaultValue:
         description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: '#/definitions/Deprecation'
       example:
         description: example information
@@ -2069,7 +2064,8 @@ definitions:
       clientDefaultValue:
         description: the value that the client should provide if the consumer doesn't provide one
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: '#/definitions/Deprecation'
       externalDocs:
         description: External Documentation Links

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -31,27 +31,16 @@
       }
     },
     "Deprecation": {
-      "description": "represents  deprecation information for a given aspect",
+      "description": "Represent information about a deprecation",
       "type": "object",
       "properties": {
-        "message": {
-          "description": "the reason why this aspect",
+        "reason": {
+          "description": "Reason why this was deprecated.",
           "type": "string"
-        },
-        "apiVersions": {
-          "description": "the api versions that this deprecation is applicable to.",
-          "type": "array",
-          "items": {
-            "$ref": "./master.json#/definitions/ApiVersion"
-          }
         }
       },
       "defaultProperties": [],
-      "additionalProperties": false,
-      "required": [
-        "apiVersions",
-        "message"
-      ]
+      "additionalProperties": false
     },
     "Extensions": {
       "description": "A dictionary of open-ended 'x-*' extensions propogated from the original source document.",
@@ -322,7 +311,8 @@
         },
         "deprecated": {
           "$ref": "./master.json#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",
@@ -819,7 +809,8 @@
         },
         "deprecated": {
           "$ref": "./master.json#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",

--- a/packages/libs/codemodel/.resources/model/json/schemas.json
+++ b/packages/libs/codemodel/.resources/model/json/schemas.json
@@ -35,7 +35,8 @@
         },
         "deprecated": {
           "$ref": "./master.json#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",
@@ -1081,7 +1082,8 @@
         },
         "deprecated": {
           "$ref": "./master.json#/definitions/Deprecation",
-          "description": "deprecation information -- ie, when this aspect doesn't apply and why"
+          "description": "Represent the deprecation information if api is deprecated.",
+          "default": "undefined"
         },
         "origin": {
           "description": "where did this aspect come from (jsonpath or 'modelerfour:<soemthing>')",

--- a/packages/libs/codemodel/.resources/model/yaml/master.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/master.yaml
@@ -97,20 +97,12 @@ definitions:
         $ref: ./master.yaml#/definitions/Dictionary<any>
   Deprecation:
     type: object
-    description: represents  deprecation information for a given aspect
+    description: Represent information about a deprecation
     additionalProperties: false
     properties:
-      apiVersions:
-        type: array
-        description: the api versions that this deprecation is applicable to.
-        items:
-          $ref: ./master.yaml#/definitions/ApiVersion
-      message:
+      reason:
         type: string
-        description: the reason why this aspect
-    required:
-      - apiVersions
-      - message
+        description: Reason why this was deprecated.
   Dictionary<ApiVersion>:
     type: object
     additionalProperties:
@@ -329,7 +321,8 @@ definitions:
         items:
           $ref: ./master.yaml#/definitions/ApiVersion
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: ./master.yaml#/definitions/Deprecation
       exceptions:
         type: array
@@ -591,7 +584,8 @@ definitions:
       clientDefaultValue:
         description: the value that the client should provide if the consumer doesn't provide one
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: ./master.yaml#/definitions/Deprecation
       externalDocs:
         description: External Documentation Links

--- a/packages/libs/codemodel/.resources/model/yaml/schemas.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/schemas.yaml
@@ -172,7 +172,8 @@ definitions:
       defaultValue:
         description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: ./master.yaml#/definitions/Deprecation
       example:
         description: example information
@@ -452,7 +453,8 @@ definitions:
       defaultValue:
         description: If the value isn't sent on the wire, the service will assume this
       deprecated:
-        description: deprecation information -- ie, when this aspect doesn't apply and why
+        description: Represent the deprecation information if api is deprecated.
+        default: undefined
         $ref: ./master.yaml#/definitions/Deprecation
       example:
         description: example information

--- a/packages/libs/codemodel/src/model/common/aspect.ts
+++ b/packages/libs/codemodel/src/model/common/aspect.ts
@@ -2,9 +2,7 @@ import { ApiVersions } from "./api-version";
 import { Deprecation } from "./deprecation";
 import { ExternalDocumentation } from "./external-documentation";
 import { Metadata } from "./metadata";
-import { Initializer, DeepPartial } from "@azure-tools/codegen";
-
-const count = 0;
+import { DeepPartial } from "@azure-tools/codegen";
 
 /** the base interface that represents an aspect of the model. */
 export interface Aspect extends Metadata {
@@ -23,7 +21,10 @@ export interface Aspect extends Metadata {
   /** API versions that this applies to. Undefined means all versions */
   apiVersions?: ApiVersions;
 
-  /** deprecation information -- ie, when this aspect doesn't apply and why */
+  /**
+   * Represent the deprecation information if api is deprecated.
+   * @default undefined
+   */
   deprecated?: Deprecation;
 
   /** where did this aspect come from (jsonpath or 'modelerfour:<soemthing>') */

--- a/packages/libs/codemodel/src/model/common/deprecation.ts
+++ b/packages/libs/codemodel/src/model/common/deprecation.ts
@@ -1,10 +1,9 @@
-import { ApiVersions } from "./api-version";
-
-/** represents  deprecation information for a given aspect  */
+/**
+ *  Represent information about a deprecation
+ */
 export interface Deprecation {
-  /** the reason why this aspect  */
-  message: string;
-
-  /** the api versions that this deprecation is applicable to. */
-  apiVersions: ApiVersions;
+  /**
+   * Reason why this was deprecated.
+   */
+  reason?: string;
 }

--- a/packages/libs/codemodel/src/model/http/http.ts
+++ b/packages/libs/codemodel/src/model/http/http.ts
@@ -9,6 +9,7 @@ import { DeepPartial, KnownMediaType, Initializer } from "@azure-tools/codegen";
 import { Extensions } from "../common/extensions";
 import { GroupSchema } from "../common/schemas/object";
 import { Languages } from "../common/languages";
+import { Deprecation } from "../common/deprecation";
 
 /** extended metadata for HTTP operation parameters  */
 export interface HttpParameter extends Protocol {
@@ -67,6 +68,7 @@ export class HttpWithBodyRequest extends HttpRequest implements HttpWithBodyRequ
     this.apply(objectInitializer);
   }
 }
+
 export interface HttpBinaryRequest extends HttpWithBodyRequest {
   /* indicates that the HTTP request should be a binary, not a serialized object */
   binary: true;
@@ -90,13 +92,21 @@ export interface HttpHeader extends Extensions {
   header: string;
   schema: Schema;
   language: Languages;
+
+  /**
+   * Represent the deprecation information if api is deprecated.
+   * @default undefined
+   */
+  deprecated?: Deprecation;
 }
+
 export class HttpHeader extends Initializer implements HttpHeader {
   constructor(public header: string, public schema: Schema, objectInitializer?: DeepPartial<HttpHeader>) {
     super();
     this.apply(objectInitializer);
   }
 }
+
 export interface HttpResponse extends Protocol {
   /** the possible HTTP status codes that this response MUST match one of. */
   statusCodes: Array<StatusCode>; // oai3 supported options.

--- a/packages/libs/codemodel/src/model/http/http.ts
+++ b/packages/libs/codemodel/src/model/http/http.ts
@@ -92,12 +92,6 @@ export interface HttpHeader extends Extensions {
   header: string;
   schema: Schema;
   language: Languages;
-
-  /**
-   * Represent the deprecation information if api is deprecated.
-   * @default undefined
-   */
-  deprecated?: Deprecation;
 }
 
 export class HttpHeader extends Initializer implements HttpHeader {

--- a/packages/libs/openapi/src/oai3.ts
+++ b/packages/libs/openapi/src/oai3.ts
@@ -194,14 +194,14 @@ export interface ExternalDocumentation extends Extensions {
 }
 
 export interface Header
-  extends Extensions,
+  extends Deprecatable,
+    Extensions,
     Partial<HasContent>,
     Partial<HasSchema>,
     Partial<HasExample>,
     Partial<HasExamples> {
   description?: string;
   required?: boolean;
-  deprecated?: boolean;
   allowEmptyValue?: boolean;
   allowReserved?: boolean;
 }
@@ -261,7 +261,8 @@ export interface OpenIdConnectSecurityScheme extends Extensions {
   openIdConnectUrl: string; // url
   description?: string;
 }
-export interface HttpOperation extends Extensions, Implementation<HttpOperationDetails> {
+
+export interface HttpOperation extends Deprecatable, Extensions, Implementation<HttpOperationDetails> {
   tags?: Array<string>;
   summary?: string;
   description?: string;
@@ -271,9 +272,13 @@ export interface HttpOperation extends Extensions, Implementation<HttpOperationD
   requestBody?: Reference<RequestBody>;
   responses: Dictionary<Reference<Response>>;
   callbacks?: Dictionary<Reference<Callback>>;
-  deprecated?: boolean;
+
   security?: Array<SecurityRequirement>;
   servers?: Array<Server>;
+}
+
+export interface Deprecatable {
+  deprecated?: boolean;
 }
 
 export interface HasSchema {
@@ -308,7 +313,8 @@ export interface InQuery extends HasSchema, Partial<HasExample>, Partial<HasExam
 }
 
 export interface Parameter
-  extends Partial<HasSchema>,
+  extends Deprecatable,
+    Partial<HasSchema>,
     Partial<HasContent>,
     Partial<HasExample>,
     Partial<HasExamples>,
@@ -318,7 +324,6 @@ export interface Parameter
 
   description?: string;
   allowEmptyValue?: boolean;
-  deprecated?: boolean;
   required?: boolean;
   style?: EncodingStyle;
 
@@ -358,7 +363,7 @@ export interface Response extends Extensions {
   links?: Dictionary<Reference<Link>>;
 }
 
-export interface Schema extends Extensions, Implementation<SchemaDetails> {
+export interface Schema extends Deprecatable, Extensions, Implementation<SchemaDetails> {
   /* common properties */
   type?: JsonType;
   title?: string;
@@ -367,7 +372,6 @@ export interface Schema extends Extensions, Implementation<SchemaDetails> {
   nullable?: boolean;
   readOnly?: boolean;
   writeOnly?: boolean;
-  deprecated?: boolean;
   required?: Array<string>;
 
   /* number restrictions */


### PR DESCRIPTION
fix #3690



This adds support for deprecated field on: 
- Operation: OpenAPI  3 & Swagger
- Parameters: OpenAPI 3 **only**
- Schema: OpenAPI3 **only**

This can be done by adding the following fielld to any of the entity described above.
```yaml
deprecated: true
```



**Modelerfour schema change:**
```yaml
# This field is added when entity is deprecated(Empty object for now).
deprecated: {}

# If model is NOT deprecated this field is not present.
```
