### PR TITLE
Allow empty version in swagger 2.0

### DIFF
--- a/common/changes/@autorest/schemas/feature-allow-empty-version-swagger_2021-10-01-18-00.json
+++ b/common/changes/@autorest/schemas/feature-allow-empty-version-swagger_2021-10-01-18-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/schemas",
+      "comment": "**Remove** empty version validation from schema validator",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/schemas",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/libs/autorest-schemas/swagger-extensions.json
+++ b/packages/libs/autorest-schemas/swagger-extensions.json
@@ -100,8 +100,7 @@
         },
         "version": {
           "type": "string",
-          "description": "A semantic version number of the API.",
-          "minLength": 1
+          "description": "A semantic version number of the API."
         },
         "description": {
           "type": "string",


### PR DESCRIPTION
fix #3047

Remove validation for verison to not be empty. Validation wasn't present in OpenAPI 3 schema and if we need a non empty version during sdk generation validation should be handled at that point.