### PR TITLE
Fix Memory leak resolution due to sourcemaps

### DIFF
--- a/common/changes/@autorest/configuration/perf-mem-sourcemap_2021-07-07-18-37.json
+++ b/common/changes/@autorest/configuration/perf-mem-sourcemap_2021-07-07-18-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "Add `interactive` to config type",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/core/perf-mem-sourcemap_2021-07-07-16-51.json
+++ b/common/changes/@autorest/core/perf-mem-sourcemap_2021-07-07-16-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Perf** Unload sourcemap from memory if not used",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/test-utils/perf-mem-sourcemap_2021-07-07-18-37.json
+++ b/common/changes/@autorest/test-utils/perf-mem-sourcemap_2021-07-07-18-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/test-utils",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@autorest/test-utils",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/datastore/perf-mem-sourcemap_2021-07-07-16-51.json
+++ b/common/changes/@azure-tools/datastore/perf-mem-sourcemap_2021-07-07-16-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "**Perf** Unload sourcemap from memory if not used",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/datastore",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/app.ts
+++ b/packages/extensions/core/src/app.ts
@@ -432,10 +432,6 @@ async function batch(api: AutoRest, args: AutorestCliArgs): Promise<void> {
       );
       throw result;
     }
-
-    console.error("DONE BATCH", batchTaskConfig);
-    await new Promise((r) => setTimeout(r, 5000));
-    debugger;
   }
 }
 

--- a/packages/extensions/core/src/app.ts
+++ b/packages/extensions/core/src/app.ts
@@ -432,6 +432,10 @@ async function batch(api: AutoRest, args: AutorestCliArgs): Promise<void> {
       );
       throw result;
     }
+
+    console.error("DONE BATCH", batchTaskConfig);
+    await new Promise((r) => setTimeout(r, 5000));
+    debugger;
   }
 }
 

--- a/packages/extensions/core/src/lib/context/autorest-context-loader.ts
+++ b/packages/extensions/core/src/lib/context/autorest-context-loader.ts
@@ -131,6 +131,7 @@ export class AutorestContextLoader {
               definition.name,
               extension.version,
               await extension.start(enableDebugger),
+              config.interactive,
             ),
           ),
         };

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -339,6 +339,8 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
       // creates the actual plugin.
       const scopeResult = await plugin(context, inputScope, context.DataStore.getDataSink(node.outputArtifact));
       const t2 = process.uptime() * 100;
