### PR TITLE
Update minimum node version from 10->12

### DIFF
--- a/.default-eslintrc.yaml
+++ b/.default-eslintrc.yaml
@@ -59,7 +59,7 @@ rules:
   # Node plugin
   # =================================================
   # Prevent from using method that are not yet availalbe in the supported version of node.(see engines field of package.json)
-  node/no-unsupported-features/node-builtins: [error, { "ignores": ["fs.promises"] }]
+  node/no-unsupported-features/node-builtins: error
   node/no-unsupported-features/es-builtins: error
   node/no-unsupported-features/es-syntax: off # Disabling this one otherwise it will complain about typescript imports which get transpiled.
   node/no-missing-import: off

--- a/common/changes/@autorest/codemodel/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/codemodel/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/codemodel",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/codemodel",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/common/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/common/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/common",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/common",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/compare/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/compare/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/compare",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/compare",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/configuration/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/configuration/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/core/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/core/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/extension-base/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/extension-base/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/extension-base",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/extension-base",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/modelerfour/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/modelerfour/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/test-utils/node-10_2021-07-09-15-50.json
+++ b/common/changes/@autorest/test-utils/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/test-utils",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/test-utils",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/codegen/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/codegen/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/codegen",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/codegen",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/datastore/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/datastore/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/datastore",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/deduplication/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/deduplication/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/deduplication",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/deduplication",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/extension/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/extension/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/extension",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/extension",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/json/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/json/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/json",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/json",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/jsonschema/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/jsonschema/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/jsonschema",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/jsonschema",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/oai2-to-oai3/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/oai2-to-oai3/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/oai2-to-oai3",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/oai2-to-oai3",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/openapi/node-10_2021-07-09-15-50.json
+++ b/common/changes/@azure-tools/openapi/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/openapi",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@azure-tools/openapi",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/autorest/node-10_2021-07-09-15-50.json
+++ b/common/changes/autorest/node-10_2021-07-09-15-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "Drop support for node 10",
+      "type": "minor"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/eng/pipelines/ci.yaml
+++ b/eng/pipelines/ci.yaml
@@ -58,11 +58,6 @@ stages:
     displayName: Regression Tests
     dependsOn: main
     jobs:
-      # autorest.typescript now only works on node 12+
-      # - template: ./templates/regression-tests.yaml
-      #   parameters:
-      #     name: node10
-      #     nodeVersion: 10.x
       - template: ./templates/regression-tests.yaml
         parameters:
           name: node12

