### PR TITLE
Add list of headers to ignore

### DIFF
--- a/common/changes/@autorest/modelerfour/feature-ignore-headers_2021-05-25-19-07.json
+++ b/common/changes/@autorest/modelerfour/feature-ignore-headers_2021-05-25-19-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "**Added** Configuration to ignore certain header names from being added to the model parameters lists",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/docs/developer/feature-status-tracking.md
+++ b/docs/developer/feature-status-tracking.md
@@ -7,12 +7,14 @@ This is a table tracking the implementation of new features across Autorest gene
 | [`AnyObject` vs `Any`][any-feat]         |              | `4.19.0`            | `5.8.0` | `v3.0.0-beta.20210428.3`            |
 | [Security standarization][security-feat] |              | `4.19.0`            |         | [WIP: PR#1128][security-csharp-wip] |
 | [Deprecation][deprecation-feat]          |              | `4.19.0`            |
+| [Header ignore][header-ignore]           |              | `4.20.0`            |
 
 <!-- Feature links -->
 
 [any-feat]: https://github.com/Azure/autorest/pull/4067
 [security-feat]: https://github.com/Azure/autorest/pull/4018
 [deprecation-feat]: https://github.com/Azure/autorest/pull/4033
+[header-ignore]: https://github.com/Azure/autorest/pull/4147
 
 <!-- Generator links -->
 

--- a/packages/extensions/modelerfour/readme.md
+++ b/packages/extensions/modelerfour/readme.md
@@ -95,6 +95,10 @@ modelerfour:
   # In this case ChildSchema will be removed and all reference to it will be updated to point to ParentSchema
   remove-empty-child-schemas: false|true
 
+  # List of header names that shouldn't be included in the codemodel.
+  # Those header would already be handled by the generator.
+  ignore-headers: string[]
+
   # **TEMPORARY FLAG DO NOT DEPEND ON IT**
   # Disable anyobject type and default to type any instead.
   # This is a temporary flag to smooth transition. It WILL be removed in a future version.

--- a/packages/extensions/modelerfour/src/modeler/modelerfour-options.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour-options.ts
@@ -46,6 +46,12 @@ export interface ModelerFourOptions {
    * This is a temporary flag to smooth transition. It WILL be removed in a future version.
    */
   "treat-type-object-as-anything"?: boolean;
+
+  /**
+   * List of header names that shouldn't be included in the codemodel.
+   * Those header would already be handled by the generator.
+   */
+  "ignore-headers"?: string[];
 }
 
 export interface ModelerFourNamingOptions {

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -154,6 +154,7 @@ export class ModelerFour {
   private uniqueNames: Dictionary<any> = {};
   private bodyProcessor: BodyProcessor;
   private securityProcessor: SecurityProcessor;
+  private ignoreHeaders: Set<string> = new Set();
 
   constructor(protected session: Session<oai3>) {
     this.input = session.model; // shadow(session.model, filename);
@@ -267,7 +268,7 @@ export class ModelerFour {
 
     this.profileFilter = await this.session.getValue("profile", []);
     this.apiVersionFilter = await this.session.getValue("api-version", []);
-
+    this.ignoreHeaders = new Set(this.options["ignore-headers"] ?? []);
     const apiVersionMode = await this.session.getValue("api-version-mode", "auto");
 
     const apiVersionParameter =
@@ -1957,95 +1958,102 @@ export class ModelerFour {
   }
 
   processParameters(httpOperation: OpenAPI.HttpOperation, operation: Operation, pathItem: OpenAPI.PathItem) {
-    values(httpOperation.parameters)
-      .select((each) => dereference(this.input, each))
-      .select((pp) => {
-        const parameter = pp.instance;
+    const parameters = Object.values(httpOperation.parameters ?? {})
+      .map((each) => dereference(this.input, each))
+      .filter((x) => !this.isParameterIgnoredHeader(x.instance));
 
-        this.use(parameter.schema, (name, schema) => {
-          if (this.apiVersionMode !== "none" && this.interpret.isApiVersionParameter(parameter)) {
-            return this.processApiVersionParameter(parameter, operation, pathItem);
+    for (const pp of parameters) {
+      const parameter = pp.instance;
+
+      this.use(parameter.schema, (name, schema) => {
+        if (this.apiVersionMode !== "none" && this.interpret.isApiVersionParameter(parameter)) {
+          return this.processApiVersionParameter(parameter, operation, pathItem);
+        }
+
+        // Not an APIVersion Parameter
+        const implementation = pp.fromRef
+          ? "method" === <any>parameter["x-ms-parameter-location"]
+            ? ImplementationLocation.Method
+            : ImplementationLocation.Client
+          : "client" === <any>parameter["x-ms-parameter-location"]
+          ? ImplementationLocation.Client
+          : ImplementationLocation.Method;
+
+        const preferredName = this.interpret.getPreferredName(parameter, schema["x-ms-client-name"] || parameter.name);
+        if (implementation === ImplementationLocation.Client) {
+          // check to see of it's already in the global parameters
+          const p = this.codeModel.findGlobalParameter((each) => each.language.default.name === preferredName);
+          if (p) {
+            return operation.addParameter(p);
           }
+        }
+        let parameterSchema = this.processSchema(name || "", schema);
 
-          // Not an APIVersion Parameter
-          const implementation = pp.fromRef
-            ? "method" === <any>parameter["x-ms-parameter-location"]
-              ? ImplementationLocation.Method
-              : ImplementationLocation.Client
-            : "client" === <any>parameter["x-ms-parameter-location"]
-            ? ImplementationLocation.Client
-            : ImplementationLocation.Method;
+        // Track the usage of this schema as an input with media type
+        this.trackSchemaUsage(parameterSchema, { usage: [SchemaContext.Input] });
 
-          const preferredName = this.interpret.getPreferredName(
-            parameter,
-            schema["x-ms-client-name"] || parameter.name,
+        if (parameter.in === ParameterLocation.Header && "x-ms-header-collection-prefix" in parameter) {
+          const dictionarySchema = this.codeModel.schemas.add(
+            new DictionarySchema(
+              parameterSchema.language.default.name,
+              parameterSchema.language.default.description,
+              parameterSchema,
+            ),
           );
-          if (implementation === ImplementationLocation.Client) {
-            // check to see of it's already in the global parameters
-            const p = this.codeModel.findGlobalParameter((each) => each.language.default.name === preferredName);
-            if (p) {
-              return operation.addParameter(p);
-            }
-          }
-          let parameterSchema = this.processSchema(name || "", schema);
+          this.trackSchemaUsage(dictionarySchema, { usage: [SchemaContext.Input] });
+          parameterSchema = dictionarySchema;
+        }
 
-          // Track the usage of this schema as an input with media type
-          this.trackSchemaUsage(parameterSchema, { usage: [SchemaContext.Input] });
-
-          if (parameter.in === ParameterLocation.Header && "x-ms-header-collection-prefix" in parameter) {
-            const dictionarySchema = this.codeModel.schemas.add(
-              new DictionarySchema(
-                parameterSchema.language.default.name,
-                parameterSchema.language.default.description,
-                parameterSchema,
+        /* regular, everyday parameter */
+        const newParam = operation.addParameter(
+          new Parameter(preferredName, this.interpret.getDescription("", parameter), parameterSchema, {
+            required: parameter.required ? true : undefined,
+            implementation,
+            extensions: this.interpret.getExtensionProperties(parameter),
+            deprecated: this.interpret.getDeprecation(parameter),
+            nullable: parameter.nullable || schema.nullable,
+            protocol: {
+              http: new HttpParameter(
+                parameter.in,
+                parameter.style
+                  ? {
+                      style: <SerializationStyle>(<unknown>parameter.style),
+                      explode: parameter.explode,
+                    }
+                  : undefined,
               ),
-            );
-            this.trackSchemaUsage(dictionarySchema, { usage: [SchemaContext.Input] });
-            parameterSchema = dictionarySchema;
-          }
-
-          /* regular, everyday parameter */
-          const newParam = operation.addParameter(
-            new Parameter(preferredName, this.interpret.getDescription("", parameter), parameterSchema, {
-              required: parameter.required ? true : undefined,
-              implementation,
-              extensions: this.interpret.getExtensionProperties(parameter),
-              deprecated: this.interpret.getDeprecation(parameter),
-              nullable: parameter.nullable || schema.nullable,
-              protocol: {
-                http: new HttpParameter(
-                  parameter.in,
-                  parameter.style
-                    ? {
-                        style: <SerializationStyle>(<unknown>parameter.style),
-                        explode: parameter.explode,
-                      }
-                    : undefined,
-                ),
+            },
+            language: {
+              default: {
+                serializedName: parameter.name,
               },
-              language: {
-                default: {
-                  serializedName: parameter.name,
-                },
-              },
-              clientDefaultValue: this.interpret.getClientDefault(parameter, schema),
-            }),
-          );
+            },
+            clientDefaultValue: this.interpret.getClientDefault(parameter, schema),
+          }),
+        );
 
-          // if allowReserved is present, add the extension attribute too.
-          if (parameter.allowReserved) {
-            newParam.extensions = newParam.extensions ?? {};
-            newParam.extensions["x-ms-skip-url-encoding"] = true;
-          }
+        // if allowReserved is present, add the extension attribute too.
+        if (parameter.allowReserved) {
+          newParam.extensions = newParam.extensions ?? {};
+          newParam.extensions["x-ms-skip-url-encoding"] = true;
+        }
 
-          if (implementation === ImplementationLocation.Client) {
-            this.codeModel.addGlobalParameter(newParam);
-          }
+        if (implementation === ImplementationLocation.Client) {
+          this.codeModel.addGlobalParameter(newParam);
+        }
 
-          return newParam;
-        });
-      })
-      .toArray();
+        return newParam;
+      });
+    }
+  }
+
+  /**
+   * Resolve if the parameter is a header that should be ignored.
+   * @param parmeter Operation parameter.
+   * @returns boolean if parameter should be ignored.
+   */
+  private isParameterIgnoredHeader(parmeter: OpenAPI.Parameter) {
+    return parmeter.in === ParameterLocation.Header && this.ignoreHeaders.has(parmeter.name);
   }
 
   processResponses(httpOperation: OpenAPI.HttpOperation, operation: Operation) {

--- a/packages/extensions/modelerfour/test/modeler/modelerfour.requests.test.ts
+++ b/packages/extensions/modelerfour/test/modeler/modelerfour.requests.test.ts
@@ -364,4 +364,49 @@ describe("Modelerfour.Request", () => {
       expect(parameter?.deprecated).toEqual({});
     });
   });
+
+  describe("ignore headers with config", () => {
+    it("propagates extensions to request header definitions", async () => {
+      const spec = createTestSpec();
+      const operationDef = {
+        operationId: "headerToIgnore",
+        description: "Has header to ignore",
+        parameters: [
+          {
+            name: "foo",
+            in: "header",
+            schema: {
+              type: "string",
+            },
+          },
+          {
+            name: "bar",
+            in: "header",
+            schema: {
+              type: "string",
+            },
+          },
+        ],
+        responses: {
+          200: {
+            description: "Response with a header extension.",
+          },
+        },
+      };
+      addOperation(spec, "/headerToIgnore", {
+        post: operationDef,
+      });
+
+      const model = await runModeler(spec, {
+        modelerfour: {
+          "ignore-headers": ["foo"],
+        },
+      });
+      const parameters = model.operationGroups[0].operations[0].parameters;
+      assert(parameters);
+      expect(parameters).toHaveLength(2);
+      expect(parameters[1].language.default.serializedName).toEqual("bar");
+      expect(parameters[1].protocol).toEqual({ http: { in: "header" } });
+    });
+  });
 });


### PR DESCRIPTION
fix #3643

Add a new configuration `ignore-headers` which can be used to configure which headers modelerfour should omit in the final codemodel.
This can be used by generator to remove header that they will automatically handle themself.

