### PR TITLE
Fix: Installing extension when parent directory to `~/.autorest` had a package.json

### DIFF
--- a/common/changes/@azure-tools/extension/fix-install-extension-parent-packge.json_2021-07-09-17-22.json
+++ b/common/changes/@azure-tools/extension/fix-install-extension-parent-packge.json_2021-07-09-17-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/extension",
+      "comment": "**Fix** Installing extension when parent directory to ~/.autorest had a package.json",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/extension",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/libs/extension/src/npm.ts
+++ b/packages/libs/extension/src/npm.ts
@@ -1,6 +1,6 @@
 import { dirname, resolve } from "path";
 import { execute } from "./exec-cmd";
-import { InstallOptions, PackageManager } from "./package-manager";
+import { ensurePackageJsonExists, InstallOptions, PackageManager } from "./package-manager";
 
 export const DEFAULT_NPM_REGISTRY = "https://registry.npmjs.org";
 
@@ -22,6 +22,8 @@ export const execNpm = async (cwd: string, ...args: string[]) => {
 
 export class Npm implements PackageManager {
   public async install(directory: string, packages: string[], options?: InstallOptions) {
+    await ensurePackageJsonExists(directory);
+
     const output = await execNpm(
       directory,
       "install",

--- a/packages/libs/extension/src/package-manager.ts
+++ b/packages/libs/extension/src/package-manager.ts
@@ -1,5 +1,5 @@
 import { writeFile, access } from "fs/promises";
-import { join } from "node:path";
+import { join } from "path";
 
 export type PackageManagerType = "yarn" | "npm";
 

--- a/packages/libs/extension/src/package-manager.ts
+++ b/packages/libs/extension/src/package-manager.ts
@@ -1,3 +1,6 @@
+import { writeFile, access } from "fs/promises";
+import { join } from "node:path";
+
 export type PackageManagerType = "yarn" | "npm";
 
 export interface InstallOptions {
@@ -10,4 +13,27 @@ export interface PackageManager {
   clean(directory: string): Promise<void>;
 
   getPackageVersions(directory: string, packageName: string): Promise<any[]>;
+}
+
+/**
+ * Ensure there is a pacakge.json in the install directory.
+ * This is to ensure that yarn add will not look for a parent package.json and install in the parent folder instead.
+ * @param directory Directory where the package will be installed.
+ */
+export async function ensurePackageJsonExists(directory: string) {
+  const filename = join(directory, "package.json");
+  if (await exists(filename)) {
+    return;
+  }
+
+  await writeFile(filename, "{}");
+}
+
+async function exists(filename: string) {
+  try {
+    await access(filename);
+    return true;
+  } catch {
+    return false;
+  }
 }

--- a/packages/libs/extension/src/yarn.ts
+++ b/packages/libs/extension/src/yarn.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "os";
 import { join, resolve } from "path";
 import { execute } from "./exec-cmd";
 import { DEFAULT_NPM_REGISTRY } from "./npm";
-import { InstallOptions, PackageManager } from "./package-manager";
+import { ensurePackageJsonExists, InstallOptions, PackageManager } from "./package-manager";
 
 let _cli: string | undefined;
 const getPathToYarnCli = async () => {
@@ -36,6 +36,7 @@ export class Yarn implements PackageManager {
   public constructor(private pathToYarnCli: string | undefined = undefined) {}
 
   public async install(directory: string, packages: string[], options?: InstallOptions) {
+    await ensurePackageJsonExists(directory);
     const output = await this.execYarn(
       directory,
       "add",


### PR DESCRIPTION
This would result in the extension being installed in the parent directory instead.
Fix is to create a package.json in the target directory to ensure `yarn add` or `npm install` will install there and not lookup for a parent package.json

fix #4201