### PR TITLE
Generalize security authentication

### DIFF
--- a/common/changes/@autorest/codemodel/feature-security-generalization_2022-03-09-00-23.json
+++ b/common/changes/@autorest/codemodel/feature-security-generalization_2022-03-09-00-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/codemodel",
+      "comment": "**Breaking** Renamed `AADTokenSecurityScheme` to `OAuth2SecurityScheme` and renamed `AzureKeySecurityScheme` to `KeySecurityScheme`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/codemodel",
+  "email": "tiguerin@microsoft.com"
+}

--- a/common/changes/@autorest/modelerfour/feature-security-generalization_2022-03-09-00-23.json
+++ b/common/changes/@autorest/modelerfour/feature-security-generalization_2022-03-09-00-23.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/modelerfour",
+      "comment": "Generalize security scheme by allowing AAD Token ",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/modelerfour",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/modelerfour/src/modeler/security-processor.test.ts
+++ b/packages/extensions/modelerfour/src/modeler/security-processor.test.ts
@@ -1,4 +1,4 @@
-import { AADTokenSecurityScheme, AzureKeySecurityScheme } from "@autorest/codemodel";
+import { OAuth2SecurityScheme, KeySecurityScheme } from "@autorest/codemodel";
 import oai3, { ParameterLocation, SecurityType } from "@azure-tools/openapi";
 import { createTestSessionFromModel } from "../../test/utils";
 import { Interpretations } from "./interpretations";
@@ -13,7 +13,7 @@ const baseOpenapiSpec = {
   paths: {},
 };
 
