### PR TITLE
Fix: Loading configuration nested under the same as a flag 

### DIFF
--- a/common/changes/@autorest/common/fix-merging-config_2021-12-01-16-29.json
+++ b/common/changes/@autorest/common/fix-merging-config_2021-12-01-16-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/common",
+      "comment": "**Fix** configuration loading issue with nested config `az:`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/common",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/configuration/fix-merging-config_2021-12-01-16-29.json
+++ b/common/changes/@autorest/configuration/fix-merging-config_2021-12-01-16-29.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "",
+      "type": "none"
+    }
+  ],
+  "packageName": "@autorest/configuration",
+  "email": "tiguerin@microsoft.com"
+}

--- a/markdown-link-check-config.json
+++ b/markdown-link-check-config.json
@@ -1,5 +1,9 @@
 {
-  "ignorePatterns": [],
+  "ignorePatterns": [
+    {
+      "pattern": "^https://msdn.microsoft.com/en-us/library/azure/dn790568.aspx"
+    }
+  ],
   "replacementPatterns": [
     {
       "pattern": "https://github\\.com/Azure/autorest/(?:blob|tree)/main/",

--- a/packages/libs/common/src/merging/merging.test.ts
+++ b/packages/libs/common/src/merging/merging.test.ts
@@ -68,6 +68,12 @@ describe("Merging", () => {
       });
     });
 
+    it("override true if lower priority is an object", () => {
+      expect(mergeOverwriteOrAppend(true, { foo: "bar" }, { concatListPathFilter: (_) => false })).toEqual({
+        foo: "bar",
+      });
+    });
+
     it("combine a complex object", () => {
       const value = mergeOverwriteOrAppend(
         { a: 1, b: 1, c: { a: 1, b: { a: 1, b: 1 } }, d: [{ a: 1, b: 1 }] },

--- a/packages/libs/common/src/merging/merging.ts
+++ b/packages/libs/common/src/merging/merging.ts
@@ -171,6 +171,15 @@ export function mergeOverwriteOrAppend(
     interpolationContext: options.interpolationContext ?? higherPriority,
   };
 
+  // if (higherPriority === true && typeof lowerPriority.extensions) {
+  //   console.log("Merge", higherPriority, lowerPriority);
+  // }
+
+  // Take care of the case where an option is enable via a flag `--az` and then nested config under it don't work(az.extensions)
+  if (higherPriority === true && typeof lowerPriority === "object") {
+    return lowerPriority;
+  }
+
   // scalars/arrays involved
   if (
     typeof higherPriority !== "object" ||
@@ -185,6 +194,7 @@ export function mergeOverwriteOrAppend(
   const result: any = {};
 
   const keys = getKeysInOrder(higherPriority, lowerPriority, computedOptions);
+
   for (const key of keys) {
     const subpath = path.concat(key);
 

--- a/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
+++ b/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
@@ -116,7 +116,7 @@ export class ConfigurationLoader {
       await manager.addConfig(result.value);
     }
     await resolveRequiredConfigs(this.fileSystem);
-
+    console.log("AZ1", ((await resolveConfig()) as any)["az"]);
     // 2. file
     if (configFileUri != null && configFileUri !== undefined) {
       // add loaded files to the input files.

--- a/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
+++ b/packages/libs/configuration/src/configuration-loader/configuration-loader.ts
@@ -116,7 +116,6 @@ export class ConfigurationLoader {
       await manager.addConfig(result.value);
     }
     await resolveRequiredConfigs(this.fileSystem);
-    console.log("AZ1", ((await resolveConfig()) as any)["az"]);
     // 2. file
     if (configFileUri != null && configFileUri !== undefined) {
       // add loaded files to the input files.

--- a/packages/libs/configuration/test/expected/nested-flag.yaml
+++ b/packages/libs/configuration/test/expected/nested-flag.yaml
@@ -1,0 +1,18 @@
+az:
+  extension: myextension
+base-folder: .
+debug: false
+directive: []
+disable-validation: false
+exclude-file: []
+input-file: []
+output-artifact: []
+output-folder: generated
+pass-thru: []
+profile: []
+require: []
+suppressions: []
+try-require: []
+use: []
+use-extension: {}
+verbose: false

--- a/packages/libs/configuration/test/inputs/nested-flag/main.md
+++ b/packages/libs/configuration/test/inputs/nested-flag/main.md
@@ -1,0 +1,10 @@
+# Nested config & Flag scenario
+
+```yaml
+az: true
+```
+
+```yaml
+az:
+  extension: myextension
+```

--- a/packages/libs/configuration/test/scenarios.test.ts
+++ b/packages/libs/configuration/test/scenarios.test.ts
@@ -22,4 +22,8 @@ describe("Configuration scenarios", () => {
   it("require", async () => {
     await testScenario("require");
   });
+
+  it("nested-flag", async () => {
+    await testScenario("nested-flag");
+  });
 });


### PR DESCRIPTION
Plugins that depends on nested configuration under the same key as the flag wouldn't get merged.