### PR TITLE
Merger performance improvements & json-pointer seperation

### DIFF
--- a/common/changes/@autorest/core/perf-merger-2_2021-04-19-23-10.json
+++ b/common/changes/@autorest/core/perf-merger-2_2021-04-19-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Perf** improvement to multi api merger",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/datastore/perf-merger-2_2021-04-19-23-10.json
+++ b/common/changes/@azure-tools/datastore/perf-merger-2_2021-04-19-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "**Deprecate** json-pointer functionality as it is moved to seperate package",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/datastore",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/json/perf-merger-2_2021-04-19-23-10.json
+++ b/common/changes/@azure-tools/json/perf-merger-2_2021-04-19-23-10.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/json",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@azure-tools/json",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -17,6 +17,7 @@ dependencies:
   '@rush-temp/deduplication': file:projects/deduplication.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/extension': file:projects/extension.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/extension-base': file:projects/extension-base.tgz_prettier@2.2.1
+  '@rush-temp/json': file:projects/json.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/jsonschema': file:projects/jsonschema.tgz_prettier@2.2.1+ts-node@9.1.1
   '@rush-temp/md-mock-api': file:projects/md-mock-api.tgz_ts-node@9.1.1
   '@rush-temp/modelerfour': file:projects/modelerfour.tgz_ts-node@9.1.1
@@ -9081,7 +9082,7 @@ packages:
       ts-node: '*'
       webpack-cli: '*'
     resolution:
-      integrity: sha512-cw7NbhPZZ+PNqpQzZ8dluctGzv7sBuRLHf2Bbbayt5dBlgncS5AqPzgVl83/uuVoNunH8OSZBeD6v55e2XozoQ==
+      integrity: sha512-N8atZJX8Sif/4E95F6Mh9h8UdpUoNRwiG8UJLDsXxHhtFu4xE9SstB3c2oij0J7PshExLLnKOTdV/LUann3TaQ==
       tarball: file:projects/autorest.tgz
     version: 0.0.0
   file:projects/codegen.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9166,7 +9167,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-QGIxd0ThHjWSq1lyPnSPhWqgb7hGME9G+HTNKMhcesWpylrActikzYtmHqrqf6lSCUM4Wl5GYRF1kpYoekV21g==
+      integrity: sha512-FVwO83cFAj/tiMsZsfQ+PAZ2i+r3a7Ql6JlcYLYp+JyYYg+3iRlfpGwYhFoyagVQwpKmfnj+6BlUft6loJ0zCA==
       tarball: file:projects/common.tgz
     version: 0.0.0
   file:projects/compare.tgz_prettier@2.2.1:
@@ -9200,7 +9201,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-+eeQE+2YSOZGA4oPRRXyP3m2ZZBQyWSR6yXmpasERSvNQnVD/+cO1Owy2C0bVTTxU8xlReQDa4T4gHkcwPVWPg==
+      integrity: sha512-enzVgUei48ZjIINccFNzweXfMODpmUgFyEEXhVkitW3fZYUoynmx4UC/FyMfxUf97MF5x4cLhHZjNAyoacPdyQ==
       tarball: file:projects/compare.tgz
     version: 0.0.0
   file:projects/configuration.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9229,7 +9230,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-OHYaCRWfl4U2U+GN4Y2T+lYr+PUeA3p6dbituy4a4cIbMWlabgVvrfXbSzJc2ABvBRIbqBAagtDoDhKpgePoUg==
+      integrity: sha512-BnkbjCNuZsfOQnbq823yoXIdTTN8bqq86sja6GF4Csj/g1nmCfXpQnHJ263RcP13LW3ItBdpCH4tL0/r9r59Hw==
       tarball: file:projects/configuration.tgz
     version: 0.0.0
   file:projects/core.tgz_ts-node@9.1.1:
@@ -9285,7 +9286,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-T8UlSiCf10EwLP/CbiR7+kcaQNq114NdrUVJ1ty6UKmQ8KKm3D/ITqarPWUmolIvIfDFCzNetQdN4s/NIiz72w==
+      integrity: sha512-teEvn07T6xWRuhn4w2IkjuMpVeD3BKTJz52iAvlPBmOS/zjcQkvLjjTgFHZ2zPoryNX5MrIQ3oU4cpVzLtEQDQ==
       tarball: file:projects/core.tgz
     version: 0.0.0
   file:projects/datastore.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9348,7 +9349,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-2wJmtQljMza9eHf8DKXW4p1DzzTn6hpgUBw0cJwid+p9QqIVo12rFy2bSqal4jn8uXbJK6qCWkvCEHrFXACdmQ==
