### PR TITLE
Feature: Add new `skip-sourcemap` flag to speed up

### DIFF
--- a/common/changes/@autorest/configuration/feature-skip-sourcemap_2021-07-14-20-19.json
+++ b/common/changes/@autorest/configuration/feature-skip-sourcemap_2021-07-14-20-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "**Added** `--skip-sourcemap` flag",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/core/feature-skip-sourcemap_2021-07-14-20-19.json
+++ b/common/changes/@autorest/core/feature-skip-sourcemap_2021-07-14-20-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Added** Flag to skip sourcemap generation",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@azure-tools/datastore/feature-skip-sourcemap_2021-07-14-20-19.json
+++ b/common/changes/@azure-tools/datastore/feature-skip-sourcemap_2021-07-14-20-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@azure-tools/datastore",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/lib/pipeline/pipeline.ts
+++ b/packages/extensions/core/src/lib/pipeline/pipeline.ts
@@ -233,7 +233,12 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
   const pipelineEmitterPlugin = createArtifactEmitterPlugin(
     async (context) =>
       new QuickDataSource([
-        await context.DataStore.getDataSink().writeObject("pipeline", pipeline.pipeline, ["fix-me-3"], "pipeline"),
+        await context.DataStore.getDataSink({ generateSourceMap: !context.config["skip-sourcemap"] }).writeObject(
+          "pipeline",
+          pipeline.pipeline,
+          ["fix-me-3"],
+          "pipeline",
+        ),
       ]),
   );
 
@@ -327,7 +332,10 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
           Text: `${nodeName} - CACHED inputs = ${(await inputScope.enum()).length} [0.0 s]`,
         });
 
-        return await readCache(cacheKey, context.DataStore.getDataSink(node.outputArtifact));
+        return await readCache(
+          cacheKey,
+          context.DataStore.getDataSink({ generateSourceMap: !context.config["skip-sourcemap"] }, node.outputArtifact),
+        );
       }
 
       const t1 = process.uptime() * 100;
@@ -337,7 +345,11 @@ export async function runPipeline(configView: AutorestContext, fileSystem: IFile
       });
 
       // creates the actual plugin.
-      const scopeResult = await plugin(context, inputScope, context.DataStore.getDataSink(node.outputArtifact));
+      const scopeResult = await plugin(
+        context,
+        inputScope,
+        context.DataStore.getDataSink({ generateSourceMap: !context.config["skip-sourcemap"] }, node.outputArtifact),
+      );
       const t2 = process.uptime() * 100;
 
       const memSuffix = context.config.debug ? `[${Math.round(process.memoryUsage().heapUsed / 1024 / 1024)} MB]` : "";
