### PR TITLE
Fix: Nullable dropped on certain properties

### DIFF
--- a/common/changes/@autorest/core/fix-nullable-props_2021-10-19-20-46.json
+++ b/common/changes/@autorest/core/fix-nullable-props_2021-10-19-20-46.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "**Fix** Nullable on certain properties during tree shaking",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/lib/plugins/tree-shaker/tree-shaker.ts
+++ b/packages/extensions/core/src/lib/plugins/tree-shaker/tree-shaker.ts
@@ -783,6 +783,7 @@ export class OAI3Shaker extends Transformer<AnyObject, AnyObject> {
         "x-ms-client-flatten": value["x-ms-client-flatten"], // we violate spec to allow flexibility in terms of flattening
         "x-ms-client-name": value["x-ms-client-name"], // we violate spec to allow flexibility in terms of naming too. *sigh*
         readOnly: value.readOnly,
+        nullable: value.nullable,
       },
       pointer,
     };


### PR DESCRIPTION
if the properties was tree shaked then it would drop the nullable attribute