### PR TITLE
Fix: breaking change in  @autorest/extension-base

### DIFF
--- a/packages/extensions/cadl/package.json
+++ b/packages/extensions/cadl/package.json
@@ -62,6 +62,6 @@
   },
   "dependencies": {
     "@cadl-lang/compiler": "~0.19.0 ",
-    "@autorest/extension-base": "~3.4.0"
+    "@autorest/extension-base": "~3.4.2"
   }
 }

--- a/packages/extensions/modelerfour/CHANGELOG.json
+++ b/packages/extensions/modelerfour/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/modelerfour",
   "entries": [
     {
+      "version": "4.22.1",
+      "tag": "@autorest/modelerfour_v4.22.1",
+      "date": "Mon, 22 Nov 2021 21:55:51 GMT",
+      "comments": {
+        "dependency": [
+          {
+            "comment": "Updating dependency \"@autorest/extension-base\" from `~3.4.0` to `~3.4.2`"
+          }
+        ]
+      }
+    },
+    {
       "version": "4.22.0",
       "tag": "@autorest/modelerfour_v4.22.0",
       "date": "Fri, 19 Nov 2021 04:23:42 GMT",

--- a/packages/extensions/modelerfour/CHANGELOG.md
+++ b/packages/extensions/modelerfour/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - @autorest/modelerfour
 
-This log was last generated on Fri, 19 Nov 2021 04:23:42 GMT and should not be manually modified.
+This log was last generated on Mon, 22 Nov 2021 21:55:51 GMT and should not be manually modified.
+
+## 4.22.1
+Mon, 22 Nov 2021 21:55:51 GMT
+
+_Version update only_
 
 ## 4.22.0
 Fri, 19 Nov 2021 04:23:42 GMT
@@ -64,7 +69,7 @@ Mon, 19 Jul 2021 15:15:41 GMT
 - Added support for anonymous security scheme
 - **Added** New option to make Content-Type extensible
 - **Added** Configuration to ignore certain header names from being added to the model parameters lists
-- **Change** Single-value enums are extensible by default and will not generate a constant
+- **Change** Single-value enums are extensible by default and will not generate a constant 
 - Drop support for node 10
 - **Perf** Flattener major performance improvement for large specs
 
@@ -113,7 +118,7 @@ Mon, 19 Apr 2021 21:06:54 GMT
 ### Patches
 
 - **Fix** Enum defined just with allOf of other enum
-- **Typo** Ambigious -> Ambiguous
+- **Typo** Ambigious -> Ambiguous 
 
 ## 4.18.3
 Tue, 13 Apr 2021 21:32:54 GMT
@@ -274,7 +279,7 @@ Tue, 26 Jan 2021 21:36:02 GMT
 ### Patches
 
 - add additional checks for empty names, collisions
-- fix errant processing on APString => Apstring
+- fix errant processing on APString => Apstring 
 - x-ms-client-name fixes on parameters
 - added setting for `preserve-uppercase-max-length` to preserve uppercase words up to a certain length.
 
@@ -284,15 +289,15 @@ Tue, 26 Jan 2021 21:36:02 GMT
 
 - static linking libraries for stability
 - processed all names in namer, styles can be set in config (see below):
-- support overrides in namer
+- support overrides in namer 
 - static linked dependency
 
 ## 4.4.x
 
 ### Patches
 
-- parameter grouping
-- some namer changes
+- parameter grouping 
+- some namer changes 
 
 ## 4.3.x
 
@@ -304,18 +309,18 @@ Tue, 26 Jan 2021 21:36:02 GMT
 - filter out 'x-ms-original' from extensions
 - add serializedName for host parameters
 - make sure reused global parameter is added to method too
-- processed values in constants/enums a bit better, support AnySchema for no type/format
+- processed values in constants/enums a bit better, support AnySchema for no type/format 
 - support server variable parameters as method unless they have x-ms-parameter-location
 
 ## 4.2.75
 
 ### Patches
 
-- add `style` to parameters to support collection format
-- `potential-breaking-change` Include common paramters from oai/path #68 (requires fix from autorest-core 3.0.6160+ )
+- add `style` to parameters to support collection format 
+- `potential-breaking-change` Include common paramters from oai/path #68 (requires fix from autorest-core 3.0.6160+ ) 
 - propogate extensions from server parameters (ie, x-ms-skip-url-encoding) #61
-- `potential-breaking-change` make operation groups case insensitive. #59
-- `potential-breaking-change` sealedChoice/Choice selection was backwards ( was creating a sealedchoice schema for modelAsString:true and vice versa) #62
+- `potential-breaking-change` make operation groups case insensitive. #59 
+- `potential-breaking-change` sealedChoice/Choice selection was backwards ( was creating a sealedchoice schema for modelAsString:true and vice versa) #62 
 - `potential-breaking-change` drop constant schema from response, use constantschema's valueType instead. #63
 - `potential-breaking-change` fix body parameter marked as required when not marked so in spec. #64
 
@@ -330,17 +335,17 @@ Tue, 26 Jan 2021 21:36:02 GMT
 ### Patches
 
 - version bump, change your configuration to specify version `~4.1.0` or greater
-
-  ```
+  
+  ``` 
   use-extension:
-    "@autorest/modelerfour" : "~4.1.0"
+    "@autorest/modelerfour" : "~4.1.0" 
   ```
-  - each Http operation (via `.protocol.http`) will now have a separate `path` and `uri` properties.
-  <br>Both are still templates, and will have parameters.
+  - each Http operation (via `.protocol.http`) will now have a separate `path` and `uri` properties. 
+  <br>Both are still templates, and will have parameters. 
   <br>The parameters for the `uri` property will have `in` set to `ParameterLocation.Uri`
   <br>The parameters for the `path` property will continue to have `in` set to `ParameterLocation.Path`
 
-
+  
   - autorest-core recently added an option to aggressively deduplicate inline models (ie, ones without a name)
   and modeler-four based generator will have that enabled by default. (ie `deduplicate-inline-models: true`)
   <br>This may increase deduplication time on extremely large openapi models.

--- a/packages/extensions/modelerfour/package.json
+++ b/packages/extensions/modelerfour/package.json
@@ -40,7 +40,7 @@
   "readme": "https://github.com/Azure/autorest/tree/main/packages/extensions/modelerfour/readme.md",
   "devDependencies": {
     "@autorest/codemodel": "~4.17.2",
-    "@autorest/extension-base": "~3.4.0",
+    "@autorest/extension-base": "~3.4.2",
     "@autorest/test-utils": "~0.5.0",
     "@azure-tools/async-io": "~3.0.0",
     "@azure-tools/codegen": "~2.9.0",

--- a/packages/libs/extension-base/CHANGELOG.json
+++ b/packages/libs/extension-base/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/extension-base",
   "entries": [
     {
+      "version": "3.4.2",
+      "tag": "@autorest/extension-base_v3.4.2",
+      "date": "Mon, 22 Nov 2021 21:55:51 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "**Fix** bring back old methods(deprecated) that introduced breaking change to smooth out the transition"
+          }
+        ]
+      }
+    },
+    {
       "version": "3.4.0",
       "tag": "@autorest/extension-base_v3.4.0",
       "date": "Fri, 19 Nov 2021 04:23:42 GMT",

--- a/packages/libs/extension-base/CHANGELOG.md
+++ b/packages/libs/extension-base/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/extension-base
 
-This log was last generated on Fri, 19 Nov 2021 04:23:42 GMT and should not be manually modified.
+This log was last generated on Mon, 22 Nov 2021 21:55:51 GMT and should not be manually modified.
+
+## 3.4.2
+Mon, 22 Nov 2021 21:55:51 GMT
+
+### Patches
+
+- **Fix** bring back old methods(deprecated) that introduced breaking change to smooth out the transition
 
 ## 3.4.0
 Fri, 19 Nov 2021 04:23:42 GMT

--- a/packages/libs/extension-base/package.json
+++ b/packages/libs/extension-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/extension-base",
-  "version": "3.4.1",
+  "version": "3.4.2",
   "description": "Library for creating AutoRest extensions",
   "main": "dist/index.js",
   "exports": {

--- a/packages/libs/extension-base/src/autorest-extension.ts
+++ b/packages/libs/extension-base/src/autorest-extension.ts
@@ -68,4 +68,17 @@ export class AutoRestExtension {
     // activate
     channel.listen();
   }
+
+  /**
+   * @deprecated Use #add
+   */
+  public Add(name: string, handler: AutoRestPluginHandler) {
+    return this.add(name, handler);
+  }
+  /**
+   * @deprecated Use #run
+   */
+  public Run(input: NodeJS.ReadableStream = process.stdin, output: NodeJS.WritableStream = process.stdout) {
+    return this.run(input, output);
+  }
 }

--- a/packages/libs/extension-base/src/extension-host.ts
+++ b/packages/libs/extension-base/src/extension-host.ts
@@ -59,6 +59,21 @@ export interface AutorestExtensionHost {
    * @deprecated
    */
   GetConfigurationFile(filename: string): Promise<string>;
+
+  /**
+   * @deprecated use #writeFile
+   */
+  WriteFile(filename: string, content: string): void;
+
+  /**
+   * @deprecated use #getValue
+   */
+  GetValue(key: string): any;
+
+  /**
+   * @deprecated use #message
+   */
+  Message(message: Message): any;
 }
 
 export class AutorestExtensionRpcHost implements AutorestExtensionHost {
@@ -67,7 +82,6 @@ export class AutorestExtensionRpcHost implements AutorestExtensionHost {
   public constructor(private channel: MessageConnection, private sessionId: string) {
     this.logger = new AutorestExtensionLogger((x) => this.message(x));
   }
-
   /**
    * Protect files that will not be cleared when using clear-output-folder.
    * @param path Path to the file/folder to protect.
@@ -131,6 +145,27 @@ export class AutorestExtensionRpcHost implements AutorestExtensionHost {
    */
   public message(message: Message): void {
     this.channel.sendNotification(IAutoRestPluginInitiatorTypes.Message, this.sessionId, message);
+  }
+
+  /**
+   * @deprecated
+   */
+  public WriteFile(filename: string, content: string) {
+    return this.writeFile({ filename, content });
+  }
+
+  /**
+   * @deprecated
+   */
+  public GetValue(key: string) {
+    return this.getValue(key);
+  }
+
+  /**
+   * @deprecated
+   */
+  public Message(message: Message) {
+    return this.message(message);
   }
 
   /**

--- a/packages/libs/extension-base/src/testing/test-session.ts
+++ b/packages/libs/extension-base/src/testing/test-session.ts
@@ -72,6 +72,6 @@ export async function createTestSession<TInputModel>(
     message: sendMessage,
     UpdateConfigurationFile: (filename: string, content: string) => {},
     GetConfigurationFile: (filename: string) => Promise.resolve(""),
-  });
+  } as any);
   return { session, errors };
 }


### PR DESCRIPTION
Version `3.4.0` of extension-base introduce breaking changes and typescript extension had the version not locked to patch using `~`.