### PR TITLE
Add missing help text for command line arguments

### DIFF
--- a/common/changes/@autorest/configuration/patch-1_2021-09-18-00-38.json
+++ b/common/changes/@autorest/configuration/patch-1_2021-09-18-00-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "Added missing help text for command line arguments",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "chlowe@microsoft.com"
+}

--- a/packages/libs/configuration/resources/help-configuration.md
+++ b/packages/libs/configuration/resources/help-configuration.md
@@ -80,7 +80,7 @@ help-content: # type: Help as defined in autorest-core/help.ts
         description: Text to include as a header comment in generated files (magic strings:MICROSOFT_MIT, MICROSOFT_APACHE, MICROSOFT_MIT_NO_VERSION, MICROSOFT_APACHE_NO_VERSION, MICROSOFT_MIT_NO_CODEGEN)
         type: string
       - key: openapi-type
-        description: Open API Type: "arm" or "data-plane"
+        description: 'Open API Type: "arm" or "data-plane"'
         type: string
       - key: max-memory-size
         type: string

--- a/packages/libs/configuration/resources/help-configuration.md
+++ b/packages/libs/configuration/resources/help-configuration.md
@@ -70,6 +70,18 @@ help-content: # type: Help as defined in autorest-core/help.ts
       - key: github-auth-token
         type: string
         description: OAuth token to use when pointing AutoRest at files living in a private GitHub repository
+      - key: azure-arm
+        description: Generate code in Azure flavor.
+        type: boolean
+      - key: head-as-boolean
+        description: When `true`, HEAD calls to non-existent resources (404) will not raise an error. Instead, if the resource exists, we return `true`, else `false`. Forced to be `true` if `--azure-arm` is set, otherwise defaults to `false`.
+        type: boolean
+      - key: header-text
+        description: Text to include as a header comment in generated files (magic strings:MICROSOFT_MIT, MICROSOFT_APACHE, MICROSOFT_MIT_NO_VERSION, MICROSOFT_APACHE_NO_VERSION, MICROSOFT_MIT_NO_CODEGEN)
+        type: string
+      - key: openapi-type
+        description: Open API Type: "arm" or "data-plane"
+        type: string
       - key: max-memory-size
         type: string
         description: Increases the maximum memory size in MB used by Node.js when running AutoRest (translates to the Node.js parameter --max-old-space-size)


### PR DESCRIPTION
https://github.com/Azure/autorest.go/pull/664 identifies several arguments with no help text and proposes documenting them in  `autorest --help --go`. They aren't specific to autorest.go, however, so I take @timotheeguerin's suggestion to add them here instead.