### PR TITLE
Tweak progress bar

### DIFF
--- a/common/changes/@autorest/common/tweak-progress_2021-11-17-22-42.json
+++ b/common/changes/@autorest/common/tweak-progress_2021-11-17-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/common",
+      "comment": "Render progress bar before closing to force it to 100%",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/common",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/autorest/tweak-progress_2021-11-17-22-42.json
+++ b/common/changes/autorest/tweak-progress_2021-11-17-22-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "autorest",
+      "comment": "Render progress bar when installing core",
+      "type": "patch"
+    }
+  ],
+  "packageName": "autorest",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/apps/autorest/src/autorest-as-a-service.ts
+++ b/packages/apps/autorest/src/autorest-as-a-service.ts
@@ -329,13 +329,13 @@ export async function selectVersion(
 
       // @autorest/core install too fast and this doesn't look good right now as Yarn doesn't give info fast enough.
       // If we migrate to yarn v2 with the api we might be able to get more info and reenable that
-      // const progress = logger.startProgress("installing core...");
+      const progress = logger.startProgress("installing core...");
       selectedVersion = await (
         await extensionManager
       ).installPackage(pkg, force, 5 * 60 * 1000, (status) => {
-        // progress.update({ ...status });
+        progress.update({ ...status });
       });
-      // progress.stop();
+      progress.stop();
 
       if (args.debug) {
         console.log(`Extension location: ${selectedVersion.packageJsonPath}`);

--- a/packages/libs/common/src/logging/console-logger-sink.ts
+++ b/packages/libs/common/src/logging/console-logger-sink.ts
@@ -104,6 +104,7 @@ export class ConsoleLoggerSink implements LoggerSink {
     const stop = () => {
       if (bar) {
         bar.update(bar.getTotal());
+        bar.render();
         bar.stop();
         multiBar.remove(bar);
         this.bars = this.bars.filter((x) => x !== bar);


### PR DESCRIPTION
Always render progress bar to 100% before stopping it. This prevent partially complete progress to be shown if it completed without reporting 100%