### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/packages/extensions/core/src/lib/pipeline/plugin-endpoint.ts
+++ b/packages/extensions/core/src/lib/pipeline/plugin-endpoint.ts
@@ -366,7 +366,7 @@ export class AutoRestExtension extends EventEmitter {
         const t = context.config.outputFolderUri.length;
         return (
           await context.fileSystem.list(ensureIsFolderUri(`${context.config.outputFolderUri}${artifactType || ""}`))
-        ).map((each) => each.substr(t));
+        ).map((each) => each.slice(t));
       },
 
       async WriteFile(filename: string, content: string, sourceMap?: Array<Mapping> | RawSourceMap): Promise<void> {

--- a/packages/extensions/modelerfour/src/modeler/interpretations.ts
+++ b/packages/extensions/modelerfour/src/modeler/interpretations.ts
@@ -294,8 +294,8 @@ export class Interpretations {
 
     return p != -1
       ? {
-          group: opId.substr(0, p),
-          member: opId.substr(p + 1),
+          group: opId.slice(0, p),
+          member: opId.slice(p + 1),
         }
       : {
           group: "",

--- a/packages/extensions/modelerfour/src/modeler/modelerfour.ts
+++ b/packages/extensions/modelerfour/src/modeler/modelerfour.ts
@@ -1711,8 +1711,7 @@ export class ModelerFour {
         {
           const server = servers[0];
           // trim extraneous slash .
-          const uri =
-            server.url.endsWith("/") && path.startsWith("/") ? server.url.substr(0, server.url.length - 1) : server.url;
+          const uri = server.url.endsWith("/") && path.startsWith("/") ? server.url.slice(0, -1) : server.url;
 
           if (server.variables === undefined || Object.keys(server.variables).length === 0) {
             // scenario 1 : single static value

--- a/packages/libs/codegen/src/formatter/formatter.ts
+++ b/packages/libs/codegen/src/formatter/formatter.ts
@@ -13,11 +13,11 @@ type StylerWithUppercasePreservation = (
 ) => string;
 
 function capitalize(s: string): string {
-  return s ? `${s.charAt(0).toUpperCase()}${s.substr(1)}` : s;
+  return s ? `${s.charAt(0).toUpperCase()}${s.slice(1)}` : s;
 }
 
 function uncapitalize(s: string): string {
-  return s ? `${s.charAt(0).toLowerCase()}${s.substr(1)}` : s;
+  return s ? `${s.charAt(0).toLowerCase()}${s.slice(1)}` : s;
 }
 
 function IsFullyUpperCase(identifier: string, maxUppercasePreserve: number) {

--- a/packages/libs/codegen/src/pluralization.ts
+++ b/packages/libs/codegen/src/pluralization.ts
@@ -1188,7 +1188,7 @@ export class EnglishPluralizationService {
       if (result.length === 0) {
         return result;
       }
-      return result.charAt(0).toUpperCase() + result.substr(1);
+      return result.charAt(0).toUpperCase() + result.slice(1);
     } else {
       return result;
     }
@@ -1204,8 +1204,8 @@ export class EnglishPluralizationService {
     // use the last space to separate the words
     const lastSpaceIndex = word.lastIndexOf(" ");
     return {
-      prefixWord: word.substr(0, lastSpaceIndex + 1),
-      suffixWord: word.substr(lastSpaceIndex + 1),
+      prefixWord: word.slice(0, lastSpaceIndex + 1),
+      suffixWord: word.slice(lastSpaceIndex + 1),
     };
     //
   }

--- a/packages/libs/codegen/src/text-manipulation.ts
+++ b/packages/libs/codegen/src/text-manipulation.ts
@@ -23,11 +23,11 @@ export function capitalize(str: string): string {
   if (acronyms.has(str)) {
     return str.toUpperCase();
   }
-  return str ? `${str.charAt(0).toUpperCase()}${str.substr(1)}` : str;
+  return str ? `${str.charAt(0).toUpperCase()}${str.slice(1)}` : str;
 }
 
 export function uncapitalize(str: string): string {
-  return str ? `${str.charAt(0).toLowerCase()}${str.substr(1)}` : str;
+  return str ? `${str.charAt(0).toLowerCase()}${str.slice(1)}` : str;
 }
 
 export function join<T>(items: Array<T>, separator: string) {
@@ -328,7 +328,7 @@ export function getPascalIdentifier(name: string): string {
 export function escapeString(text: string | undefined): string {
   if (text) {
     const q = JSON.stringify(text);
-    return q.substr(1, q.length - 2);
+    return q.slice(1, -1);
   }
   return "";
 }

--- a/packages/libs/codegen/src/utility.ts
+++ b/packages/libs/codegen/src/utility.ts
@@ -102,7 +102,7 @@ export function guid() {
     "-" +
     quartet() +
     "-4" +
-    quartet().substr(0, 3) +
+    quartet().slice(0, 3) +
     "-" +
     quartet() +
     "-" +

--- a/packages/libs/datastore/src/data-store/data-store.ts
+++ b/packages/libs/datastore/src/data-store/data-store.ts
@@ -85,7 +85,7 @@ export class DataStore {
     // make a sanitized name
     let filename = uri.replace(/[^\w.()]+/g, "-");
     if (filename.length > 64) {
-      filename = `${md5(filename)}-${filename.substr(filename.length - 64)}`;
+      filename = `${md5(filename)}-${filename.slice(-64)}`;
     }
     const name = join(await this.getCacheFolder(), filename);
 

--- a/packages/libs/datastore/src/file-system/memory-file-system.ts
+++ b/packages/libs/datastore/src/file-system/memory-file-system.ts
@@ -28,7 +28,7 @@ export class MemoryFileSystem implements IFileSystem {
       if (!uri.startsWith(folderUri)) {
         return false;
       }
-      return uri.substr(folderUri.length).indexOf("/") === -1;
+      return uri.slice(folderUri.length).indexOf("/") === -1;
     });
   }
 

--- a/packages/tools/compare/src/comparers.ts
+++ b/packages/tools/compare/src/comparers.ts
@@ -311,7 +311,7 @@ export interface CompareSourceOptions {
  * path) using a comparer that is selected based on the file's extension.
  */
 export function compareFile(oldFile: FileDetails, newFile: FileDetails, options: CompareSourceOptions): CompareResult {
-  const extension = path.extname(oldFile.name).substr(1);
+  const extension = path.extname(oldFile.name).slice(1);
   const comparer = options.comparersByType[extension];
   return comparer ? comparer(oldFile, newFile) : undefined;
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.