### PR TITLE
SemanticValidator: Path param validation

### DIFF
--- a/common/changes/@autorest/configuration/feature-path-param-defined-validation_2021-04-09-16-20.json
+++ b/common/changes/@autorest/configuration/feature-path-param-defined-validation_2021-04-09-16-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "Added skip-semantics-validation config flag",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/core/feature-path-param-defined-validation_2021-04-09-16-20.json
+++ b/common/changes/@autorest/core/feature-path-param-defined-validation_2021-04-09-16-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Added** [SemanticValidator] Path parameters validation to the semantic validator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/docs/generate/flags.md
+++ b/docs/generate/flags.md
@@ -24,9 +24,11 @@
 ## Autorest flags
 Those are flags that affect autorest only
 
-| Flag | Description
-|------------------|-------------
-| `--output-converted-oai3` | If enabled and the input-files are `swager 2.0` this will output the resulting OpenAPI3.0 converted files to the `output-folder`
+| Flag                          | Description                                                                                                                      |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `--output-converted-oai3`     | If enabled and the input-files are `swager 2.0` this will output the resulting OpenAPI3.0 converted files to the `output-folder` |
+| `--skip-semantics-validation` | Disable the semantic validator plugin.                                                                                           |
+
 
 ## Temporary flags
 Those flags are temporary and will be removed in the future. Those flags are here to have a smoother rollout of certain feature.

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation-plugin.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation-plugin.ts
@@ -1,12 +1,17 @@
 import { PipelinePlugin } from "../../pipeline/common";
 import oai3 from "@azure-tools/openapi";
-import { SemanticError, validateOpenAPISemantics } from "./semantics-validation";
+import { validateOpenAPISemantics } from "./semantics-validation";
 import { DataHandle } from "@azure-tools/datastore";
 import { AutorestContext } from "../../context";
 import util from "util";
