### PR TITLE
x-nullable Example wording clarification

### DIFF
--- a/docs/extensions/readme.md
+++ b/docs/extensions/readme.md
@@ -1233,7 +1233,7 @@ A dictionary where a key's value can be null.
 ```
 
 **Example**:
-An object with an optional property.
+An object with a nullable property.
 
 ```json
 "Widget": {


### PR DESCRIPTION
When I was looking at the `x-nullable` docs and read this example's wording, I initially mistook it to mean that schemas without `x-nullable` are required.

Technically speaking, inverse statements aren't logically equivalent to their original - `if p then q` != `if not p then not q` and all that. But I think this simple wording change could clear up possible confusion.