### PR TITLE
`--help` usage include `yaml` and `json` as config file formats

### DIFF
--- a/common/changes/@autorest/core/docs-help-config-file-ext_2022-03-14-16-21.json
+++ b/common/changes/@autorest/core/docs-help-config-file-ext_2022-03-14-16-21.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "`--help` usage include `yaml` and `json` as config file formats",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/core",
+  "email": "tiguerin@microsoft.com"
+}

--- a/packages/extensions/core/src/commands/help.ts
+++ b/packages/extensions/core/src/commands/help.ts
@@ -21,7 +21,7 @@ function printHelpHeader() {
     [
       "",
       "",
-      color("**Usage**: autorest `[configuration-file.md] with [...options]`"),
+      color("**Usage**: `autorest [config-file.{md|json|yaml}] [...additional options]`"),
       "",
       color("  See: https://aka.ms/autorest/cli for additional documentation"),
     ].join("\n"),


### PR DESCRIPTION
fix #4457

Make sure the `--help` info specify that yaml and json are also valid configuration formats. This was already specified in the docs https://github.com/Azure/autorest/blob/main/docs/generate/readme.md but not when using autorest 
![image](https://user-images.githubusercontent.com/1031227/158215720-c456457a-893e-426b-b83f-ecafb8b862a4.png)
