### PR TITLE
Add back renamed model in codemodel to prevent breaking change

### DIFF
--- a/packages/extensions/modelerfour/package.json
+++ b/packages/extensions/modelerfour/package.json
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/Azure/autorest/tree/main/packages/extensions/modelerfour",
   "readme": "https://github.com/Azure/autorest/tree/main/packages/extensions/modelerfour/readme.md",
   "devDependencies": {
-    "@autorest/codemodel": "~4.18.0",
+    "@autorest/codemodel": "~4.18.1",
     "@autorest/extension-base": "~3.4.2",
     "@autorest/test-utils": "~0.5.1",
     "@azure-tools/async-io": "~3.0.0",

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -2302,6 +2302,47 @@
         }
       ]
     },
+    "AADTokenSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false,
+      "required": [
+        "scopes",
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/SecurityScheme"
+        }
+      ]
+    },
+    "AzureKeySecurityScheme": {
+      "type": "object",
+      "properties": {
+        "headerName": {
+          "type": "string"
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false,
+      "required": [
+        "headerName",
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/definitions/SecurityScheme"
+        }
+      ]
+    },
     "ValueOrFactory": {
       "anyOf": [
         {

--- a/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
+++ b/packages/libs/codemodel/.resources/all-in-one/json/code-model.json
@@ -2302,6 +2302,37 @@
         }
       ]
     },
+    "ValueOrFactory": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/ApiVersion"
+        },
+        {
+          "type": "object",
+          "defaultProperties": [],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Example": {
+      "description": "example data [UNFINISHED]",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {},
+        "externalValue": {
+          "description": "an URI",
+          "type": "string"
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false
+    },
     "AADTokenSecurityScheme": {
       "type": "object",
       "properties": {
@@ -2342,37 +2373,6 @@
           "$ref": "#/definitions/SecurityScheme"
         }
       ]
-    },
-    "ValueOrFactory": {
-      "anyOf": [
-        {
-          "$ref": "#/definitions/ApiVersion"
-        },
-        {
-          "type": "object",
-          "defaultProperties": [],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "Example": {
-      "description": "example data [UNFINISHED]",
-      "type": "object",
-      "properties": {
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "value": {},
-        "externalValue": {
-          "description": "an URI",
-          "type": "string"
-        }
-      },
-      "defaultProperties": [],
-      "additionalProperties": false
     },
     "HttpMethod": {
       "description": "standard HTTP protocol methods",

--- a/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
+++ b/packages/libs/codemodel/.resources/all-in-one/yaml/code-model.yaml
@@ -3,6 +3,19 @@ description: the model that contains all the information required to generate a 
 $schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false
 definitions:
+  AADTokenSecurityScheme:
+    type: object
+    additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/SecurityScheme'
+    properties:
+      scopes:
+        type: array
+        items:
+          type: string
+    required:
+      - scopes
+      - type
   APIKeySecurityScheme:
     type: object
     additionalProperties: false
@@ -157,6 +170,17 @@ definitions:
       - authorizationUrl
       - scopes
       - tokenUrl
+  AzureKeySecurityScheme:
+    type: object
+    additionalProperties: false
+    allOf:
+      - $ref: '#/definitions/SecurityScheme'
+    properties:
+      headerName:
+        type: string
+    required:
+      - headerName
+      - type
   BearerHTTPSecurityScheme:
     type: object
     additionalProperties: false

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -961,6 +961,47 @@
         }
       ]
     },
+    "AADTokenSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false,
+      "required": [
+        "scopes",
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "./http.json#/definitions/SecurityScheme"
+        }
+      ]
+    },
+    "AzureKeySecurityScheme": {
+      "type": "object",
+      "properties": {
+        "headerName": {
+          "type": "string"
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false,
+      "required": [
+        "headerName",
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "./http.json#/definitions/SecurityScheme"
+        }
+      ]
+    },
     "ValueOrFactory": {
       "anyOf": [
         {

--- a/packages/libs/codemodel/.resources/model/json/master.json
+++ b/packages/libs/codemodel/.resources/model/json/master.json
@@ -961,6 +961,37 @@
         }
       ]
     },
+    "ValueOrFactory": {
+      "anyOf": [
+        {
+          "$ref": "./master.json#/definitions/ApiVersion"
+        },
+        {
+          "type": "object",
+          "defaultProperties": [],
+          "additionalProperties": false
+        }
+      ]
+    },
+    "Example": {
+      "description": "example data [UNFINISHED]",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": {},
+        "externalValue": {
+          "description": "an URI",
+          "type": "string"
+        }
+      },
+      "defaultProperties": [],
+      "additionalProperties": false
+    },
     "AADTokenSecurityScheme": {
       "type": "object",
       "properties": {
@@ -1001,37 +1032,6 @@
           "$ref": "./http.json#/definitions/SecurityScheme"
         }
       ]
