### PR TITLE
Fix: Dictionaries don't get xml serialization property added in codemodel

### DIFF
--- a/common/changes/@autorest/modelerfour/fix-dict-serialization_2021-08-11-19-31.json
+++ b/common/changes/@autorest/modelerfour/fix-dict-serialization_2021-08-11-19-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "**Fix** Dictionaries don't get xml serialization information passed into codemodel",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -787,6 +787,9 @@ export class ModelerFour {
       this.interpret.getName(name, schema),
       this.interpret.getDescription("", schema),
       null,
+      {
+        serialization: this.interpret.getSerialization(schema),
+      },
     );
     // cache this now before we accidentally recurse on this type.
     this.schemaCache.set(schema, dictSchema);


### PR DESCRIPTION
fix #4256

Todo: 
- [ ] add tests