### PR TITLE
Add a warning when using `x-ms-code-generation-settings` which is not supported in V3

### DIFF
--- a/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation-plugin.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation-plugin.ts
@@ -43,7 +43,10 @@ export function createSemanticValidationPlugin(): PipelinePlugin {
         for (const error of errors) {
           logValidationError(context, file, error);
         }
-        throw new Error("Semantic validation failed. There was some errors");
+        // IF there was at least one error throw.
+        if (errors.find((x) => x.level === "error")) {
+          throw new Error("Semantic validation failed. There was some errors");
+        }
       }
     }
 
@@ -57,11 +60,16 @@ export function logValidationError(context: AutorestContext, fileIn: DataHandle,
     const formattedValue = util.inspect(value, { colors: true });
     messageLines.push(`  **${name}**: ${formattedValue}`);
   }
-
-  context.trackError({
+  const log = {
     code: error.code,
     message: messageLines.join("\n"),
     source: [{ document: fileIn.key, position: { path: error.path } }],
     details: error,
-  });
+  };
+
+  if (error.level === "error") {
+    context.trackError(log);
+  } else {
+    context.trackWarning(log);
+  }
 }

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/semantics-validation.ts
@@ -1,10 +1,14 @@
 import oai3 from "@azure-tools/openapi";
 import { ResolveReferenceFn, SemanticError } from "./types";
 import { createReferenceResolver } from "./utils";
-import { validateDiscriminator, validatePaths } from "./validators";
+import { validateDiscriminator, validateOutdatedExtensions, validatePaths } from "./validators";
 
 export function validateOpenAPISemantics(spec: oai3.Model, resolve: ResolveReferenceFn | undefined): SemanticError[] {
   const resolveReference = createReferenceResolver(spec, resolve);
 
-  return [...validateDiscriminator(spec), ...validatePaths(spec, resolveReference)];
+  return [
+    ...validateDiscriminator(spec),
+    ...validatePaths(spec, resolveReference),
+    ...validateOutdatedExtensions(spec),
+  ];
 }

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/types.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/types.ts
@@ -4,9 +4,13 @@ export enum SemanticErrorCodes {
   DiscriminatorNotRequired = "DiscriminatorNotRequired",
   PathParameterEmtpy = "PathParameterEmtpy",
   PathParameterMissingDefinition = "PathParameterMissingDefinition",
+  OutdatedExtension = "OutdatedExtension",
 }
 
+export type SemanticErrorLevel = "error" | "warn";
+
 export interface SemanticError {
+  level: SemanticErrorLevel;
   code: string;
   message: string;
   params: Record<string, unknown>;

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/discriminator-validator.ts
@@ -20,6 +20,7 @@ export function validateDiscriminator(spec: oai3.Model): SemanticError[] {
       } else {
         if (!model.required || !model.required.includes(discriminator.propertyName)) {
           errors.push({
+            level: "error",
             code: SemanticErrorCodes.DiscriminatorNotRequired,
             params: { discriminator },
             message: "Discriminator must be a required property.",

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/index.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/index.ts
@@ -1,2 +1,3 @@
 export * from "./discriminator-validator";
 export * from "./paths-validator";
+export * from "./outdated-exetnsion-validator";

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/outdated-exetnsion-validator.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/outdated-exetnsion-validator.ts
@@ -1,0 +1,21 @@
+import oai3 from "@azure-tools/openapi";
+import { SemanticError, SemanticErrorCodes } from "../types";
+
+/**
+ * Validate for x- extension that were previously supported but are
+ * @param spec
+ * @returns
+ */
+export function validateOutdatedExtensions(spec: oai3.Model): SemanticError[] {
+  const errors: SemanticError[] = [];
+  if (spec.info["x-ms-code-generation-settings"]) {
+    errors.push({
+      level: "warn",
+      code: SemanticErrorCodes.OutdatedExtension,
+      message: `x-ms-code-generation-settings; is not supported in Autorest V3. It will just be ignored.`,
+      path: ["info", "x-ms-code-generation-settings"],
+      params: {},
+    });
+  }
+  return errors;
+}

--- a/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.ts
+++ b/packages/extensions/core/src/lib/plugins/semantics-validation/validators/paths-validator.ts
@@ -65,6 +65,7 @@ function findPathParameter(
 
 function createPathParameterEmptyError(uri: string): SemanticError {
   return {
+    level: "error",
     code: SemanticErrorCodes.PathParameterEmtpy,
     message: `A path parameter in uri ${uri} is empty.`,
     params: { uri },
@@ -75,6 +76,7 @@ function createPathParameterEmptyError(uri: string): SemanticError {
 function createPathParameterMissingDefinitionError(uri: string, paramName: string, methods: string[]): SemanticError {
   const missingStr = methods.map((str) => `'${str}'`).join(", ");
   return {
+    level: "error",
     code: SemanticErrorCodes.PathParameterMissingDefinition,
     message: `Path parameter '${paramName}' referenced in path '${uri}' needs to be defined in every operation at either the path or operation level. (Missing in ${missingStr})`,
     params: { paramName, uri, methods },


### PR DESCRIPTION
```
WARNING: Semantic violation: x-ms-code-generation-settings; is not supported in Autorest V3. It will just be ignored. (info > x-ms-code-generation-settings)
    - https://github.com/Azure/azure-rest-api-specs/blob/825623d005ca24789e675db4fe75415c7585b7fe/specification/storage/resource-manager/Microsoft.Storage/stable/2015-06-15/storage.json:12:2
```