--- a/packages/apps/autorest/entrypoints/app.js
+++ b/packages/apps/autorest/entrypoints/app.js
@@ -31,10 +31,8 @@ if (
 } else {
   try {
     const v = process.versions.node.split(".");
-    if (v[0] < 10 || (v[0] === 10 && v[1] < 16)) {
-      console.error(
-        "\nFATAL: Node v10 or higher (v10.16.x minimum, v14.x LTS recommended) is required for AutoRest.\n",
-      );
+    if (v[0] < 12) {
+      console.error("\nFATAL: Node v12 or higher (v12.x minimum, v14.x LTS recommended) is required for AutoRest.\n");
       process.exit(1);
     }
 

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.3",
   "description": "The AutoRest tool generates client libraries for accessing RESTful web services. Input to AutoRest is an OpenAPI spec that describes the REST API.",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -3,7 +3,7 @@
   "version": "3.4.5",
   "description": "AutoRest core module",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",
@@ -61,7 +61,6 @@
     "@types/jsonpath": "^0.2.0",
     "@types/lodash": "~4.14.168",
     "@types/node": "~14.14.20",
-
     "@types/webpack": "~4.41.26",
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",

--- a/packages/extensions/modelerfour/package.json
+++ b/packages/extensions/modelerfour/package.json
@@ -6,7 +6,7 @@
     "doc": "docs"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "main": "dist/main.js",
   "typings": "dist/main.d.ts",

--- a/packages/libs/codegen/package.json
+++ b/packages/libs/codegen/package.json
@@ -8,7 +8,7 @@
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",

--- a/packages/libs/codemodel/package.json
+++ b/packages/libs/codemodel/package.json
@@ -8,7 +8,7 @@
   "main": "dist/exports.js",
   "typings": "dist/exports.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc -p .",

--- a/packages/libs/common/package.json
+++ b/packages/libs/common/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",

--- a/packages/libs/configuration/package.json
+++ b/packages/libs/configuration/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",

--- a/packages/libs/datastore/package.json
+++ b/packages/libs/datastore/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/main.js",
   "typings": "./dist/main.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",
@@ -39,7 +39,6 @@
     "@types/jest": "^26.0.20",
     "@types/jsonpath": "^0.2.0",
     "@types/node": "~14.14.20",
-
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "eslint-plugin-jest": "~24.3.2",

--- a/packages/libs/deduplication/package.json
+++ b/packages/libs/deduplication/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/main.js",
   "typings": "./dist/main.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/libs/extension-base/package.json
+++ b/packages/libs/extension-base/package.json
@@ -5,7 +5,7 @@
   "main": "dist/exports.js",
   "typings": "./dist/exports.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc -p .",

--- a/packages/libs/extension/package.json
+++ b/packages/libs/extension/package.json
@@ -3,7 +3,7 @@
   "version": "3.2.7",
   "description": "Yarn-Based extension aquisition (for Azure Open Source Projects)",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",

--- a/packages/libs/json/package.json
+++ b/packages/libs/json/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",

--- a/packages/libs/jsonschema/package.json
+++ b/packages/libs/jsonschema/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "build": "tsc -p ./tsconfig.build.json",

--- a/packages/libs/oai2-to-oai3/package.json
+++ b/packages/libs/oai2-to-oai3/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/src/index.js",
   "typings": "./dist/src/index.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",
@@ -40,7 +40,6 @@
     "@types/jest": "^26.0.20",
     "@types/js-yaml": "~4.0.0",
     "@types/node": "~14.14.20",
-
     "@typescript-eslint/eslint-plugin": "^4.12.0",
     "@typescript-eslint/parser": "^4.12.0",
     "eslint-plugin-jest": "~24.3.2",

--- a/packages/libs/openapi/package.json
+++ b/packages/libs/openapi/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "typings": "./dist/index.d.ts",
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/testing/test-public-packages/package.json
+++ b/packages/testing/test-public-packages/package.json
@@ -14,7 +14,7 @@
     "test": "node ./dist/index.js"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/testing/test-utils/package.json
+++ b/packages/testing/test-utils/package.json
@@ -14,7 +14,7 @@
     "test": "echo 'No tests'"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/tools/compare/package.json
+++ b/packages/tools/compare/package.json
@@ -7,7 +7,7 @@
     "autorest-compare": "dist/index.js"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "start": "ts-node src/index.ts",

--- a/packages/tools/md-mock-api/package.json
+++ b/packages/tools/md-mock-api/package.json
@@ -8,7 +8,7 @@
     "md-mock-api": "./dist/cli/cli.js"
   },
   "engines": {
-    "node": ">=10.13.0"
+    "node": ">=12.0.0"
   },
   "scripts": {
     "lint:fix": "eslint  . --fix --ext .ts",

--- a/rush.json
+++ b/rush.json
@@ -3,7 +3,7 @@
   "rushVersion": "5.38.0",
   "pnpmVersion": "5.16.0",
   "pnpmOptions": {},
-  "nodeSupportedVersionRange": ">=10.12.0",
+  "nodeSupportedVersionRange": ">=12.0.0",
   // Disabling this during migration of other repos as it is causing issues.
   // This needs to be enabled again. https://github.com/Azure/autorest/issues/3807
   "ensureConsistentVersions": true,


### PR DESCRIPTION
Typescript generator libraries already dropped support for node 10. This makes it consistent.
Node 10 reached end of life in may 2021. 