+      await new Promise((r) => setTimeout(r, 5000));
+      global.gc();
 
       const memSuffix = context.config.debug ? `[${Math.round(process.memoryUsage().heapUsed / 1024 / 1024)} MB]` : "";
       context.Message({

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -339,8 +339,6 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
       // creates the actual plugin.
       const scopeResult = await plugin(context, inputScope, context.DataStore.getDataSink(node.outputArtifact));
       const t2 = process.uptime() * 100;
-      await new Promise((r) => setTimeout(r, 5000));
-      global.gc();
 
       const memSuffix = context.config.debug ? `[${Math.round(process.memoryUsage().heapUsed / 1024 / 1024)} MB]` : "";
       context.Message({

--- a/packages/extensions/core/src/lib/plugins/allof-cleaner.ts
+++ b/packages/extensions/core/src/lib/plugins/allof-cleaner.ts
@@ -1,16 +1,4 @@
-/* eslint-disable no-useless-escape */
-import {
-  AnyObject,
-  DataHandle,
-  DataSink,
-  DataSource,
-  Node,
-  parseJsonPointer,
-  Transformer,
-  QuickDataSource,
-  JsonPath,
-  Source,
-} from "@azure-tools/datastore";
+import { DataHandle, DataSink, DataSource, QuickDataSource, Source } from "@azure-tools/datastore";
 import { Model, isReference, Refable, Schema } from "@azure-tools/openapi";
 
 import { AutorestContext } from "../context";
@@ -45,13 +33,13 @@ export class AllOfCleaner {
 }
 
 async function allofCleaner(config: AutorestContext, input: DataSource, sink: DataSink) {
-  const inputs = await Promise.all((await input.Enum()).map(async (x) => input.ReadStrict(x)));
+  const inputs = await Promise.all((await input.Enum()).map(async (x) => input.readStrict(x)));
   const result: Array<DataHandle> = [];
 
   for (const each of inputs) {
     const fixer = new AllOfCleaner(each);
     result.push(
-      await sink.WriteObject("oai3.clean-allof.json", await fixer.getOutput(), each.identity, "openapi-clean-allof"),
+      await sink.writeObject("oai3.clean-allof.json", await fixer.getOutput(), each.identity, "openapi-clean-allof"),
     );
   }
   return new QuickDataSource(result, input.pipeState);

--- a/packages/extensions/core/src/lib/plugins/component-key-renamer.ts
+++ b/packages/extensions/core/src/lib/plugins/component-key-renamer.ts
@@ -106,7 +106,6 @@ async function renameComponentsKeys(config: AutorestContext, input: DataSource, 
         await processor.getOutput(),
         each.identity,
         "openapi-document-renamed",
-        await processor.getSourceMappings(),
       ),
     );
   }

--- a/packages/extensions/core/src/lib/plugins/components-cleaner.ts
+++ b/packages/extensions/core/src/lib/plugins/components-cleaner.ts
@@ -234,20 +234,12 @@ export class ComponentsCleaner extends Transformer<any, oai.Model> {
 }
 
 async function clean(config: AutorestContext, input: DataSource, sink: DataSink) {
-  const inputs = await Promise.all((await input.Enum()).map(async (x) => input.ReadStrict(x)));
+  const inputs = await Promise.all((await input.enum()).map(async (x) => input.readStrict(x)));
   const result: Array<DataHandle> = [];
   for (const each of inputs) {
     const processor = new ComponentsCleaner(each);
     const output = await processor.getOutput();
-    result.push(
-      await sink.WriteObject(
-        "oai3.cleaned.json",
-        output,
-        each.identity,
-        "openapi-document-cleaned",
-        await processor.getSourceMappings(),
-      ),
-    );
+    result.push(await sink.writeObject("oai3.cleaned.json", output, each.identity, "openapi-document-cleaned"));
   }
 
   return new QuickDataSource(result, input.pipeState);

--- a/packages/extensions/core/src/lib/plugins/conversion.ts
+++ b/packages/extensions/core/src/lib/plugins/conversion.ts
@@ -9,7 +9,7 @@ export function createSwaggerToOpenApi3Plugin(fileSystem?: IFileSystem): Pipelin
     const files = await input.Enum();
     const inputs: Array<DataHandle> = [];
     for (const file of files) {
-      inputs.push(await input.ReadStrict(file));
+      inputs.push(await input.readStrict(file));
     }
     const results = await convertOai2ToOai3Files(inputs);
     const resultHandles: Array<DataHandle> = [];
@@ -18,8 +18,8 @@ export function createSwaggerToOpenApi3Plugin(fileSystem?: IFileSystem): Pipelin
       if (input === undefined) {
         throw new Error(`Unexpected error while trying to map output of file ${name}. It cannot be found as an input.`);
       }
-      const out = await sink.WriteObject("OpenAPI", clone(result), input.identity);
-      resultHandles.push(await sink.Forward(input.Description, out));
+      const out = await sink.writeObject("OpenAPI", clone(result), input.identity);
+      resultHandles.push(await sink.Forward(input.description, out));
     }
     return new QuickDataSource(resultHandles, input.pipeState);
   };

--- a/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplication-plugin.ts
+++ b/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplication-plugin.ts
@@ -4,17 +4,16 @@ import { PipelinePlugin } from "../../pipeline/common";
 import { EnumDeduplicator } from "./enum-deduplicator";
 
 async function deduplicateEnums(config: AutorestContext, input: DataSource, sink: DataSink) {
-  const inputs = await Promise.all((await input.Enum()).map(async (x) => input.ReadStrict(x)));
+  const inputs = await Promise.all((await input.enum()).map(async (x) => input.readStrict(x)));
   const result: Array<DataHandle> = [];
   for (const each of inputs) {
     const deduplicator = new EnumDeduplicator(each);
     result.push(
-      await sink.WriteObject(
+      await sink.writeObject(
         "oai3.enum-deduplicated.json",
         await deduplicator.getOutput(),
         each.identity,
         "openapi-document-enum-deduplicated",
-        await deduplicator.getSourceMappings(),
       ),
     );
   }

--- a/packages/extensions/core/src/lib/plugins/merger.ts
+++ b/packages/extensions/core/src/lib/plugins/merger.ts
@@ -510,7 +510,7 @@ function cleanRefs(instance: AnyObject): AnyObject {
 }
 
 async function merge(context: AutorestContext, input: DataSource, sink: DataSink) {
-  const inputs = await Promise.all((await input.Enum()).map((x) => input.ReadStrict(x)));
+  const inputs = await Promise.all((await input.enum()).map((x) => input.readStrict(x)));
   if (inputs.length === 1) {
     const model = await inputs[0].readObject<any>();
     if (model.info?.["x-ms-metadata"]?.merged) {
@@ -519,7 +519,7 @@ async function merge(context: AutorestContext, input: DataSource, sink: DataSink
       // we're just going to clean the refs and give it back the way it came in.
       cleanRefs(model);
       return new QuickDataSource(
-        [await sink.WriteObject("merged oai3 doc...", model, inputs[0].identity, "merged-oai3", undefined)],
+        [await sink.writeObject("merged oai3 doc...", model, inputs[0].identity, "merged-oai3", undefined)],
         input.pipeState,
       );
     }
@@ -538,7 +538,6 @@ async function merge(context: AutorestContext, input: DataSource, sink: DataSink
         // eslint-disable-next-line prefer-spread
         [].concat.apply([], <any>inputs.map((each) => each.identity)),
         "merged-oai3",
-        await processor.getSourceMappings(),
       ),
     ],
     input.pipeState,

--- a/packages/extensions/core/src/lib/plugins/new-composer.ts
+++ b/packages/extensions/core/src/lib/plugins/new-composer.ts
@@ -485,7 +485,6 @@ async function compose(config: AutorestContext, input: DataSource, sink: DataSin
         // eslint-disable-next-line prefer-spread
         [].concat.apply([], <any>inputs.map((each) => each.identity)),
         "merged-oai3",
-        await composer.getSourceMappings(),
       ),
     ],
     input.pipeState,

--- a/packages/extensions/core/src/lib/plugins/profile-filter.ts
+++ b/packages/extensions/core/src/lib/plugins/profile-filter.ts
@@ -496,7 +496,6 @@ async function filter(config: AutorestContext, input: DataSource, sink: DataSink
           output,
           each.identity,
           "openapi3-document-profile-filtered",
-          await processor.getSourceMappings(),
         ),
       );
     } else {

--- a/packages/extensions/core/src/lib/plugins/subset-schemas-deduplicator.ts
+++ b/packages/extensions/core/src/lib/plugins/subset-schemas-deduplicator.ts
@@ -381,7 +381,6 @@ async function deduplicateSubsetSchemas(config: AutorestContext, input: DataSour
         await processor.getOutput(),
         each.identity,
         "openapi-document-schema-reduced",
-        await processor.getSourceMappings(),
       ),
     );
   }

--- a/packages/extensions/core/src/lib/plugins/tree-shaker/tree-shaker.ts
+++ b/packages/extensions/core/src/lib/plugins/tree-shaker/tree-shaker.ts
@@ -806,7 +806,7 @@ export class OAI3Shaker extends Transformer<AnyObject, AnyObject> {
 }
 
 async function shakeTree(context: AutorestContext, input: DataSource, sink: DataSink) {
-  const inputs = await Promise.all((await input.Enum()).map(async (x) => input.ReadStrict(x)));
+  const inputs = await Promise.all((await input.Enum()).map(async (x) => input.readStrict(x)));
   const result: Array<DataHandle> = [];
   const isSimpleTreeShake = !!context.GetEntry("simple-tree-shake");
   for (const each of inputs) {
@@ -823,15 +823,7 @@ async function shakeTree(context: AutorestContext, input: DataSource, sink: Data
       },
     });
 
-    result.push(
-      await sink.writeObject(
-        "oai3.shaken.json",
-        output,
-        each.identity,
-        "openapi-document-shaken",
-        await shaker.getSourceMappings(),
-      ),
-    );
+    result.push(await sink.writeObject("oai3.shaken.json", output, each.identity, "openapi-document-shaken"));
   }
   return new QuickDataSource(result, input.pipeState);
 }

