### PR TITLE
Fix Pets.json samples

### DIFF
--- a/docs/openapi/examples/pets.json
+++ b/docs/openapi/examples/pets.json
@@ -1,19 +1,14 @@
 {
-  "swagger": "3.0",
+  "swagger": "2.0",
   "info": {
     "title": "Pet Client",
-    "description": "Example service client that also manages pets"
+    "description": "Example service client that also manages pets",
+    "version": "2.0"
   },
   "host": "localhost:3000",
-  "schemes": [
-    "http"
-  ],
-  "consumes": [
-    "application/json"
-  ],
-  "produces": [
-    "application/json"
-  ],
+  "schemes": ["http"],
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
   "paths": {
     "/pets": {
       "get": {
@@ -97,9 +92,7 @@
     },
     "Dog": {
       "type": "object",
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "properties": {
         "name": {
           "type": "string",


### PR DESCRIPTION
fix #4129
Seems like the spec was defined with `swagger: 3.0` instead of 'swagger: 2.0`