+      integrity: sha512-mjsWk/M79p1AEDHi5cyDZkrSMRU2byd6TXbG/gm6FJqLIWz/VlSYhBoWr6J50co8ph9b8PuHm1+bSogqX33saQ==
       tarball: file:projects/deduplication.tgz
     version: 0.0.0
   file:projects/extension-base.tgz_prettier@2.2.1:
@@ -9380,6 +9381,7 @@ packages:
       '@azure-tools/async-io': 3.0.253
       '@azure-tools/eventing': 3.0.252
       '@azure-tools/tasks': 3.0.253
+      '@azure/logger': 1.0.2
       '@types/command-exists': 1.2.0
       '@types/jest': 26.0.20
       '@types/node': 14.14.34
@@ -9413,8 +9415,32 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-CjjPfn9SpeBwsmy8lBa/FntLhU1OanWMdPG2UAM5IikNdNgij5AM47nMyR9SRX46y1GcOGAS/eOWcWRkVoI6dQ==
+      integrity: sha512-WR1oVuYC6i/S5T3rDF89yMm6sOSGArXegynpRt7U9U/jPvxrmNyEVeGjiRJUYmarQnuGx+5aqNBEmoB158bIJQ==
       tarball: file:projects/extension.tgz
+    version: 0.0.0
+  file:projects/json.tgz_prettier@2.2.1+ts-node@9.1.1:
+    dependencies:
+      '@types/jest': 26.0.20
+      '@types/node': 14.14.34
+      '@typescript-eslint/eslint-plugin': 4.17.0_3641211d697b4d4d12940eb9cf33dc28
+      '@typescript-eslint/parser': 4.17.0_eslint@7.21.0+typescript@4.2.3
+      eslint: 7.21.0
+      eslint-plugin-jest: 24.3.2_f7a788bcd4fefc8ee2fd4a52e26bb045
+      eslint-plugin-node: 11.1.0_eslint@7.21.0
+      eslint-plugin-prettier: 3.2.0_eslint@7.21.0+prettier@2.2.1
+      eslint-plugin-unicorn: 27.0.0_eslint@7.21.0
+      jest: 26.6.3_ts-node@9.1.1
+      rimraf: 3.0.2
+      typescript: 4.2.3
+    dev: false
+    id: file:projects/json.tgz
+    name: '@rush-temp/json'
+    peerDependencies:
+      prettier: '*'
+      ts-node: '*'
+    resolution:
+      integrity: sha512-Gdyh6bqIA4l5lw27MAUZh2howCicUbZPh16kvsKOMX31Uw3VBzXQurFcJGpjo5rF9o+vcGItNhMMuZiTfZW6Lg==
+      tarball: file:projects/json.tgz
     version: 0.0.0
   file:projects/jsonschema.tgz_prettier@2.2.1+ts-node@9.1.1:
     dependencies:
@@ -9521,7 +9547,7 @@ packages:
     peerDependencies:
       ts-node: '*'
     resolution:
-      integrity: sha512-u2p4mI+uw0HfrOM26fbJNx8Lbmjjpuo/iz/DrcXQvxtKM8dScmni+sb+gti+HSnxmNAvV3UfR4CJvs3/S3fhNA==
+      integrity: sha512-uUe+svoKXH75gXlPFm7QOj59MW7Y0z8YxravGUGo+QW5L5kadX+weqbvjGko/Zj37SSMpKyVLF7dZPMLI1JQ7Q==
       tarball: file:projects/modelerfour.tgz
     version: 0.0.0
   file:projects/oai2-to-oai3.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9550,7 +9576,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-BeIoiIVS/JbfG5NZriUvqknI2mCvK4Q2I/jLaVjNDZPkuSK8eEn0prpqlTspJPDwChY/0AqS7gdLYlDnatpHhA==
