### PR TITLE
Fix: args.test relability with ~

### DIFF
--- a/common/changes/autorest/fix-args-tests-relability_2021-04-19-15-21.json
+++ b/common/changes/autorest/fix-args-tests-relability_2021-04-19-15-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/apps/autorest/test/args.test.ts
+++ b/packages/apps/autorest/test/args.test.ts
@@ -44,7 +44,7 @@ describe("Args", () => {
   });
 
   it("parse args with ~ path", () => {
-    expect(parseArgs(["--configFileOrFolder:~/path/to/folder"]).configFileOrFolder).toEqual(
+    expect(join(parseArgs(["--configFileOrFolder:~/path/to/folder"]).configFileOrFolder)).toEqual(
       join(homedir(), "path/to/folder"),
     );
   });


### PR DESCRIPTION
For some reason the `parse args with ~` test wasn't failing all the time due to windows/unix path separator difference. Just making sure both side  are using the system path seperators.
fix #4063

