### PR TITLE
Fix: Uncaught promise exception when plugin has no dependent

### DIFF
--- a/common/changes/@autorest/core/floating-promise-last-plugin_2021-04-29-15-09.json
+++ b/common/changes/@autorest/core/floating-promise-last-plugin_2021-04-29-15-09.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Fix** Uncaught promise exception",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/lib/outstanding-task-awaiter.ts
+++ b/packages/extensions/core/src/lib/outstanding-task-awaiter.ts
@@ -9,16 +9,15 @@ export class OutstandingTaskAwaiter {
   private locked = false;
   private outstandingTasks: Array<Promise<any>> = [];
 
-  public async Wait(): Promise<void> {
+  public async wait(): Promise<void> {
     this.locked = true;
     await Promise.all(this.outstandingTasks);
   }
 
-  public async Await<T>(task: Promise<T>): Promise<T> {
+  public await<T>(task: Promise<T>) {
     if (this.locked) {
       throw new OutstandingTaskAlreadyCompletedException();
     }
     this.outstandingTasks.push(task);
-    return task;
   }
 }

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -429,17 +429,17 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
         taskx._finishedAt = Date.now();
       })
       .catch(() => (taskx._state = "failed"));
-    void barrier.Await(task);
-    void barrierRobust.Await(task.catch(() => {}));
+    barrier.await(task);
+    barrierRobust.await(task.catch(() => {}));
   }
 
   try {
-    await barrier.Wait();
+    await barrier.wait();
     await emitStats(configView);
   } catch (e) {
     // wait for outstanding nodes
     try {
-      await barrierRobust.Wait();
+      await barrierRobust.wait();
     } catch {
       // wait for others to fail or whatever...
     }


### PR DESCRIPTION
fix #4043 

This seems to have been due to the async `wait` method which did nothing but save the promise(So not async). Removing the async fixes the issue.