### PR TITLE
Fix CSharp docs link

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,6 +2,7 @@
   "typescript.tsdk": "./common/temp/node_modules/typescript/lib",
   "search.exclude": {
     "**/dist/**": true,
+    "Samples/**": true,
   },
   "files.exclude": {
     "**/node_modules/**": true,

--- a/docs/client/readme.md
+++ b/docs/client/readme.md
@@ -1,13 +1,15 @@
-# <img align="center" src="../images/logo.png">  Using the Generated Client
+# <img align="center" src="../images/logo.png"> Using the Generated Client
 
 This is highly-language specific, so please refer to the documentation we have for our individual language generators:
+
 - [Python][python]
 - [Java][java]
 - [C#][csharp]
 - [Typescript][typescript]
 
 <!--LINKS-->
+
 [python]: https://github.com/Azure/autorest.python/tree/autorestv3/docs/client/readme.md
 [java]: https://github.com/Azure/autorest.java/tree/v4/docs/client/readme.md
-[csharp]: https://github.com/Azure/autorest.csharp/tree/v3/docs/client/readme.md
+[csharp]: https://github.com/Azure/autorest.csharp/tree/feature/v3/docs/client/readme.md
 [typescript]: https://github.com/Azure/autorest.typescript/tree/v6/docs/client/readme.md


### PR DESCRIPTION
Csharp doc pr was merged but the link here was referencing the wrong branch name. https://github.com/Azure/autorest.csharp/pull/1100

fix #4020
