### PR TITLE
Update swagger-extensions.json

### DIFF
--- a/common/changes/@autorest/schemas/x-ms-examples_2022-02-11-15-41.json
+++ b/common/changes/@autorest/schemas/x-ms-examples_2022-02-11-15-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/schemas",
+      "comment": "Fix `x-ms-examples` schema reference",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/schemas",
+  "email": "leni@microsoft.com"
+}

--- a/packages/libs/autorest-schemas/example-schema.json
+++ b/packages/libs/autorest-schemas/example-schema.json
@@ -1,6 +1,6 @@
 {
   "title": "A JSON Schema for x-ms-examples extension in Swagger 2.0 API.",
-  "$id": "https://raw.githubusercontent.com/Azure/autorest/master/packages/libs/autorest-schemas/example-schema.json#",
+  "$id": "https://raw.githubusercontent.com/Azure/autorest/main/packages/libs/autorest-schemas/example-schema.json#",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "required": ["parameters", "responses"],

--- a/packages/libs/autorest-schemas/swagger-extensions.json
+++ b/packages/libs/autorest-schemas/swagger-extensions.json
@@ -1852,7 +1852,7 @@
           "$ref": "#/definitions/jsonReference"
         },
         "else": {
-          "$ref": "https://raw.githubusercontent.com/Azure/autorest/master/schema/example-schema.json#"
+          "$ref": "https://raw.githubusercontent.com/Azure/autorest/main/packages/libs/autorest-schemas/example-schema.json#"
         }
       }
     }


### PR DESCRIPTION
The `x-ms-examples` schema is referenced in azure-rest-api-specs repo documentation (see https://github.com/Azure/azure-rest-api-specs/pull/17819)