+      integrity: sha512-IOWRifGUrzMD+cgVpkO5t43DWWyiU1YfNvF5itzuIz94jQrgKeOPIxxGKHOk9tOJpFiG/KOiNtkn+aG0tqwKug==
       tarball: file:projects/oai2-to-oai3.tgz
     version: 0.0.0
   file:projects/openapi.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9599,7 +9625,7 @@ packages:
     peerDependencies:
       prettier: '*'
     resolution:
-      integrity: sha512-V4Z4Z2TNrXNy8FMLGuk9uJh/V7d3UyMB7mAfoMhySkyHvB6WsrirDJCi596Hmk4V2xrC6fzUQONnodb+0rQWgg==
+      integrity: sha512-xIpPrXRPMX95W4hRDf7QeK7xxAG7mzFL8LAL/b3yvdR27KTGvpEIPzv1IduTjfcCDAYLM+Z2ZLdaZxD8Pe65yw==
       tarball: file:projects/test-public-packages.tgz
     version: 0.0.0
   file:projects/test-utils.tgz_prettier@2.2.1+ts-node@9.1.1:
@@ -9620,7 +9646,7 @@ packages:
       prettier: '*'
       ts-node: '*'
     resolution:
-      integrity: sha512-nuFWmDF0AyvYS6KLkzHGpEHP+Qko3rnM7JJ2VGnikgg4anJnInHR0yhIZBh7JKh3E9UExU+FZrgFXg2dnCleIw==
+      integrity: sha512-6j3QcD3+C9nR9I68Y2wBXM0LiUsEy7q7a8rXaojEEnx6POuGElpFFHw/iJ3q2tYAoWG33cvXQVknZKpcKzyFhg==
       tarball: file:projects/test-utils.tgz
     version: 0.0.0
 registry: ''
@@ -9643,6 +9669,7 @@ specifiers:
   '@rush-temp/deduplication': file:./projects/deduplication.tgz
   '@rush-temp/extension': file:./projects/extension.tgz
   '@rush-temp/extension-base': file:./projects/extension-base.tgz
+  '@rush-temp/json': file:./projects/json.tgz
   '@rush-temp/jsonschema': file:./projects/jsonschema.tgz
   '@rush-temp/md-mock-api': file:./projects/md-mock-api.tgz
   '@rush-temp/modelerfour': file:./projects/modelerfour.tgz

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -48,6 +48,7 @@
     "@azure-tools/datastore": "~4.3.0",
     "@azure-tools/deduplication": "~3.0.269",
     "@azure-tools/extension": "~3.2.5",
+    "@azure-tools/json": "~1.0.0",
     "@azure-tools/jsonschema": "~1.0.0",
     "@azure-tools/linq": "~3.1.0",
     "@azure-tools/oai2-to-oai3": "~4.2.281",