-    },
-    "ValueOrFactory": {
-      "anyOf": [
-        {
-          "$ref": "./master.json#/definitions/ApiVersion"
-        },
-        {
-          "type": "object",
-          "defaultProperties": [],
-          "additionalProperties": false
-        }
-      ]
-    },
-    "Example": {
-      "description": "example data [UNFINISHED]",
-      "type": "object",
-      "properties": {
-        "summary": {
-          "type": "string"
-        },
-        "description": {
-          "type": "string"
-        },
-        "value": {},
-        "externalValue": {
-          "description": "an URI",
-          "type": "string"
-        }
-      },
-      "defaultProperties": [],
-      "additionalProperties": false
     },
     "Record<string,any>": {
       "type": "object",

--- a/packages/libs/codemodel/.resources/model/yaml/master.yaml
+++ b/packages/libs/codemodel/.resources/model/yaml/master.yaml
@@ -3,6 +3,19 @@ description: the model that contains all the information required to generate a 
 $schema: http://json-schema.org/draft-07/schema#
 additionalProperties: false
 definitions:
+  AADTokenSecurityScheme:
+    type: object
+    additionalProperties: false
+    allOf:
+      - $ref: ./http.yaml#/definitions/SecurityScheme
+    properties:
+      scopes:
+        type: array
+        items:
+          type: string
+    required:
+      - scopes
+      - type
   ApiVersion:
     type: object
     description: |-
@@ -34,6 +47,17 @@ definitions:
     description: a collection of api versions
     items:
       $ref: ./master.yaml#/definitions/ApiVersion
+  AzureKeySecurityScheme:
+    type: object
+    additionalProperties: false
+    allOf:
+      - $ref: ./http.yaml#/definitions/SecurityScheme
+    properties:
+      headerName:
+        type: string
+    required:
+      - headerName
+      - type
   BinaryResponse:
     type: object
     description: a response where the content should be treated as a binary instead of a value or object

--- a/packages/libs/codemodel/CHANGELOG.json
+++ b/packages/libs/codemodel/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/codemodel",
   "entries": [
     {
+      "version": "4.18.1",
+      "tag": "@autorest/codemodel_v4.18.1",
+      "date": "Wed, 16 Mar 2022 15:14:54 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Add back old security types to prevent breaking changes"
+          }
+        ]
+      }
+    },
+    {
       "version": "4.18.0",
       "tag": "@autorest/codemodel_v4.18.0",
       "date": "Tue, 15 Mar 2022 16:00:38 GMT",

--- a/packages/libs/codemodel/CHANGELOG.md
+++ b/packages/libs/codemodel/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/codemodel
 
-This log was last generated on Tue, 15 Mar 2022 16:00:38 GMT and should not be manually modified.
+This log was last generated on Wed, 16 Mar 2022 15:14:54 GMT and should not be manually modified.
+
+## 4.18.1
+Wed, 16 Mar 2022 15:14:54 GMT
+
+### Patches
+
+- Add back old security types to prevent breaking changes
 
 ## 4.18.0
 Tue, 15 Mar 2022 16:00:38 GMT

--- a/packages/libs/codemodel/package.json
+++ b/packages/libs/codemodel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/codemodel",
-  "version": "4.18.0",
+  "version": "4.18.1",
   "description": "AutoRest code model library",
   "directories": {
     "doc": "docs"

--- a/packages/libs/codemodel/src/exports.ts
+++ b/packages/libs/codemodel/src/exports.ts
@@ -44,3 +44,4 @@ export * from "./model/common/schemas/relationship";
 export * from "./model/common/schemas/string";
 export * from "./model/common/schemas/time";
 export * from "./model/common/security";
+export * from "./model/deprecated";

--- a/packages/libs/codemodel/src/model/common/security.ts
+++ b/packages/libs/codemodel/src/model/common/security.ts
@@ -51,33 +51,3 @@ export class KeySecurityScheme implements KeySecurityScheme {
     Object.assign(this, objectInitializer);
   }
 }
-
-/**
- * @deprecated use @see OAuth2SecurityScheme
- */
-export interface AADTokenSecurityScheme extends SecurityScheme {
-  type: "AADToken";
-  scopes: string[];
-}
-
-export class AADTokenSecurityScheme implements AADTokenSecurityScheme {
-  public constructor(objectInitializer?: DeepPartial<AADTokenSecurityScheme>) {
-    this.type = "AADToken";
-    Object.assign(this, objectInitializer);
-  }
-}
-
-/**
- * @deprecated use @see KeySecurityScheme
- */
-export interface AzureKeySecurityScheme extends SecurityScheme {
-  type: "AzureKey";
-  headerName: string;
-}
-
-export class AzureKeySecurityScheme implements AzureKeySecurityScheme {
-  public constructor(objectInitializer?: DeepPartial<AzureKeySecurityScheme>) {
-    this.type = "AzureKey";
-    Object.assign(this, objectInitializer);
-  }
-}

--- a/packages/libs/codemodel/src/model/common/security.ts
+++ b/packages/libs/codemodel/src/model/common/security.ts
@@ -51,3 +51,33 @@ export class KeySecurityScheme implements KeySecurityScheme {
     Object.assign(this, objectInitializer);
   }
 }
