### PR TITLE
Supress global warning

### DIFF
--- a/common/changes/@autorest/core/fix-allow-supressing-global-warnings_2021-06-25-15-38.json
+++ b/common/changes/@autorest/core/fix-allow-supressing-global-warnings_2021-06-25-15-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "Allow suppressing warnings without source",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}


### PR DESCRIPTION
The `suppress` directive was not supressing warning without a source location attached to it.