--- a/packages/extensions/core/src/lib/plugins/merger.ts
+++ b/packages/extensions/core/src/lib/plugins/merger.ts
@@ -60,14 +60,14 @@ import { PipelinePlugin } from "../pipeline/common";
  *
  */
 export class MultiAPIMerger extends Transformer<any, oai.Model> {
-  opCount = 0;
-  cCount = new Dictionary<number>();
-  refs = new Dictionary<string>();
+  private opCount = 0;
+  private cCount: Record<string, number> = {};
+  private refs: Record<string, string> = {};
 
   descriptions = new Set();
   apiVersions = new Set();
   titles = new Set();
-
+  private time = 0;
   constructor(
     input: Array<DataHandle>,
     protected overrideTitle: string | undefined,
@@ -208,6 +208,7 @@ export class MultiAPIMerger extends Transformer<any, oai.Model> {
   protected expandRefs(node: any) {
     walk(node, (value: any) => {
       if (value && typeof value === "object") {
+        const start = new Date().getTime();
         const ref = value.$ref;
         if (ref && typeof ref === "string" && ref.startsWith("#")) {
           const fullRef = `${(<DataHandle>this.currentInput).originalFullPath}${ref}`;
@@ -217,7 +218,7 @@ export class MultiAPIMerger extends Transformer<any, oai.Model> {
             this.refs[fullRef] = this.refs[ref];
           }
         }
-
+        this.time += new Date().getTime() - start;
         return "visit-children";
       }
       return "stop";

--- a/packages/extensions/core/src/lib/plugins/merger.ts
+++ b/packages/extensions/core/src/lib/plugins/merger.ts
@@ -9,7 +9,8 @@ import {
   Transformer,
   visit,
 } from "@azure-tools/datastore";
-import { clone, Dictionary, values, visitor } from "@azure-tools/linq";
+import { walk } from "@azure-tools/json";
+import { clone, Dictionary, visitor } from "@azure-tools/linq";
 
 import * as oai from "@azure-tools/openapi";
 import { AutorestContext } from "../context";
@@ -205,7 +206,7 @@ export class MultiAPIMerger extends Transformer<any, oai.Model> {
   }
 
   protected expandRefs(node: any) {
-    for (const { value } of visit(node)) {
+    walk(node, (value: any) => {
       if (value && typeof value === "object") {
         const ref = value.$ref;
         if (ref && typeof ref === "string" && ref.startsWith("#")) {
@@ -217,10 +218,10 @@ export class MultiAPIMerger extends Transformer<any, oai.Model> {
           }
         }
 
-        // now, recurse into this object
-        this.expandRefs(value);
+        return "visit-children";
       }
-    }
+      return "stop";
+    });
   }
 
   public async finish() {

--- a/packages/libs/datastore/package.json
+++ b/packages/libs/datastore/package.json
@@ -54,6 +54,7 @@
   },
   "dependencies": {
     "@azure-tools/codegen": "~2.5.294",
+    "@azure-tools/json": "~1.0.0",
     "@azure-tools/linq": "~3.1.0",
     "@azure-tools/tasks": "~3.0.0",
     "@azure-tools/uri": "~3.1.1",

--- a/packages/libs/datastore/src/json-pointer/json-pointer.test.ts
+++ b/packages/libs/datastore/src/json-pointer/json-pointer.test.ts
@@ -1,74 +1,7 @@
 /* eslint-disable jest/no-conditional-expect */
-import { keys } from "@azure-tools/linq";
 import * as pointer from "./json-pointer";
 
 describe("JsonPointer", () => {
-  let rfcExample: any;
-  let rfcValues: any;
-  let rfcParsed: any;
-
-  beforeEach(() => {
-    rfcExample = {
-      "foo": ["bar", "baz"],
-      "bar": { baz: 10 },
-      "": 0,
-      "a/b": 1,
-      "c%d": 2,
-      "e^f": 3,
-      "g|h": 4,
-      "i\\j": 5,
-      'k"l': 6,
-      " ": 7,
-      "m~n": 8,
-    };
-
-    rfcValues = {
-      "": rfcExample,
-      "/foo": rfcExample.foo,
-      "/foo/0": "bar",
-      "/bar": rfcExample.bar,
-      "/bar/baz": 10,
-      "/": 0,
-      "/a~1b": 1,
-      "/c%d": 2,
-      "/e^f": 3,
-      "/g|h": 4,
-      "/i\\j": 5,
-      '/k"l': 6,
-      "/ ": 7,
-      "/m~0n": 8,
-    };
-
-    rfcParsed = {
-      "": { tokens: [], value: rfcExample },
-      "/foo": { tokens: ["foo"], value: rfcExample.foo },
-      "/foo/0": { tokens: ["foo", "0"], value: "bar" },
-      "/bar": { tokens: ["bar"], value: rfcExample.bar },
-      "/bar/baz": { tokens: ["bar", "baz"], value: 10 },
-      "/": { tokens: [""], value: 0 },
-      "/a~1b": { tokens: ["a/b"], value: 1 },
-      "/c%d": { tokens: ["c%d"], value: 2 },
-      "/e^f": { tokens: ["e^f"], value: 3 },
-      "/g|h": { tokens: ["g|h"], value: 4 },
-      "/i\\j": { tokens: ["i\\j"], value: 5 },
-      '/k"l': { tokens: ['k"l'], value: 6 },
-      "/ ": { tokens: [" "], value: 7 },
-      "/m~0n": { tokens: ["m~n"], value: 8 },
-    };
-  });
-
-  it("should work for root element", () => {
-    const obj = {};
-    expect(pointer.get(obj, "")).toEqual(obj);
-  });
-
-  it("should do examples", () => {
-    for (const p of keys(rfcValues)) {
-      const expectedValue = rfcValues[p];
-      expect(pointer.get(rfcExample, p)).toEqual(expectedValue);
-    }
-  });
-
   it("should create arrays for - and reference the (nonexistent) member after the last array element.", () => {
     const obj = <any>["foo"];
     pointer.set(obj, "/-/test/-", "expected");

--- a/packages/libs/datastore/src/json-pointer/json-pointer.ts
+++ b/packages/libs/datastore/src/json-pointer/json-pointer.ts
@@ -1,5 +1,5 @@
 import { Dictionary, items } from "@azure-tools/linq";
-import jp from "@azure-tools/json";
+import * as jp from "@azure-tools/json";
 
 export type JsonPointer = string;
 export type JsonPointerTokens = Array<string>;

--- a/packages/libs/datastore/src/json-pointer/json-pointer.ts
+++ b/packages/libs/datastore/src/json-pointer/json-pointer.ts
@@ -1,4 +1,5 @@
 import { Dictionary, items } from "@azure-tools/linq";
+import jp from "@azure-tools/json";
 
 export type JsonPointer = string;
 export type JsonPointerTokens = Array<string>;
@@ -232,39 +233,14 @@ export function has(obj: any, pointer: JsonPointer | JsonPointerTokens) {
 }
 
 /**
- * Escapes a reference token
- *
- * @param str
- * @returns {string}
- */
-function escape(str: string) {
-  return str.toString().replace(/~/g, "~0").replace(/\//g, "~1");
-}
-
-/**
- * Unescapes a reference token
- *
- * @param str
- * @returns {string}
- */
-function unescape(str: string) {
-  return str.replace(/~1/g, "/").replace(/~0/g, "~");
-}
-
-/**
  * Converts a json pointer into a array of reference tokens
  *
  * @param pointer
  * @returns {Array}
+ * @deprecated use from @azure-tools/json
  */
 export function parseJsonPointer(pointer: string): JsonPointerTokens {
-  if (pointer === "") {
-    return new Array<string>();
-  }
-  if (pointer.charAt(0) !== "/") {
-    throw new Error("Invalid JSON pointer: " + pointer);
-  }
-  return pointer.substring(1).split(/\//).map(unescape);
+  return jp.parseJsonPointer(pointer);
 }
 
 /**
@@ -272,10 +248,8 @@ export function parseJsonPointer(pointer: string): JsonPointerTokens {
  *
  * @param refTokens segment of paths.
  * @returns JsonPointer string.
+ * @deprecated use from @azure-tools/json
  */
 export function serializeJsonPointer(refTokens: JsonPointerTokens): string {
-  if (refTokens.length === 0) {
-    return "";
-  }
-  return `/${refTokens.map(escape).join("/")}`;
+  return jp.serializeJsonPointer(refTokens);
 }

--- a/packages/libs/datastore/src/json-pointer/json-pointer.ts
+++ b/packages/libs/datastore/src/json-pointer/json-pointer.ts
@@ -25,18 +25,10 @@ export interface NodeT<T, K extends keyof T> {
  * @param {Object} obj - object to work on
  * @param {JsonPointer|JsonPointerTokens} pointer - pointer or tokens to a location
  * @returns {*} - value at location, or will throw if location is not present.
+ * @deprecated use @azure-tools/json#getJsonPointer
  */
-export function get(obj: any, pointer: JsonPointer | JsonPointerTokens) {
-  const refTokens = Array.isArray(pointer) ? pointer : parseJsonPointer(pointer);
-
-  for (let i = 0; i < refTokens.length; ++i) {
-    const tok = refTokens[i];
-    if (!(typeof obj === "object" && tok in obj)) {
-      throw new Error("Invalid reference token: " + tok);
-    }
-    obj = obj[tok];
-  }
-  return obj;
+export function get(obj: any, pointer: JsonPointer | JsonPointerTokens): any {
+  return jp.getFromJsonPointer(obj, pointer);
 }
 
 /**
@@ -129,6 +121,7 @@ export function toDictionary(obj: any, descend?: (value: any) => boolean) {
  * @param obj
  * @param {function} iterator
  * @param {function} descend
+ * @deprecated use @azure-tools/json#walk
  */
 export function walk(
   obj: any,

--- a/packages/libs/json/.eslintrc.yaml
+++ b/packages/libs/json/.eslintrc.yaml
@@ -1,0 +1,3 @@
+parser: "@typescript-eslint/parser"
+extends:
+  - "../../../.default-eslintrc.yaml"

--- a/packages/libs/json/Readme.md
+++ b/packages/libs/json/Readme.md
@@ -1,0 +1,1 @@
+# Library to interact with json objects

--- a/packages/libs/json/index.ts
+++ b/packages/libs/json/index.ts
@@ -1,0 +1,1 @@
+export * from "./refs";

--- a/packages/libs/json/jest.config.js
+++ b/packages/libs/json/jest.config.js
@@ -1,0 +1,10 @@
+// @ts-check
+
+const defaultConfig = require("../../../jest.default.config");
+
+const config = {
+  ...defaultConfig,
+  testMatch: ["<rootDir>/src/**/*.test.ts", "<rootDir>/test/**/*.test.ts"],
+};
+
+module.exports = config;

--- a/packages/libs/json/package.json
+++ b/packages/libs/json/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@azure-tools/json",
+  "version": "1.0.0",
+  "description": "Json objects utilities",
+  "main": "dist/index.js",
+  "typings": "dist/index.d.ts",
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "scripts": {
+    "build": "tsc -p ./tsconfig.build.json",
+    "watch": "tsc -p ./tsconfig.build.json --watch",
+    "lint:fix": "eslint ./src --fix --ext .ts",
+    "lint": "eslint ./src --ext .ts --max-warnings=0",
+    "prepare": "npm run build",
+    "test": "jest --watchAll --coverage=false",
+    "test:ci": "jest --ci",
+    "clean": "rimraf ./dist"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/autorest.git"
+  },
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/autorest/issues"
+  },
+  "homepage": "https://github.com/Azure/autorest/tree/master/packages/libs/json",
+  "devDependencies": {
+    "@types/jest": "^26.0.20",
+    "@types/node": "~14.14.20",
+    "@typescript-eslint/eslint-plugin": "^4.12.0",
+    "@typescript-eslint/parser": "^4.12.0",
+    "eslint-plugin-jest": "~24.3.2",
+    "eslint-plugin-node": "~11.1.0",
+    "eslint-plugin-prettier": "~3.2.0",
+    "eslint-plugin-unicorn": "~27.0.0",
+    "eslint": "^7.17.0",
+    "jest": "^26.6.3",
+    "rimraf": "^3.0.2",
+    "typescript": "~4.2.3"
+  },
+  "dependencies": {}
+}

--- a/packages/libs/json/src/index.ts
+++ b/packages/libs/json/src/index.ts
@@ -1,1 +1,2 @@
 export * from "./json-pointer/json-pointer";
+export * from "./traverse/traverse";

--- a/packages/libs/json/src/index.ts
+++ b/packages/libs/json/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./json-pointer/json-pointer";

--- a/packages/libs/json/src/json-pointer/json-pointer.test.ts
+++ b/packages/libs/json/src/json-pointer/json-pointer.test.ts
@@ -1,0 +1,27 @@
+import { parseJsonPointer, serializeJsonPointer } from "./json-pointer";
+
+describe("Json Pointer", () => {
+  it("serialize simple json path", () => {
+    expect(serializeJsonPointer(["path", "to", "prop"])).toEqual("/path/to/prop");
+  });
+
+  it("serialize json path with / characters", () => {
+    expect(serializeJsonPointer(["path", "/this/is/here", "prop"])).toEqual("/path/~1this~1is~1here/prop");
+  });
+
+  it("serialize json path with ~ characters", () => {
+    expect(serializeJsonPointer(["path", "this~is~here", "prop"])).toEqual("/path/this~0is~0here/prop");
+  });
+
+  it("parse simple json path", () => {
+    expect(parseJsonPointer("/path/to/prop")).toEqual(["path", "to", "prop"]);
+  });
+
+  it("parse json path with / characters", () => {
+    expect(parseJsonPointer("/path/~1this~1is~1here/prop")).toEqual(["path", "/this/is/here", "prop"]);
+  });
+
+  it("parse json path with ~ characters", () => {
+    expect(parseJsonPointer("/path/this~0is~0here/prop")).toEqual(["path", "this~is~here", "prop"]);
+  });
+});

--- a/packages/libs/json/src/json-pointer/json-pointer.test.ts
+++ b/packages/libs/json/src/json-pointer/json-pointer.test.ts
@@ -1,4 +1,4 @@
-import { parseJsonPointer, serializeJsonPointer } from "./json-pointer";
+import { getFromJsonPointer, parseJsonPointer, serializeJsonPointer } from "./json-pointer";
 
 describe("Json Pointer", () => {
   it("serialize simple json path", () => {
@@ -23,5 +23,49 @@ describe("Json Pointer", () => {
 
   it("parse json path with ~ characters", () => {
     expect(parseJsonPointer("/path/this~0is~0here/prop")).toEqual(["path", "this~is~here", "prop"]);
+  });
+
+  describe("getFromJsonPointer()", () => {
+    const examples = {
+      "foo": ["bar", "baz"],
+      "bar": { baz: 10 },
+      "": 0,
+      "a/b": 1,
+      "c%d": 2,
+      "e^f": 3,
+      "g|h": 4,
+      "i\\j": 5,
+      'k"l': 6,
+      " ": 7,
+      "m~n": 8,
+    };
+
+    const expectedValues = {
+      "": examples,
+      "/foo": examples.foo,
+      "/foo/0": "bar",
+      "/bar": examples.bar,
+      "/bar/baz": 10,
+      "/": 0,
+      "/a~1b": 1,
+      "/c%d": 2,
+      "/e^f": 3,
+      "/g|h": 4,
+      "/i\\j": 5,
+      '/k"l': 6,
+      "/ ": 7,
+      "/m~0n": 8,
+    };
+
+    it("should work for root element", () => {
+      const obj = {};
+      expect(getFromJsonPointer(obj, "")).toEqual(obj);
+    });
+
+    it("should do examples", () => {
+      for (const [key, expectedValue] of Object.entries(expectedValues)) {
+        expect(getFromJsonPointer(examples, key)).toEqual(expectedValue);
+      }
+    });
   });
 });

--- a/packages/libs/json/src/json-pointer/json-pointer.ts
+++ b/packages/libs/json/src/json-pointer/json-pointer.ts
@@ -1,0 +1,51 @@
+export type JsonPointer = string;
+export type JsonPointerTokens = Array<string>;
+
+/**
+ * Escapes a reference token
+ *
+ * @param str
+ * @returns {string}
+ */
+function escape(str: string): string {
+  return str.toString().replace(/~/g, "~0").replace(/\//g, "~1");
+}
+
+/**
+ * Unescapes a reference token
+ *
+ * @param str
+ * @returns {string}
+ */
+function unescape(str: string): string {
+  return str.replace(/~1/g, "/").replace(/~0/g, "~");
+}
+
+/**
+ * Converts a json pointer into a array of reference tokens
+ *
+ * @param pointer
+ * @returns {Array}
+ */
+export function parseJsonPointer(pointer: string): JsonPointerTokens {
+  if (pointer === "") {
+    return new Array<string>();
+  }
+  if (pointer.charAt(0) !== "/") {
+    throw new Error("Invalid JSON pointer: " + pointer);
+  }
+  return pointer.substring(1).split(/\//).map(unescape);
+}
+
+/**
+ * Builds a json pointer from a array of reference tokens
+ *
+ * @param refTokens segment of paths.
+ * @returns JsonPointer string.
+ */
+export function serializeJsonPointer(refTokens: JsonPointerTokens): string {
+  if (refTokens.length === 0) {
+    return "";
+  }
+  return `/${refTokens.map(escape).join("/")}`;
+}

--- a/packages/libs/json/src/json-pointer/json-pointer.ts
+++ b/packages/libs/json/src/json-pointer/json-pointer.ts
@@ -1,5 +1,5 @@
 export type JsonPointer = string;
-export type JsonPointerTokens = Array<string>;
+export type JsonPointerTokens = string[];
 
 /**
  * Escapes a reference token
@@ -48,4 +48,24 @@ export function serializeJsonPointer(refTokens: JsonPointerTokens): string {
     return "";
   }
   return `/${refTokens.map(escape).join("/")}`;
+}
+
+/**
+ * Lookup a json pointer in an object
+ *
+ * @param {Object} obj - object to work on
+ * @param {JsonPointer|JsonPointerTokens} pointer - pointer or tokens to a location
+ * @returns {*} - value at location, or will throw if location is not present.
+ */
+export function getFromJsonPointer<T>(obj: any, pointer: JsonPointer | JsonPointerTokens): T {
+  const refTokens = Array.isArray(pointer) ? pointer : parseJsonPointer(pointer);
+
+  for (let i = 0; i < refTokens.length; ++i) {
+    const tok = refTokens[i];
+    if (!(typeof obj === "object" && tok in obj)) {
+      throw new Error("Invalid reference token: " + tok);
+    }
+    obj = obj[tok];
+  }
+  return obj;
 }

--- a/packages/libs/json/src/traverse/traverse.test.ts
+++ b/packages/libs/json/src/traverse/traverse.test.ts
@@ -1,0 +1,45 @@
+import { serializeJsonPointer } from "../json-pointer/json-pointer";
+import { walk } from "./traverse";
+
+describe("Traverse", () => {
+  describe("walk", () => {
+    const obj = {
+      id: 123,
+      user: {
+        name: "Foo",
+        address: {
+          city: "Seattle",
+        },
+      },
+    };
+
+    it("walk nested object", () => {
+      const visited: Record<string, any> = {};
+      walk(obj, (value, path) => {
+        visited[serializeJsonPointer(path)] = value;
+        return "visit-children";
+      });
+      expect(Object.keys(visited).length).toEqual(6);
+      expect(visited[""]).toEqual(obj);
+      expect(visited["/id"]).toEqual(123);
+      expect(visited["/user"]).toEqual(obj.user);
+      expect(visited["/user/name"]).toEqual(obj.user.name);
+      expect(visited["/user/address"]).toEqual(obj.user.address);
+      expect(visited["/user/address/city"]).toEqual(obj.user.address.city);
+    });
+
+    it("stop walking when asked to", () => {
+      const visited: Record<string, any> = {};
+      walk(obj, (value: any, path) => {
+        visited[serializeJsonPointer(path)] = value;
+        return value.city ? "stop" : "visit-children";
+      });
+      expect(Object.keys(visited).length).toEqual(5);
+      expect(visited["/id"]).toEqual(123);
+      expect(visited["/user"]).toEqual(obj.user);
+      expect(visited["/user/name"]).toEqual(obj.user.name);
+      expect(visited["/user/address"]).toEqual(obj.user.address);
+      expect(visited["/user/address/city"]).toBeUndefined();
+    });
+  });
+});

--- a/packages/libs/json/src/traverse/traverse.ts
+++ b/packages/libs/json/src/traverse/traverse.ts
@@ -1,0 +1,33 @@
+export type WalkStatus = "stop" | "visit-children";
+
+/**
+ * Recursively visit all the node in a json object.
+ * Visitor should return a @see {WalkStatus} to determine if the object should be visited further.
+ * @param obj Object to visit
+ * @param visitor Vistor function.
+ */
+export function walk(obj: unknown, visitor: (value: unknown, path: string[]) => WalkStatus) {
+  return walkInternal(obj, [], visitor);
+}
+
+function walkInternal(obj: unknown, path: string[], visitor: (value: unknown, path: string[]) => WalkStatus) {
+  if (!obj) {
+    return undefined;
+  }
+
+  if (visitor(obj, path) !== "visit-children") {
+    return;
+  }
+
+  if (Array.isArray(obj)) {
+    for (const [index, item] of obj.entries()) {
+      walkInternal(item, [...path, index.toString()], visitor);
+    }
+  } else if (typeof obj === "object") {
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    for (const [key, item] of Object.entries(obj!)) {
+      walkInternal(item, [...path, key], visitor);
+    }
+  }
+  return false;
+}

--- a/packages/libs/json/tsconfig.build.json
+++ b/packages/libs/json/tsconfig.build.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["**/*.test.*", "test/**/*"]
+}

--- a/packages/libs/json/tsconfig.json
+++ b/packages/libs/json/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"]
+}

--- a/rush.json
+++ b/rush.json
@@ -121,6 +121,12 @@
       "shouldPublish": true
     },
     {
+      "packageName": "@azure-tools/json",
+      "projectFolder": "packages/libs/json",
+      "reviewCategory": "production",
+      "shouldPublish": true
+    },
+    {
       "packageName": "@azure-tools/jsonschema",
       "projectFolder": "packages/libs/jsonschema",
       "reviewCategory": "production",


### PR DESCRIPTION
Previous PR #4086 found the main performance sink was the use of linq library. However modifying the existing visit in datastore would have caused issue for other uses. This creates a new package `@azure-tools/json` design to contain any json object intercation and manipulation