--- a/packages/extensions/core/src/lib/plugins/version-param-handler.ts
+++ b/packages/extensions/core/src/lib/plugins/version-param-handler.ts
@@ -168,13 +168,7 @@ async function handleApiVersionParameter(config: AutorestContext, input: DataSou
       const processor = new ApiVersionParameterHandler(each);
       const output = await processor.getOutput();
       result.push(
-        await sink.WriteObject(
-          "oai3.noapiversion.json",
-          output,
-          each.identity,
-          "openapi-document-noapiversion",
-          await processor.getSourceMappings(),
-        ),
+        await sink.WriteObject("oai3.noapiversion.json", output, each.identity, "openapi-document-noapiversion"),
       );
     }
     return new QuickDataSource(result, input.pipeState);

--- a/packages/libs/configuration/src/autorest-normalized-configuration.ts
+++ b/packages/libs/configuration/src/autorest-normalized-configuration.ts
@@ -37,6 +37,11 @@ export interface AutorestNormalizedConfiguration extends AutorestRawConfiguratio
   "stats"?: boolean;
 
   /**
+   * Start the autorest.interactive plugin and cache traffic between extensions.
+   */
+  "interactive"?: boolean;
+
+  /**
    * Skip the semantic validation plugin.
    */
   "skip-semantics-validation"?: boolean;

