### PR TITLE
Add original operation id

### DIFF
--- a/common/changes/@autorest/codemodel/feature-operationId_2022-02-26-02-07.json
+++ b/common/changes/@autorest/codemodel/feature-operationId_2022-02-26-02-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/codemodel",
+      "comment": "Add `operationId` on Operation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/codemodel",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/modelerfour/feature-operationId_2022-02-26-02-07.json
+++ b/common/changes/@autorest/modelerfour/feature-operationId_2022-02-26-02-07.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "Add support for setting original `operationId` on operation",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/modelerfour/src/modeler/interpretations.ts
+++ b/packages/extensions/modelerfour/src/modeler/interpretations.ts
@@ -310,9 +310,16 @@ export class Interpretations {
     );
   }
 
-  getOperationId(httpMethod: string, path: string, original: OpenAPI.HttpOperation) {
+  getOperationId(
+    httpMethod: string,
+    path: string,
+    original: OpenAPI.HttpOperation,
+  ): { member: string; group: string; operationId?: string } {
     if (original.operationId) {
-      return this.splitOpId(original.operationId);
+      return {
+        ...this.splitOpId(original.operationId),
+        operationId: original.operationId,
+      };
     }
 
     // synthesize from tags.

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -1642,11 +1642,12 @@ export class ModelerFour {
     path = p > -1 ? path.substring(0, p) : path;
 
     // get group and operation name
-    const { group, member } = this.interpret.getOperationId(method, path, httpOperation);
+    const { group, member, operationId } = this.interpret.getOperationId(method, path, httpOperation);
     const memberName = httpOperation["x-ms-client-name"] ?? member;
     const operationGroup = this.codeModel.getOperationGroup(group);
     const operation = operationGroup.addOperation(
       new Operation(memberName, this.interpret.getDescription("", httpOperation), {
+        operationId,
         extensions: this.interpret.getExtensionProperties(httpOperation),
         apiVersions: this.interpret.getApiVersions(pathItem),
         deprecated: this.interpret.getDeprecation(httpOperation),

--- a/packages/extensions/modelerfour/test/scenarios/expected/body-binary-json/modeler.yaml
+++ b/packages/extensions/modelerfour/test/scenarios/expected/body-binary-json/modeler.yaml
@@ -52,6 +52,7 @@ operationGroups:
     $key: Upload
     operations:
       - !Operation 
+        operationId: Upload_File
         apiVersions:
           - !ApiVersion 
             version: 1.0.0

--- a/packages/extensions/modelerfour/test/scenarios/expected/custom-content-type-parm/modeler.yaml
+++ b/packages/extensions/modelerfour/test/scenarios/expected/custom-content-type-parm/modeler.yaml
@@ -56,6 +56,7 @@ operationGroups:
     $key: ''
     operations:
       - !Operation 
+        operationId: postWithCustomContentType
         apiVersions:
           - !ApiVersion 
             version: 1.0.0

--- a/packages/extensions/modelerfour/test/scenarios/expected/nested-dictionaries/modeler.yaml
+++ b/packages/extensions/modelerfour/test/scenarios/expected/nested-dictionaries/modeler.yaml
@@ -57,6 +57,7 @@ operationGroups:
     $key: dictionary
     operations:
       - !Operation 
+        operationId: dictionary_getDictionaryValid
         apiVersions:
           - !ApiVersion 
             version: test-0.1

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -866,6 +866,10 @@
       "description": "represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)",
       "type": "object",
       "properties": {
+        "operationId": {
+          "description": "Original Operation ID if present.\nThis can be used to identify the original id of an operation before it is styled.",
+          "type": "string"
+        },
         "parameters": {
           "description": "common parameters when there are multiple requests",
           "type": "array",

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -867,7 +867,7 @@
       "type": "object",
       "properties": {
         "operationId": {
-          "description": "Original Operation ID if present.\nThis can be used to identify the original id of an operation before it is styled.",
+          "description": "Original Operation ID if present.\nThis can be used to identify the original id of an operation before it is styled.\nTHIS IS NOT the name of the operation that should be used in the generator. Use `.language.default.name` for this",
           "type": "string"
         },
         "parameters": {

--- a/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -1281,6 +1281,7 @@ definitions:
         description: |-
           Original Operation ID if present.
           This can be used to identify the original id of an operation before it is styled.
+          THIS IS NOT the name of the operation that should be used in the generator. Use `.language.default.name` for this
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions

--- a/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -1276,6 +1276,11 @@ definitions:
     description: represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)
     additionalProperties: false
     properties:
+      operationId:
+        type: string
+        description: |-
+          Original Operation ID if present.
+          This can be used to identify the original id of an operation before it is styled.
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -608,6 +608,10 @@
       "description": "represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)",
       "type": "object",
       "properties": {
+        "operationId": {
+          "description": "Original Operation ID if present.\nThis can be used to identify the original id of an operation before it is styled.",
+          "type": "string"
+        },
         "parameters": {
           "description": "common parameters when there are multiple requests",
           "type": "array",

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -609,7 +609,7 @@
       "type": "object",
       "properties": {
         "operationId": {
-          "description": "Original Operation ID if present.\nThis can be used to identify the original id of an operation before it is styled.",
+          "description": "Original Operation ID if present.\nThis can be used to identify the original id of an operation before it is styled.\nTHIS IS NOT the name of the operation that should be used in the generator. Use `.language.default.name` for this",
           "type": "string"
         },
         "parameters": {

--- a/packages/libs/codemodel/.resources/model/yaml/master.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/master.yaml
@@ -323,6 +323,11 @@ definitions:
     description: represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)
     additionalProperties: false
     properties:
+      operationId:
+        type: string
+        description: |-
+          Original Operation ID if present.
+          This can be used to identify the original id of an operation before it is styled.
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions

--- a/packages/libs/codemodel/.resources/model/yaml/master.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/master.yaml
@@ -328,6 +328,7 @@ definitions:
         description: |-
           Original Operation ID if present.
           This can be used to identify the original id of an operation before it is styled.
+          THIS IS NOT the name of the operation that should be used in the generator. Use `.language.default.name` for this
       apiVersions:
         type: array
         description: API versions that this applies to. Undefined means all versions

--- a/packages/libs/codemodel/src/model/common/operation.ts
+++ b/packages/libs/codemodel/src/model/common/operation.ts
@@ -11,6 +11,7 @@ export interface Operation extends Aspect {
   /**
    * Original Operation ID if present.
    * This can be used to identify the original id of an operation before it is styled.
+   * THIS IS NOT the name of the operation that should be used in the generator. Use `.language.default.name` for this
    */
   operationId?: string;
 

--- a/packages/libs/codemodel/src/model/common/operation.ts
+++ b/packages/libs/codemodel/src/model/common/operation.ts
@@ -8,6 +8,12 @@ import { SchemaType } from "./schema-type";
 
 /** represents a single callable endpoint with a discrete set of inputs, and any number of output possibilities (responses or exceptions)  */
 export interface Operation extends Aspect {
+  /**
+   * Original Operation ID if present.
+   * This can be used to identify the original id of an operation before it is styled.
+   */
+  operationId?: string;
+
   /** common parameters when there are multiple requests */
   parameters?: Array<Parameter>;
 


### PR DESCRIPTION
fix #4427

Add a new field `operationId` on the operation object. This is a direct mapping of the original operation ID from the spec.