-const AADTokenSecuritySchemeDef: oai3.SecurityScheme = {
+const OAuth2SecuritySchemeDef: oai3.SecurityScheme = {
   "x-ms-metadata": {
     name: "AADToken",
   },
@@ -26,7 +26,7 @@ const AADTokenSecuritySchemeDef: oai3.SecurityScheme = {
   },
 };
 
-const AzureKeySecuritySchemeDef: oai3.SecurityScheme = {
+const KeySecuritySchemeDef: oai3.SecurityScheme = {
   "x-ms-metadata": {
     name: "AzureKey",
   },
@@ -56,14 +56,14 @@ describe("Security Processor", () => {
         ...baseOpenapiSpec,
         components: {
           securitySchemes: {
-            AADToken: AADTokenSecuritySchemeDef,
+            AADToken: OAuth2SecuritySchemeDef,
           },
         },
         security: [{ AADToken: ["https://myresource.com/.default"] }],
       });
 
       expect(security.authenticationRequired).toBe(true);
-      expect(security.schemes).toEqual([new AADTokenSecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
+      expect(security.schemes).toEqual([new OAuth2SecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
     });
 
     it("configure Azure Key security", async () => {
@@ -71,14 +71,14 @@ describe("Security Processor", () => {
         ...baseOpenapiSpec,
         components: {
           securitySchemes: {
-            AzureKey: AzureKeySecuritySchemeDef,
+            AzureKey: KeySecuritySchemeDef,
           },
         },
         security: [{ AzureKey: [] }],
       });
 
       expect(security.authenticationRequired).toBe(true);
-      expect(security.schemes).toEqual([new AzureKeySecurityScheme({ headerName: "my-header-name" })]);
+      expect(security.schemes).toEqual([new KeySecurityScheme({ in: "header", name: "my-header-name" })]);
     });
 
     it("configure multiple security", async () => {
@@ -86,8 +86,8 @@ describe("Security Processor", () => {
         ...baseOpenapiSpec,
         components: {
           securitySchemes: {
-            AADToken: AADTokenSecuritySchemeDef,
-            AzureKey: AzureKeySecuritySchemeDef,
+            AADToken: OAuth2SecuritySchemeDef,
+            AzureKey: KeySecuritySchemeDef,
           },
         },
         security: [{ AADToken: ["https://myresource.com/.default"] }, { AzureKey: [] }],
@@ -95,8 +95,8 @@ describe("Security Processor", () => {
 
       expect(security.authenticationRequired).toBe(true);
       expect(security.schemes).toEqual([
-        new AADTokenSecurityScheme({ scopes: ["https://myresource.com/.default"] }),
-        new AzureKeySecurityScheme({ headerName: "my-header-name" }),
+        new OAuth2SecurityScheme({ scopes: ["https://myresource.com/.default"] }),
+        new KeySecurityScheme({ in: "header", name: "my-header-name" }),
       ]);
     });
 
@@ -105,14 +105,14 @@ describe("Security Processor", () => {
         ...baseOpenapiSpec,
         components: {
           securitySchemes: {
-            AADToken: AADTokenSecuritySchemeDef,
+            AADToken: OAuth2SecuritySchemeDef,
           },
         },
         security: [{ AADToken: ["https://myresource.com/.default"] }, {}],
       });
 
       expect(security.authenticationRequired).toBe(false);
-      expect(security.schemes).toEqual([new AADTokenSecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
+      expect(security.schemes).toEqual([new OAuth2SecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
     });
 
     it("raise an error if referencing undefined security scheme", async () => {
@@ -121,7 +121,7 @@ describe("Security Processor", () => {
           ...baseOpenapiSpec,
           components: {
             securitySchemes: {
-              AADToken: AADTokenSecuritySchemeDef,
+              AADToken: OAuth2SecuritySchemeDef,
             },
           },
           security: [{ ThisIsNotDefined: ["https://myresource.com/.default"] }, {}],
@@ -138,7 +138,7 @@ describe("Security Processor", () => {
       });
 
       expect(security.authenticationRequired).toBe(true);
-      expect(security.schemes).toEqual([new AADTokenSecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
+      expect(security.schemes).toEqual([new OAuth2SecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
     });
 
     it("configure Azure Key security", async () => {
@@ -148,7 +148,7 @@ describe("Security Processor", () => {
       });
 
       expect(security.authenticationRequired).toBe(true);
-      expect(security.schemes).toEqual([new AzureKeySecurityScheme({ headerName: "my-header-name" })]);
+      expect(security.schemes).toEqual([new KeySecurityScheme({ in: "header", name: "my-header-name" })]);
     });
 
     it("configure multiple security", async () => {
@@ -160,8 +160,8 @@ describe("Security Processor", () => {
 
       expect(security.authenticationRequired).toBe(true);
       expect(security.schemes).toEqual([
-        new AADTokenSecurityScheme({ scopes: ["https://myresource.com/.default"] }),
-        new AzureKeySecurityScheme({ headerName: "my-header-name" }),
+        new OAuth2SecurityScheme({ scopes: ["https://myresource.com/.default"] }),
+        new KeySecurityScheme({ in: "header", name: "my-header-name" }),
       ]);
     });
 
@@ -172,7 +172,7 @@ describe("Security Processor", () => {
       });
 
       expect(security.authenticationRequired).toBe(false);
-      expect(security.schemes).toEqual([new AADTokenSecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
+      expect(security.schemes).toEqual([new OAuth2SecurityScheme({ scopes: ["https://myresource.com/.default"] })]);
     });
 
     it("raise an error if passing unknown security scheme", async () => {
@@ -194,7 +194,7 @@ describe("Security Processor", () => {
 
       expect(security.authenticationRequired).toBe(true);
       expect(security.schemes).toEqual([
-        new AADTokenSecurityScheme({ scopes: ["https://management.azure.com/.default"] }),
+        new OAuth2SecurityScheme({ scopes: ["https://management.azure.com/.default"] }),
       ]);
     });
   });

--- a/packages/extensions/modelerfour/src/modeler/security-processor.ts
+++ b/packages/extensions/modelerfour/src/modeler/security-processor.ts
@@ -1,4 +1,4 @@
-import { AADTokenSecurityScheme, AzureKeySecurityScheme, Security, SecurityScheme } from "@autorest/codemodel";
+import { OAuth2SecurityScheme, KeySecurityScheme, Security, SecurityScheme } from "@autorest/codemodel";
 import { Session } from "@autorest/extension-base";
 import * as oai3 from "@azure-tools/openapi";
 import { dereference, ParameterLocation, Refable } from "@azure-tools/openapi";
@@ -65,7 +65,7 @@ export class SecurityProcessor {
 
     return new Security(true, {
       schemes: [
-        new AADTokenSecurityScheme({
+        new OAuth2SecurityScheme({
           scopes: this.securityConfig.scopes ?? [ArmDefaultScope],
         }),
       ],
@@ -99,11 +99,11 @@ export class SecurityProcessor {
   private getSecuritySchemeFromConfig(name: string): SecurityScheme | undefined {
     switch (name) {
       case KnownSecurityScheme.AADToken:
-        return new AADTokenSecurityScheme({
+        return new OAuth2SecurityScheme({
           scopes: this.securityConfig.scopes,
         });
       case KnownSecurityScheme.AzureKey:
-        return new AzureKeySecurityScheme({
+        return new KeySecurityScheme({
           headerName: this.securityConfig.headerName,
         });
       case KnownSecurityScheme.Anonymous:
@@ -153,7 +153,7 @@ export class SecurityProcessor {
           throw new Error(`Couldn't find a scheme defined in the securitySchemes with name: ${name}`);
         }
 
-        const processedScheme = this.processSecurityScheme(name, oai3SecurityRequirement[name], scheme);
+        const processedScheme = this.processSecurityScheme(oai3SecurityRequirement[name], scheme);
         if (processedScheme !== undefined) {
           schemes.push(processedScheme);
         } else {
@@ -183,26 +183,19 @@ export class SecurityProcessor {
     return map;
   }
 
-  private processSecurityScheme(
-    name: string,
-    scopes: string[],
-    scheme: oai3.SecurityScheme,
-  ): SecurityScheme | undefined {
-    if (name === KnownSecurityScheme.AADToken) {
-      return new AADTokenSecurityScheme({
+  private processSecurityScheme(scopes: string[], scheme: oai3.SecurityScheme): SecurityScheme | undefined {
+    if (scheme.type === "oauth2") {
+      return new OAuth2SecurityScheme({
         scopes: scopes,
       });
-    } else if (name === KnownSecurityScheme.AzureKey) {
-      if (scheme.type !== oai3.SecurityType.ApiKey) {
-        throw new Error(`AzureKey security scheme should be of type 'apiKey' but was '${scheme.type}'`);
-      }
-
+    } else if (scheme.type === "apiKey") {
       if (scheme.in !== ParameterLocation.Header) {
         throw new Error(`AzureKey security scheme should be of in 'header' but was '${scheme.in}'`);
       }
 
-      return new AzureKeySecurityScheme({
+      return new KeySecurityScheme({
         headerName: scheme.name,
+        in: "header",
       });
     } else {
       return undefined;

--- a/packages/extensions/modelerfour/src/modeler/security-processor.ts
+++ b/packages/extensions/modelerfour/src/modeler/security-processor.ts
@@ -104,7 +104,8 @@ export class SecurityProcessor {
         });
       case KnownSecurityScheme.AzureKey:
         return new KeySecurityScheme({
-          headerName: this.securityConfig.headerName,
+          in: "header",
+          name: this.securityConfig.headerName,
         });
       case KnownSecurityScheme.Anonymous:
         return undefined;
@@ -194,7 +195,7 @@ export class SecurityProcessor {
       }
 
       return new KeySecurityScheme({
-        headerName: scheme.name,
+        name: scheme.name,
         in: "header",
       });
     } else {

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -2285,15 +2285,15 @@
             "header"
           ]
         },
-        "headerName": {
+        "name": {
           "type": "string"
         }
       },
       "defaultProperties": [],
       "additionalProperties": false,
       "required": [
-        "headerName",
         "in",
+        "name",
         "type"
       ],
       "allOf": [

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -2254,7 +2254,7 @@
         "type"
       ]
     },
-    "AADTokenSecurityScheme": {
+    "OAuth2SecurityScheme": {
       "type": "object",
       "properties": {
         "scopes": {
@@ -2276,9 +2276,15 @@
         }
       ]
     },
-    "AzureKeySecurityScheme": {
+    "KeySecurityScheme": {
       "type": "object",
       "properties": {
+        "in": {
+          "type": "string",
+          "enum": [
+            "header"
+          ]
+        },
         "headerName": {
           "type": "string"
         }
@@ -2287,6 +2293,7 @@
       "additionalProperties": false,
       "required": [
         "headerName",
+        "in",
         "type"
       ],
       "allOf": [
@@ -2509,33 +2516,6 @@
       "additionalProperties": false,
       "required": [
         "scheme",
-        "type"
-      ]
-    },
-    "OAuth2SecurityScheme": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "oauth2"
-          ]
-        },
-        "flows": {
-          "$ref": "#/definitions/OAuthFlows"
-        },
-        "description": {
-          "type": "string"
-        },
-        "extensions": {
-          "$ref": "#/definitions/Record<string,any>",
-          "description": "additional metadata extensions dictionary"
-        }
-      },
-      "defaultProperties": [],
-      "additionalProperties": false,
-      "required": [
-        "flows",
         "type"
       ]
     },

--- a/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -3,19 +3,6 @@ description: the model that contains all the information required to generate a 
 $schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false
 definitions:
-  AADTokenSecurityScheme:
-    type: object
-    additionalProperties: false
-    allOf:
-      - $ref: '#/definitions/SecurityScheme'
-    properties:
-      scopes:
-        type: array
-        items:
-          type: string
-    required:
-      - scopes
-      - type
   APIKeySecurityScheme:
     type: object
     additionalProperties: false
@@ -170,17 +157,6 @@ definitions:
       - authorizationUrl
       - scopes
       - tokenUrl
-  AzureKeySecurityScheme:
-    type: object
-    additionalProperties: false
-    allOf:
-      - $ref: '#/definitions/SecurityScheme'
-    properties:
-      headerName:
-        type: string
-    required:
-      - headerName
-      - type
   BearerHTTPSecurityScheme:
     type: object
     additionalProperties: false
@@ -1014,6 +990,22 @@ definitions:
         $ref: '#/definitions/Record<string,any>'
     required:
       - title
+  KeySecurityScheme:
+    type: object
+    additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/SecurityScheme'
+    properties:
+      headerName:
+        type: string
+      in:
+        type: string
+        enum:
+          - header
+    required:
+      - headerName
+      - in
+      - type
   KnownMediaType:
     type: string
     enum:
@@ -1173,20 +1165,15 @@ definitions:
   OAuth2SecurityScheme:
     type: object
     additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/SecurityScheme'
     properties:
-      type:
-        type: string
-        enum:
-          - oauth2
-      description:
-        type: string
-      flows:
-        $ref: '#/definitions/OAuthFlows'
-      extensions:
-        description: additional metadata extensions dictionary
-        $ref: '#/definitions/Record<string,any>'
+      scopes:
+        type: array
+        items:
+          type: string
     required:
-      - flows
+      - scopes
       - type
   OAuthFlows:
     type: object

--- a/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -996,15 +996,15 @@ definitions:
     allOf:
       - $ref: '#/definitions/SecurityScheme'
     properties:
-      headerName:
+      name:
         type: string
       in:
         type: string
         enum:
           - header
     required:
-      - headerName
       - in
+      - name
       - type
   KnownMediaType:
     type: string

--- a/packages/libs/codemodel/.resources/model/json/http.json
+++ b/packages/libs/codemodel/.resources/model/json/http.json
@@ -14,6 +14,28 @@
         "type"
       ]
     },
+    "OAuth2SecurityScheme": {
+      "type": "object",
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false,
+      "required": [
+        "scopes",
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "./http.json#/definitions/SecurityScheme"
+        }
+      ]
+    },
     "AuthorizationCodeOAuthFlow": {
       "type": "object",
       "properties": {
@@ -154,33 +176,6 @@
       "additionalProperties": false,
       "required": [
         "scheme",
-        "type"
-      ]
-    },
-    "OAuth2SecurityScheme": {
-      "type": "object",
-      "properties": {
-        "type": {
-          "type": "string",
-          "enum": [
-            "oauth2"
-          ]
-        },
-        "flows": {
-          "$ref": "./http.json#/definitions/OAuthFlows"
-        },
-        "description": {
-          "type": "string"
-        },
-        "extensions": {
-          "$ref": "./master.json#/definitions/Record<string,any>",
-          "description": "additional metadata extensions dictionary"
-        }
-      },
-      "defaultProperties": [],
-      "additionalProperties": false,
-      "required": [
-        "flows",
         "type"
       ]
     },

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -935,31 +935,15 @@
         "schemes"
       ]
     },
-    "AADTokenSecurityScheme": {
+    "KeySecurityScheme": {
       "type": "object",
       "properties": {
-        "scopes": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        }
-      },
-      "defaultProperties": [],
-      "additionalProperties": false,
-      "required": [
-        "scopes",
-        "type"
-      ],
-      "allOf": [
-        {
-          "$ref": "./http.json#/definitions/SecurityScheme"
-        }
-      ]
-    },
-    "AzureKeySecurityScheme": {
-      "type": "object",
-      "properties": {
+        "in": {
+          "type": "string",
+          "enum": [
+            "header"
+          ]
+        },
         "headerName": {
           "type": "string"
         }
@@ -968,6 +952,7 @@
       "additionalProperties": false,
       "required": [
         "headerName",
+        "in",
         "type"
       ],
       "allOf": [

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -944,15 +944,15 @@
             "header"
           ]
         },
-        "headerName": {
+        "name": {
           "type": "string"
         }
       },
       "defaultProperties": [],
       "additionalProperties": false,
       "required": [
-        "headerName",
         "in",
+        "name",
         "type"
       ],
       "allOf": [

--- a/packages/libs/codemodel/.resources/model/yaml/http.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/http.yaml
@@ -379,20 +379,15 @@ definitions:
   OAuth2SecurityScheme:
     type: object
     additionalProperties: false
+    allOf:
+      - $ref: ./http.yaml#/definitions/SecurityScheme
     properties:
-      type:
-        type: string
-        enum:
-          - oauth2
-      description:
-        type: string
-      flows:
-        $ref: ./http.yaml#/definitions/OAuthFlows
-      extensions:
-        description: additional metadata extensions dictionary
-        $ref: ./master.yaml#/definitions/Record<string,any>
+      scopes:
+        type: array
+        items:
+          type: string
     required:
-      - flows
+      - scopes
       - type
   OAuthFlows:
     type: object

--- a/packages/libs/codemodel/.resources/model/yaml/master.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/master.yaml
@@ -3,19 +3,6 @@ description: the model that contains all the information required to generate a 
 $schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false
 definitions:
-  AADTokenSecurityScheme:
-    type: object
-    additionalProperties: false
-    allOf:
-      - $ref: ./http.yaml#/definitions/SecurityScheme
-    properties:
-      scopes:
-        type: array
-        items:
-          type: string
-    required:
-      - scopes
-      - type
   ApiVersion:
     type: object
     description: |-
@@ -47,17 +34,6 @@ definitions:
     description: a collection of api versions
     items:
       $ref: ./master.yaml#/definitions/ApiVersion
-  AzureKeySecurityScheme:
-    type: object
-    additionalProperties: false
-    allOf:
-      - $ref: ./http.yaml#/definitions/SecurityScheme
-    properties:
-      headerName:
-        type: string
-    required:
-      - headerName
-      - type
   BinaryResponse:
     type: object
     description: a response where the content should be treated as a binary instead of a value or object
@@ -235,6 +211,22 @@ definitions:
         $ref: ./master.yaml#/definitions/Record<string,any>
     required:
       - title
+  KeySecurityScheme:
+    type: object
+    additionalProperties: false
+    allOf:
+      - $ref: ./http.yaml#/definitions/SecurityScheme
+    properties:
+      headerName:
+        type: string
+      in:
+        type: string
+        enum:
+          - header
+    required:
+      - headerName
+      - in
+      - type
   Language:
     type: object
     description: the bare-minimum fields for per-language metadata on a given aspect

--- a/packages/libs/codemodel/.resources/model/yaml/master.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/master.yaml
@@ -217,15 +217,15 @@ definitions:
     allOf:
       - $ref: ./http.yaml#/definitions/SecurityScheme
     properties:
-      headerName:
+      name:
         type: string
       in:
         type: string
         enum:
           - header
     required:
-      - headerName
       - in
+      - name
       - type
   Language:
     type: object

--- a/packages/libs/codemodel/src/model/common/security.ts
+++ b/packages/libs/codemodel/src/model/common/security.ts
@@ -42,7 +42,7 @@ export class OAuth2SecurityScheme implements OAuth2SecurityScheme {
 export interface KeySecurityScheme extends SecurityScheme {
   type: "Key";
   in: "header";
-  headerName: string;
+  name: string;
 }
 
 export class KeySecurityScheme implements KeySecurityScheme {

--- a/packages/libs/codemodel/src/model/common/security.ts
+++ b/packages/libs/codemodel/src/model/common/security.ts
@@ -27,26 +27,27 @@ export interface SecurityScheme {
   type: string;
 }
 
-export interface AADTokenSecurityScheme extends SecurityScheme {
-  type: "AADToken";
+export interface OAuth2SecurityScheme extends SecurityScheme {
+  type: "OAuth2";
   scopes: string[];
 }
 
-export class AADTokenSecurityScheme implements AADTokenSecurityScheme {
-  public constructor(objectInitializer?: DeepPartial<AADTokenSecurityScheme>) {
-    this.type = "AADToken";
+export class OAuth2SecurityScheme implements OAuth2SecurityScheme {
+  public constructor(objectInitializer?: DeepPartial<OAuth2SecurityScheme>) {
+    this.type = "OAuth2";
     Object.assign(this, objectInitializer);
   }
 }
 
-export interface AzureKeySecurityScheme extends SecurityScheme {
-  type: "AzureKey";
+export interface KeySecurityScheme extends SecurityScheme {
+  type: "Key";
+  in: "header";
   headerName: string;
 }
 
-export class AzureKeySecurityScheme implements AzureKeySecurityScheme {
-  public constructor(objectInitializer?: DeepPartial<AzureKeySecurityScheme>) {
-    this.type = "AzureKey";
+export class KeySecurityScheme implements KeySecurityScheme {
+  public constructor(objectInitializer?: DeepPartial<KeySecurityScheme>) {
+    this.type = "Key";
     Object.assign(this, objectInitializer);
   }
 }

--- a/packages/libs/codemodel/src/model/yaml-schema.ts
+++ b/packages/libs/codemodel/src/model/yaml-schema.ts
@@ -26,7 +26,7 @@ import { BooleanSchema, CharSchema } from "./common/schemas/primitive";
 import { OrSchema, XorSchema } from "./common/schemas/relationship";
 import { StringSchema, ODataQuerySchema, CredentialSchema, UriSchema, UuidSchema } from "./common/schemas/string";
 import { DurationSchema, DateTimeSchema, DateSchema, UnixTimeSchema, TimeSchema } from "./common/schemas/time";
-import { AADTokenSecurityScheme, AzureKeySecurityScheme, Security } from "./common/security";
+import { OAuth2SecurityScheme, KeySecurityScheme, Security } from "./common/security";
 import { Value } from "./common/value";
 import {
   HttpWithBodyRequest,
@@ -138,8 +138,8 @@ export const codeModelSchema = DEFAULT_SCHEMA.extend([
   TypeInfo(License),
   TypeInfo(OperationGroup),
 
-  TypeInfo(AADTokenSecurityScheme),
-  TypeInfo(AzureKeySecurityScheme),
+  TypeInfo(OAuth2SecurityScheme),
+  TypeInfo(KeySecurityScheme),
   TypeInfo(Languages),
   TypeInfo(Language),
   TypeInfo(CSharpLanguage),


### PR DESCRIPTION
fix #4426

**Breaking change for generators:**
- Renamed `AADTokenSecurityScheme` to `OAuth2SecurityScheme`
- Renamed `AzureKeySecurityScheme` to `KeySecurityScheme`
   - Property `headerName` renamed to `name`
   - Added property `in` which can only be `header` for now.