+import { SemanticError } from "./types";
 
 export function createSemanticValidationPlugin(): PipelinePlugin {
   return async (context, input, sink) => {
+    if (context.config["skip-semantics-validation"]) {
+      context.trackWarning({ code: "SkippedSemanticValidation", message: "Semantic validation was skipped." });
+      return input;
+    }
     const inputs = await Promise.all((await input.enum()).map(async (x) => input.readStrict(x)));
 
     for (const file of inputs) {

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation.ts
@@ -1,7 +1,10 @@
 import oai3 from "@azure-tools/openapi";
-import { SemanticError } from "./types";
+import { ResolveReferenceFn, SemanticError } from "./types";
+import { createReferenceResolver } from "./utils";
 import { validateDiscriminator, validatePaths } from "./validators";
 
-export function validateOpenAPISemantics(spec: oai3.Model): SemanticError[] {
-  return [...validateDiscriminator(spec), ...validatePaths(spec)];
+export function validateOpenAPISemantics(spec: oai3.Model, resolve: ResolveReferenceFn | undefined): SemanticError[] {
+  const resolveReference = createReferenceResolver(spec, resolve);
+
+  return [...validateDiscriminator(spec), ...validatePaths(spec, resolveReference)];
 }

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation.ts
@@ -1,48 +1,7 @@
-import { EnhancedPosition } from "@azure-tools/datastore";
 import oai3 from "@azure-tools/openapi";
-import { Position } from "source-map";
+import { SemanticError } from "./types";
+import { validateDiscriminator, validatePaths } from "./validators";
 
-export enum SemanticErrorCodes {
-  DiscriminatorNotRequired = "DiscriminatorNotRequired",
-}
-
-export function validateOpenAPISemantics(spec: oai3.Model) {
-  return [...validateDiscriminator(spec)];
-}
-
-export function validateDiscriminator(spec: oai3.Model): SemanticError[] {
-  const schemas = spec.components?.schemas;
-  if (!schemas) {
-    return [];
-  }
-  const errors: SemanticError[] = [];
-  for (const [name, model] of Object.entries(schemas)) {
-    if ("$ref" in model) {
-      continue;
-    }
-    const discriminator = model.discriminator;
-    if (discriminator) {
-      if (model.oneOf || model.anyOf) {
-        // Not validating in this case. This is valid OpenAPI but we don't support discriminator defined that way yet.
-      } else {
-        if (!model.required || !model.required.includes(discriminator.propertyName)) {
-          errors.push({
-            code: SemanticErrorCodes.DiscriminatorNotRequired,
-            params: { discriminator },
-            message: "Discriminator must be a required property.",
-            path: ["components", "schemas", name],
-          });
-        }
-      }
-    }
-  }
-
-  return errors;
-}
-
-export interface SemanticError {
-  code: string;
-  message: string;
-  params: Record<string, unknown>;
-  path: string[];
+export function validateOpenAPISemantics(spec: oai3.Model): SemanticError[] {
+  return [...validateDiscriminator(spec), ...validatePaths(spec)];
 }

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/types.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/types.ts
@@ -1,0 +1,12 @@
+export enum SemanticErrorCodes {
+  DiscriminatorNotRequired = "DiscriminatorNotRequired",
+  PathParameterEmtpy = "PathParameterEmtpy",
+  PathParameterMissingDefinition = "PathParameterMissingDefinition",
+}
+
+export interface SemanticError {
+  code: string;
+  message: string;
+  params: Record<string, unknown>;
+  path: string[];
+}

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/types.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/types.ts
@@ -1,3 +1,5 @@
+import { Refable } from "@azure-tools/openapi";
+
 export enum SemanticErrorCodes {
   DiscriminatorNotRequired = "DiscriminatorNotRequired",
   PathParameterEmtpy = "PathParameterEmtpy",
@@ -10,3 +12,5 @@ export interface SemanticError {
   params: Record<string, unknown>;
   path: string[];
 }
+
+export type ResolveReferenceFn<T = any> = (r: Refable<T>) => T;

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/utils.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/utils.ts
@@ -1,0 +1,9 @@
+import oai3, { dereference } from "@azure-tools/openapi";
+import { ResolveReferenceFn } from "./types";
+
+export function createReferenceResolver<T>(
+  spec: oai3.Model,
+  resolveReference: ResolveReferenceFn<T> | undefined,
+): ResolveReferenceFn<T> {
+  return resolveReference ?? ((item) => dereference(spec, item).instance);
+}

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.test.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.test.ts
@@ -1,5 +1,6 @@
-import { SemanticErrorCodes, validateDiscriminator } from "./semantics-validation";
 import oai3 from "@azure-tools/openapi";
+import { SemanticErrorCodes } from "../types";
+import { validateDiscriminator } from "./discriminator-validator";
 
 const baseModel: oai3.Model = {
   info: {

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.ts
@@ -6,11 +6,13 @@ export function validateDiscriminator(spec: oai3.Model): SemanticError[] {
   if (!schemas) {
     return [];
   }
+
   const errors: SemanticError[] = [];
   for (const [name, model] of Object.entries(schemas)) {
     if ("$ref" in model) {
       continue;
     }
+
     const discriminator = model.discriminator;
     if (discriminator) {
       if (model.oneOf || model.anyOf) {

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.ts
@@ -1,0 +1,32 @@
+import oai3 from "@azure-tools/openapi";
+import { SemanticError, SemanticErrorCodes } from "../types";
+
+export function validateDiscriminator(spec: oai3.Model): SemanticError[] {
+  const schemas = spec.components?.schemas;
+  if (!schemas) {
+    return [];
+  }
+  const errors: SemanticError[] = [];
+  for (const [name, model] of Object.entries(schemas)) {
+    if ("$ref" in model) {
+      continue;
+    }
+    const discriminator = model.discriminator;
+    if (discriminator) {
+      if (model.oneOf || model.anyOf) {
+        // Not validating in this case. This is valid OpenAPI but we don't support discriminator defined that way yet.
+      } else {
+        if (!model.required || !model.required.includes(discriminator.propertyName)) {
+          errors.push({
+            code: SemanticErrorCodes.DiscriminatorNotRequired,
+            params: { discriminator },
+            message: "Discriminator must be a required property.",
+            path: ["components", "schemas", name],
+          });
+        }
+      }
+    }
+  }
+
+  return errors;
+}

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/index.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/index.ts
@@ -1,0 +1,2 @@
+export * from "./discriminator-validator";
+export * from "./paths-validator";

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.test.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.test.ts
@@ -128,4 +128,25 @@ describe("Semantic Validation > Paths", () => {
 
     expect(errors).toHaveLength(0);
   });
+
+  it("succeeed if path parameter when using mixed global and per method paarams", () => {
+    const errors = validatePaths({
+      ...baseModel,
+      paths: {
+        "/my/{myMissingParam}/foo/{otherMissingParam}": {
+          parameters: [{ in: ParameterLocation.Path, name: "myMissingParam" }],
+          get: {
+            responses: OkResponse,
+            parameters: [{ in: ParameterLocation.Path, name: "otherMissingParam" }],
+          },
+          post: {
+            responses: OkResponse,
+            parameters: [{ in: ParameterLocation.Path, name: "otherMissingParam" }],
+          },
+        },
+      },
+    });
+
+    expect(errors).toHaveLength(0);
+  });
 });

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.test.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.test.ts
@@ -1,0 +1,131 @@
+import oai3, { ParameterLocation } from "@azure-tools/openapi";
+import { SemanticErrorCodes } from "../types";
+import { validatePaths } from "./paths-validator";
+
+const baseModel: oai3.Model = {
+  info: {
+    title: "Semantic Validation Unit Tests",
+    version: "1.0",
+  },
+  openApi: "3.0.0",
+  paths: {},
+};
+
+const OkResponse = {
+  200: {
+    description: "Ok.",
+  },
+};
+
+describe("Semantic Validation > Paths", () => {
+  it("resolve error if path parameter is empty", () => {
+    const errors = validatePaths({
+      ...baseModel,
+      paths: {
+        "/my/{}/empty/param": {},
+      },
+    });
+
+    expect(errors).toEqual([
+      {
+        code: SemanticErrorCodes.PathParameterEmtpy,
+        message: "A path parameter in uri /my/{}/empty/param is empty.",
+        params: { uri: "/my/{}/empty/param" },
+        path: ["paths", "/my/{}/empty/param"],
+      },
+    ]);
+  });
+
+  it("resolve error if path parameter is not defined in parameters", () => {
+    const errors = validatePaths({
+      ...baseModel,
+      paths: {
+        "/my/{myMissingParam}/foo": {
+          get: {
+            responses: OkResponse,
+          },
+        },
+      },
+    });
+
+    expect(errors).toEqual([
+      {
+        code: SemanticErrorCodes.PathParameterMissingDefinition,
+        message:
+          "Path parameter 'myMissingParam' referenced in path '/my/{myMissingParam}/foo' needs to be defined in every operation at either the path or operation level. (Missing in 'get')",
+        params: { methods: ["get"], paramName: "myMissingParam", uri: "/my/{myMissingParam}/foo" },
+        path: ["paths", "/my/{myMissingParam}/foo"],
+      },
+    ]);
+  });
+
+  it("resolve error if path parameter is missing in certain methods", () => {
+    const errors = validatePaths({
+      ...baseModel,
+      paths: {
+        "/my/{myMissingParam}/foo": {
+          get: {
+            responses: OkResponse,
+            parameters: [{ in: ParameterLocation.Path, name: "myMissingParam" }],
+          },
+          post: {
+            responses: OkResponse,
+            parameters: [{ in: ParameterLocation.Query, name: "myMissingParam" }],
+          },
+          put: {
+            responses: OkResponse,
+          },
+        },
+      },
+    });
+
+    expect(errors).toEqual([
+      {
+        code: SemanticErrorCodes.PathParameterMissingDefinition,
+        message:
+          "Path parameter 'myMissingParam' referenced in path '/my/{myMissingParam}/foo' needs to be defined in every operation at either the path or operation level. (Missing in 'post', 'put')",
+        params: { methods: ["post", "put"], paramName: "myMissingParam", uri: "/my/{myMissingParam}/foo" },
+        path: ["paths", "/my/{myMissingParam}/foo"],
+      },
+    ]);
+  });
+
+  it("succeeed if path parameter is present at the path level", () => {
+    const errors = validatePaths({
+      ...baseModel,
+      paths: {
+        "/my/{myMissingParam}/foo": {
+          parameters: [{ in: ParameterLocation.Path, name: "myMissingParam" }],
+          get: {
+            responses: OkResponse,
+          },
+          post: {
+            responses: OkResponse,
+          },
+        },
+      },
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it("succeeed if path parameter is present in all methods", () => {
+    const errors = validatePaths({
+      ...baseModel,
+      paths: {
+        "/my/{myMissingParam}/foo": {
+          get: {
+            responses: OkResponse,
+            parameters: [{ in: ParameterLocation.Path, name: "myMissingParam" }],
+          },
+          post: {
+            responses: OkResponse,
+            parameters: [{ in: ParameterLocation.Path, name: "myMissingParam" }],
+          },
+        },
+      },
+    });
+
+    expect(errors).toHaveLength(0);
+  });
+});

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.ts
@@ -1,0 +1,66 @@
+import { SemanticError, SemanticErrorCodes } from "../types";
+import oai3, { dereference, Refable } from "@azure-tools/openapi";
+
+export const PATH_TEMPLATES_REGEX = /\{(.*?)\}/g;
+
+export function validatePaths(spec: oai3.Model): SemanticError[] {
+  const paths = spec.paths;
+  const errors: SemanticError[] = [];
+  for (const [uri, pathItem] of Object.entries(paths)) {
+    const paramNames = (uri.match(PATH_TEMPLATES_REGEX) || []).map((x) => x.replace("{", "").replace("}", ""));
+    for (const paramName of paramNames) {
+      if (!paramName || paramName === "") {
+        errors.push(createPathParameterEmptyError(uri));
+        continue;
+      }
+
+      errors.push(...validatePathParameterExists(uri, paramName, pathItem, spec));
+    }
+  }
+  return errors;
+}
+
+function validatePathParameterExists(
+  uri: string,
+  paramName: string,
+  pathItem: oai3.PathItem,
+  spec: oai3.Model,
+): SemanticError[] {
+  if (pathItem.parameters) {
+    if (findPathParameter(paramName, pathItem.parameters, spec)) {
+      return [];
+    }
+  }
+
+  const misssingFromMethods = [];
+  for (const [method, operation] of Object.entries(pathItem)) {
+    if (!findPathParameter(paramName, operation.parameters ?? [], spec)) {
+      misssingFromMethods.push(method);
+    }
+  }
+
+  return [createPathParameterMissingDefinitionError(uri, paramName, misssingFromMethods)];
+}
+
+function findPathParameter(paramName: string, parameters: Refable<oai3.Parameter>[], spec: oai3.Model) {
+  return parameters.map((x) => dereference(spec, x).instance).find((x) => x.in === "path" && x.name === "paramName");
+}
+
+function createPathParameterEmptyError(uri: string): SemanticError {
+  return {
+    code: SemanticErrorCodes.PathParameterEmtpy,
+    message: `A path parameter in uri ${uri} is empty.`,
+    params: { uri },
+    path: ["paths", uri],
+  };
+}
+
+function createPathParameterMissingDefinitionError(uri: string, paramName: string, methods: string[]): SemanticError {
+  const missingStr = methods.map((str) => `"${str}"`).join(", ");
+  return {
+    code: SemanticErrorCodes.PathParameterMissingDefinition,
+    message: `Path parameter '${paramName}' referenced in path '${uri}' needs to be defined in every operation at either the path or operation level. (Missing in ${missingStr})`,
+    params: { paramName, uri, methods },
+    path: ["paths", uri],
+  };
+}

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.ts
@@ -4,6 +4,8 @@ import { createReferenceResolver } from "../utils";
 
 export const PATH_TEMPLATES_REGEX = /\{(.*?)\}/g;
 
+const operationKeys = new Set(["get", "post", "put", "delete", "options", "head", "patch", "trace"]);
+
 /**
  * Semantic validation for paths.
  * @param spec OpenAPI Spec to validate.
@@ -42,7 +44,7 @@ function validatePathParameterExists(
   }
 
   const misssingFromMethods = [];
-  for (const [method, operation] of Object.entries(pathItem)) {
+  for (const [method, operation] of Object.entries(pathItem).filter(([method]) => operationKeys.has(method))) {
     if (!findPathParameter(paramName, operation.parameters ?? [], resolveReference)) {
       misssingFromMethods.push(method);
     }

--- a/packages/libs/configuration/src/autorest-raw-configuration.ts
+++ b/packages/libs/configuration/src/autorest-raw-configuration.ts
@@ -36,6 +36,11 @@ export interface AutorestRawConfiguration extends AutorestRawConfigurationAlias 
    */
   "stats"?: boolean;
 
+  /**
+   * Skip the semantic validation plugin.
+   */
+  "skip-semantics-validation"?: boolean;
+
   "override-info"?: any; // make sure source maps are pulling it! (see "composite swagger" method)
   "title"?: any;
   "description"?: any;

--- a/regression-tests/package.json
+++ b/regression-tests/package.json
@@ -9,6 +9,6 @@
     "url": "https://github.com/Azure/autorest/issues"
   },
   "devDependencies": {
-    "@microsoft.azure/autorest.testserver": "^3.0.17"
+    "@microsoft.azure/autorest.testserver": "^3.0.21"
   }
 }

--- a/regression-tests/regression-compare.yaml
+++ b/regression-tests/regression-compare.yaml
@@ -78,7 +78,7 @@ languages:
       - --use:@autorest/modelerfour@4.18.0-dev.1
       - --package-name:test-package
       - --title:TestClient
-      - --use:@autorest/typescript@6.0.0-dev.20201208.1
+      - --use:@autorest/typescript@6.0.0-alpha.20210309.1
     newArgs:
       - --v3
       - --debug
@@ -86,4 +86,4 @@ languages:
       - --use:../packages/extensions/modelerfour
       - --package-name:test-package
       - --title:TestClient
-      - --use:@autorest/typescript@6.0.0-dev.20201208.1
+      - --use:@autorest/typescript@6.0.0-alpha.20210309.1

--- a/regression-tests/regression-compare.yaml
+++ b/regression-tests/regression-compare.yaml
@@ -66,7 +66,8 @@ languages:
       - --use:@autorest/modelerfour@4.18.0-dev.1
       - --use:@autorest/python@5.5.0
     newArgs:
-      - --version:3.0.6371
+      - --debug
+      - --version:../packages/extensions/core
       - --use:../packages/extensions/modelerfour
       - --use:@autorest/python@5.5.0
 


### PR DESCRIPTION
Added validation to make sure the path parameters are defined in definitions. Also added `--skip-semantics-validation` flag to disable semantic validation in case this causes issues

fix #3991

Todo: 
- [x] tests