### PR TITLE
Fix: Deduplicating bool enums changed type to string

### DIFF
--- a/common/changes/@autorest/core/fix-deduplicate-bool-enums_2021-09-15-22-56.json
+++ b/common/changes/@autorest/core/fix-deduplicate-bool-enums_2021-09-15-22-56.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Fix** Deduplicating `boolean` enums changed type to `string`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplicator.test.ts
+++ b/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplicator.test.ts
@@ -135,4 +135,34 @@ describe("EnumDeduplicator", () => {
       });
     });
   });
+
+  describe("2 boolean enums with same name", () => {
+    const falseEnum: oai3.Schema = {
+      "x-ms-metadata": { apiVersions: ["2021-01-01"] },
+      type: "boolean",
+      enum: [false],
+      "x-ms-enum": {
+        name: "FalseConst",
+        modelAsString: false,
+      },
+    };
+
+    it("combine into 1", async () => {
+      const result = await runEnumDeduplicator({
+        components: {
+          schemas: {
+            "schemas:0": { ...falseEnum },
+            "schemas:1": { ...falseEnum },
+          },
+        },
+      });
+      expect(Object.keys(result.components?.schemas ?? [])).toHaveLength(1);
+      expect(result.components?.schemas?.["FalseConst"]).toEqual({
+        enum: [false],
+        type: "boolean",
+        "x-ms-enum": { modelAsString: false, name: "FalseConst" },
+        "x-ms-metadata": { apiVersions: ["2021-01-01"] },
+      });
+    });
+  });
 });

--- a/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplicator.test.ts
+++ b/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplicator.test.ts
@@ -40,6 +40,40 @@ describe("EnumDeduplicator", () => {
     expect(result.components?.schemas?.["Bar"]).toEqual(barEnum);
   });
 
+  // Regression for https://github.com/Azure/autorest/issues/4294
+  // where if x-ms-enum was passed it would use x-ms-enum.name for the name reglardless of it defined.
+  it("keeps distinct enums if x-ms-enum is passed", async () => {
+    const fooEnum = {
+      "x-ms-metadata": { name: "Foo" },
+      type: JsonType.String,
+      enum: ["one", "two"],
+      "x-ms-enum": { modelAsString: false },
+    };
+
+    const barEnum = {
+      "x-ms-metadata": { name: "Bar" },
+      type: JsonType.String,
+      enum: ["three", "four", "five"],
+      "x-ms-enum": { modelAsString: false },
+    };
+
+    const result = await runEnumDeduplicator({
+      components: {
+        schemas: {
+          "schemas:0": fooEnum,
+          "schemas:1": barEnum,
+        },
+      },
+    });
+
+    // It should have use the name of the enum as the schema key.
+    expect(result.components?.schemas).toHaveProperty("Foo");
+    expect(result.components?.schemas).toHaveProperty("Bar");
+
+    expect(result.components?.schemas?.["Foo"]).toEqual(fooEnum);
+    expect(result.components?.schemas?.["Bar"]).toEqual(barEnum);
+  });
+
   it("merge enums with same name", async () => {
     const fooEnum1 = {
       "x-ms-metadata": { name: "Foo", apiVersions: "1.0.0" },

--- a/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplicator.ts
+++ b/packages/extensions/core/src/lib/plugins/enum-deduplication/enum-deduplicator.ts
@@ -30,8 +30,7 @@ export class EnumDeduplicator extends TransformerViaPointer<oai3.Model, oai3.Mod
         return false;
       }
       // use the given name if specified, otherwise fallback to the metadata name
-      const name = pascalCase(value["x-ms-enum"] ? value["x-ms-enum"].name : value["x-ms-metadata"].name);
-
+      const name = pascalCase(getEnumName(value));
       const e = this.enums.get(name) || this.enums.set(name, []).get(name) || [];
       e.push({ target, value, key, pointer, originalNodes });
       return true;
@@ -51,7 +50,7 @@ export class EnumDeduplicator extends TransformerViaPointer<oai3.Model, oai3.Mod
       );
 
       const first = enumSet[0];
-      const name = first.value["x-ms-enum"] ? first.value["x-ms-enum"].name : first.value["x-ms-metadata"].name;
+      const name = getEnumName(first.value);
       if (enumSet.length === 1) {
         const originalRef = `#/components/schemas/${first.key}`;
         const newRef = `#/components/schemas/${name}`;
@@ -70,10 +69,12 @@ export class EnumDeduplicator extends TransformerViaPointer<oai3.Model, oai3.Mod
       if (first.value.description) {
         this.clone(mergedEnum, "description", first.pointer, first.value.description);
       }
+      if (first.value.type) {
+        this.clone(mergedEnum, "type", first.pointer, first.value.type);
+      }
       if (first.value["x-ms-enum"]) {
         this.clone(mergedEnum, "x-ms-enum", first.pointer, first.value["x-ms-enum"]);
       }
-      this.clone(mergedEnum, "type", first.pointer, "string");
       const newRef = `#/components/schemas/${name}`;
       this.newArray(mergedEnum, "enum", "");
 
@@ -116,4 +117,13 @@ export class EnumDeduplicator extends TransformerViaPointer<oai3.Model, oai3.Mod
       }
     }
   }
+}
+
+/**
+ * Returns the name of the enum. Either provided via `x-ms-enum.name` or resolved automatically.
+ * @param value Enum Schema
+ * @returns name of the enum.
+ */
+function getEnumName(value: oai3.Schema): string {
+  return value["x-ms-enum"]?.name ? value["x-ms-enum"].name : value["x-ms-metadata"].name;
 }


### PR DESCRIPTION
fix #4294

Fix issue where if 2 `boolean` enums had the same name it would convert them to `string`.

Also fix problem that if providing `x-ms-enum` it would try to use `x-ms-enum.name` even if it wasn't provided resulting in enums being named `undefined` and merged