### PR TITLE
Fix --memory flag not working

### DIFF
--- a/packages/apps/autorest/CHANGELOG.json
+++ b/packages/apps/autorest/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "autorest",
   "entries": [
     {
+      "version": "3.3.2",
+      "tag": "autorest_v3.3.2",
+      "date": "Tue, 20 Jul 2021 16:57:32 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "**Fix** `--memory` flag not working"
+          }
+        ]
+      }
+    },
+    {
       "version": "3.3.0",
       "tag": "autorest_v3.3.0",
       "date": "Mon, 19 Jul 2021 15:15:42 GMT",

--- a/packages/apps/autorest/CHANGELOG.md
+++ b/packages/apps/autorest/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - autorest
 
-This log was last generated on Mon, 19 Jul 2021 15:15:42 GMT and should not be manually modified.
+This log was last generated on Tue, 20 Jul 2021 16:57:32 GMT and should not be manually modified.
+
+## 3.3.2
+Tue, 20 Jul 2021 16:57:32 GMT
+
+### Patches
+
+- **Fix** `--memory` flag not working
 
 ## 3.3.0
 Mon, 19 Jul 2021 15:15:42 GMT

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -1,6 +1,6 @@
 {
   "name": "autorest",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "The AutoRest tool generates client libraries for accessing RESTful web services. Input to AutoRest is an OpenAPI spec that describes the REST API.",
   "engines": {
     "node": ">=12.0.0"

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -165,7 +165,8 @@ export async function runCoreOutOfProc(
     if (maxMemory < 1024) {
       throw new Error("Cannot set memory to be less than 1GB(1024MB)");
     }
-    env.NODE_OPTIONS = `${env.NODE_OPTIONS} --max_old_space_size=${maxMemory}`;
+    env.NODE_OPTIONS = `${env.NODE_OPTIONS ?? ""} --max_old_space_size=${maxMemory}`;
+    console.log(`Setting memory to ${maxMemory}mb for @autorest/core`);
   }
   try {
     const ep = await resolveEntrypoint(localPath, entrypoint);

--- a/packages/testing/test-public-packages/package.json
+++ b/packages/testing/test-public-packages/package.json
@@ -31,7 +31,7 @@
   "homepage": "https://github.com/Azure/autorest#readme",
   "dependencies": {
     "@autorest/core": "~3.5.0",
-    "autorest": "~3.3.0",
+    "autorest": "~3.3.2",
     "source-map-support": "^0.5.19"
   },
   "devDependencies": {

--- a/packages/tools/compare/package.json
+++ b/packages/tools/compare/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/Azure/autorest.compare#readme",
   "dependencies": {
-    "autorest": "~3.3.0",
+    "autorest": "~3.3.2",
     "chalk": "^4.1.0",
     "diff": "^4.0.1",
     "js-yaml": "~4.0.0",


### PR DESCRIPTION
`--memory` flag was setting `NODE_OPTIONS` with undefined if not provided before which would cause node to ignore it.