+
+/**
+ * @deprecated use @see OAuth2SecurityScheme
+ */
+export interface AADTokenSecurityScheme extends SecurityScheme {
+  type: "AADToken";
+  scopes: string[];
+}
+
+export class AADTokenSecurityScheme implements AADTokenSecurityScheme {
+  public constructor(objectInitializer?: DeepPartial<AADTokenSecurityScheme>) {
+    this.type = "AADToken";
+    Object.assign(this, objectInitializer);
+  }
+}
+
+/**
+ * @deprecated use @see KeySecurityScheme
+ */
+export interface AzureKeySecurityScheme extends SecurityScheme {
+  type: "AzureKey";
+  headerName: string;
+}
+
+export class AzureKeySecurityScheme implements AzureKeySecurityScheme {
+  public constructor(objectInitializer?: DeepPartial<AzureKeySecurityScheme>) {
+    this.type = "AzureKey";
+    Object.assign(this, objectInitializer);
+  }
+}

--- a/packages/libs/codemodel/src/model/deprecated.ts
+++ b/packages/libs/codemodel/src/model/deprecated.ts
@@ -1,0 +1,37 @@
+/**
+ * This file contains model that have been deprecated and should not be present in the codemodel produced by modelerfour.
+ * They are kept here to reduce the breaking changes in generator that don't pin their dependencies.
+ */
+
+import { DeepPartial } from "@azure-tools/codegen";
+import { SecurityScheme } from "./common/security";
+
+/**
+ * @deprecated use @see OAuth2SecurityScheme
+ */
+export interface AADTokenSecurityScheme extends SecurityScheme {
+  type: "AADToken";
+  scopes: string[];
+}
+
+export class AADTokenSecurityScheme implements AADTokenSecurityScheme {
+  public constructor(objectInitializer?: DeepPartial<AADTokenSecurityScheme>) {
+    this.type = "AADToken";
+    Object.assign(this, objectInitializer);
+  }
+}
+
+/**
+ * @deprecated use @see KeySecurityScheme
+ */
+export interface AzureKeySecurityScheme extends SecurityScheme {
+  type: "AzureKey";
+  headerName: string;
+}
+
+export class AzureKeySecurityScheme implements AzureKeySecurityScheme {
+  public constructor(objectInitializer?: DeepPartial<AzureKeySecurityScheme>) {
+    this.type = "AzureKey";
+    Object.assign(this, objectInitializer);
+  }
+}


### PR DESCRIPTION
Add back the original model as deprecated so the new version of the codemodel is not breaking.