@@ -454,7 +466,7 @@ async function emitStats(context: AutorestContext) {
   const plugin = createArtifactEmitterPlugin(
     async () =>
       new QuickDataSource([
-        await context.DataStore.getDataSink().writeObject(
+        await context.DataStore.getDataSink({ generateSourceMap: !context.config["skip-sourcemap"] }).writeObject(
           "stats.json",
           context.stats.getAll(),
           ["stats"],
@@ -462,5 +474,9 @@ async function emitStats(context: AutorestContext) {
         ),
       ]),
   );
-  await plugin(context, new QuickDataSource([]), context.DataStore.getDataSink());
+  await plugin(
+    context,
+    new QuickDataSource([]),
+    context.DataStore.getDataSink({ generateSourceMap: !context.config["skip-sourcemap"] }),
+  );
 }

--- a/packages/extensions/core/src/lib/plugins/emitter.ts
+++ b/packages/extensions/core/src/lib/plugins/emitter.ts
@@ -45,52 +45,52 @@ async function emitArtifactInternal(
 
 let emitCtr = 0;
 async function emitArtifact(
-  config: AutorestContext,
+  context: AutorestContext,
   uri: string,
   handle: DataHandle,
   isObject: boolean,
 ): Promise<void> {
   const artifactType = handle.artifactType;
-  const result = emitArtifactInternal(config, artifactType, uri, handle);
+  const result = emitArtifactInternal(context, artifactType, uri, handle);
 
   if (isObject) {
-    const sink = config.DataStore.getDataSink();
+    const sink = context.DataStore.getDataSink({ generateSourceMap: !context.config["skip-sourcemap"] });
 
-    if (isOutputArtifactOrMapRequested(config, artifactType + ".yaml")) {
+    if (isOutputArtifactOrMapRequested(context, artifactType + ".yaml")) {
       const h = await sink.writeData(
         `${++emitCtr}.yaml`,
         Stringify(await handle.readObject<any>()),
         ["fix-me"],
         artifactType,
       );
-      await emitArtifactInternal(config, artifactType + ".yaml", uri + ".yaml", h);
+      await emitArtifactInternal(context, artifactType + ".yaml", uri + ".yaml", h);
     }
-    if (isOutputArtifactOrMapRequested(config, artifactType + ".norm.yaml")) {
+    if (isOutputArtifactOrMapRequested(context, artifactType + ".norm.yaml")) {
       const h = await sink.writeData(
         `${++emitCtr}.norm.yaml`,
         Stringify(Normalize(await handle.readObject<any>())),
         ["fix-me"],
         artifactType,
       );
-      await emitArtifactInternal(config, artifactType + ".norm.yaml", uri + ".norm.yaml", h);
+      await emitArtifactInternal(context, artifactType + ".norm.yaml", uri + ".norm.yaml", h);
     }
-    if (isOutputArtifactOrMapRequested(config, artifactType + ".json")) {
+    if (isOutputArtifactOrMapRequested(context, artifactType + ".json")) {
       const h = await sink.writeData(
         `${++emitCtr}.json`,
         JSON.stringify(await handle.readObject<any>(), null, 2),
         ["fix-me"],
         artifactType,
       );
-      await emitArtifactInternal(config, artifactType + ".json", uri + ".json", h);
+      await emitArtifactInternal(context, artifactType + ".json", uri + ".json", h);
     }
-    if (isOutputArtifactOrMapRequested(config, artifactType + ".norm.json")) {
+    if (isOutputArtifactOrMapRequested(context, artifactType + ".norm.json")) {
       const h = await sink.writeData(
         `${++emitCtr}.norm.json`,
         JSON.stringify(Normalize(await handle.readObject<any>()), null, 2),
         ["fix-me"],
         artifactType,
       );
-      await emitArtifactInternal(config, artifactType + ".norm.json", uri + ".norm.json", h);
+      await emitArtifactInternal(context, artifactType + ".norm.json", uri + ".norm.json", h);
     }
   }
   return result;

--- a/packages/libs/configuration/src/autorest-normalized-configuration.ts
+++ b/packages/libs/configuration/src/autorest-normalized-configuration.ts
@@ -111,6 +111,11 @@ export interface AutorestNormalizedConfiguration extends AutorestRawConfiguratio
   "debugger"?: any;
 
   /**
+   * Skip sourcemap generation. To speedup.
+   */
+  "skip-sourcemap"?: boolean;
+
+  /**
    * Force updating the version of core even if there is a local version satisfying the requirement.
    */
   "force"?: boolean;

--- a/packages/libs/datastore/src/data-store/data-sink.ts
+++ b/packages/libs/datastore/src/data-store/data-sink.ts
@@ -4,8 +4,13 @@ import { compileMapping, Mapping } from "../source-map/source-map";
 
 import { DataHandle } from "./data-handle";
 
+export interface DataSinkOptions {
+  generateSourceMap?: boolean;
+}
+
 export class DataSink {
   constructor(
+    private options: DataSinkOptions,
     private write: (
       description: string,
       rawData: string,
@@ -35,8 +40,10 @@ export class DataSink {
   ): Promise<DataHandle> {
     return this.writeDataWithSourceMap(description, data, artifact, identity, async (readHandle) => {
       const sourceMapGenerator = new SourceMapGenerator({ file: readHandle.key });
-      if (mappings) {
-        await compileMapping(mappings.mappings, sourceMapGenerator, mappings.mappingSources.concat(readHandle));
+      if (this.options.generateSourceMap) {
+        if (mappings) {
+          await compileMapping(mappings.mappings, sourceMapGenerator, mappings.mappingSources.concat(readHandle));
+        }
       }
       return sourceMapGenerator.toJSON();
     });

--- a/packages/libs/datastore/src/data-store/data-store.ts
+++ b/packages/libs/datastore/src/data-store/data-store.ts
@@ -18,7 +18,7 @@ import { createHash } from "crypto";
 import { DataSource } from "./data-source";
 import { ReadThroughDataSource } from "./read-through-data-source";
 import { Data, DataHandle } from "./data-handle";
-import { DataSink } from "./data-sink";
+import { DataSink, DataSinkOptions } from "./data-sink";
 
 const md5 = (content: any) => (content ? createHash("md5").update(JSON.stringify(content)).digest("hex") : null);
 
@@ -106,8 +106,12 @@ export class DataStore {
     return resolveUri(this.BaseUri, `${this.uid++}?${encodeURIComponent(description)}`);
   }
 
-  public getDataSink(defaultArtifact: string = FALLBACK_DEFAULT_OUTPUT_ARTIFACT): DataSink {
+  public getDataSink(
+    dataSinkOptions: DataSinkOptions = { generateSourceMap: true },
+    defaultArtifact: string = FALLBACK_DEFAULT_OUTPUT_ARTIFACT,
+  ): DataSink {
     return new DataSink(
+      dataSinkOptions,
       (description, data, artifact, identity, sourceMapFactory) =>
         this.writeData(description, data, artifact || defaultArtifact, identity, sourceMapFactory),
       async (description, input) => {


### PR DESCRIPTION
Resolving the memory leak due to the sourcemap closure had to involve converting from mapping to sourcemaps at runtime instead of when an error occurs. However this can slow down the process. 