--- a/packages/libs/datastore/src/data-store/data-handle.ts
+++ b/packages/libs/datastore/src/data-store/data-handle.ts
@@ -1,7 +1,7 @@
 import { MappedPosition, Position, RawSourceMap, SourceMapConsumer } from "source-map";
 import { promises as fs } from "fs";
 import { ParseToAst as parseAst, YAMLNode, parseYaml, ParseNode } from "../yaml";
-import { LineIndices } from "../parsing/text-utility";
+import { getLineIndices } from "../parsing/text-utility";
 
 export interface Data {
   status: "loaded" | "unloaded";
@@ -169,7 +169,7 @@ export class DataHandle {
 
   public async lineIndices() {
     if (!this.item.lineIndices) {
-      this.item.lineIndices = LineIndices(await this.readData());
+      this.item.lineIndices = getLineIndices(await this.readData());
     }
 
     return this.item.lineIndices;

--- a/packages/libs/datastore/src/parsing/text-utility.ts
+++ b/packages/libs/datastore/src/parsing/text-utility.ts
@@ -12,7 +12,7 @@ const regexNewLine = /\r?\n/g;
  * Return an array containg the indexes where each line start. Each cell has the index to its coresponding line.
  * @param text Text to index.
  */
-export function LineIndices(text: string): Array<number> {
+export function getLineIndices(text: string): Array<number> {
   const indices = [0];
 
   let match: RegExpExecArray | null;
@@ -33,7 +33,7 @@ export function Lines(text: string): Array<string> {
  * @param index Index.
  */
 export function indexToPositionInText(text: string, index: number): sourceMapPosition {
-  return indexToPositionFromLineIndices(LineIndices(text), index);
+  return indexToPositionFromLineIndices(getLineIndices(text), index);
 }
 
 /**

--- a/packages/libs/datastore/src/parsing/text-utility.ts
+++ b/packages/libs/datastore/src/parsing/text-utility.ts
@@ -42,7 +42,7 @@ export function indexToPositionInText(text: string, index: number): sourceMapPos
  * @param index Index.
  */
 export async function indexToPosition(text: DataHandle, index: number): Promise<sourceMapPosition> {
-  return indexToPositionFromLineIndices(await text.metadata.lineIndices, index);
+  return indexToPositionFromLineIndices(await text.lineIndices(), index);
 }
 
 /**

--- a/packages/testing/test-utils/src/data-store-test-utils.ts
+++ b/packages/testing/test-utils/src/data-store-test-utils.ts
@@ -1,4 +1,4 @@
-import { DataHandle, LineIndices } from "@azure-tools/datastore";
+import { DataHandle, getLineIndices } from "@azure-tools/datastore";
 
 /**
  * Create a data handle from some string content.
@@ -16,7 +16,7 @@ export function createDataHandle(content: string, props: { name?: string } = {})
       identity: [name],
       artifactType: "",
       cached: content,
-      lineIndices: LineIndices(content),
+      lineIndices: getLineIndices(content),
       sourceMap: undefined,
     },
     false,

--- a/packages/testing/test-utils/src/data-store-test-utils.ts
+++ b/packages/testing/test-utils/src/data-store-test-utils.ts
@@ -1,4 +1,4 @@
-import { DataHandle, LazyPromise, LineIndices } from "@azure-tools/datastore";
+import { DataHandle, LineIndices } from "@azure-tools/datastore";
 
 /**
  * Create a data handle from some string content.
@@ -11,11 +11,12 @@ export function createDataHandle(content: string, props: { name?: string } = {})
   return new DataHandle(
     key,
     {
+      status: "loaded",
       name,
       identity: [name],
       artifactType: "",
       cached: content,
-      lineIndices: new LazyPromise<number[]>(() => Promise.resolve(LineIndices(content))),
+      lineIndices: LineIndices(content),
       sourceMap: undefined,
     },
     false,

--- a/packages/testing/test-utils/src/data-store-test-utils.ts
+++ b/packages/testing/test-utils/src/data-store-test-utils.ts
@@ -15,9 +15,8 @@ export function createDataHandle(content: string, props: { name?: string } = {})
       identity: [name],
       artifactType: "",
       cached: content,
-      metadata: {
-        lineIndices: new LazyPromise<number[]>(() => Promise.resolve(LineIndices(content))),
-      } as any,
+      lineIndices: new LazyPromise<number[]>(() => Promise.resolve(LineIndices(content))),
+      sourceMap: undefined,
     },
     false,
   );


### PR DESCRIPTION
Issue is the sourcemap factory would create a closure that would never be unloaded from memory unlike the main content.

Also removed the traffic interception if --interactive is not on.