### PR TITLE
Avoid pointless warning

### DIFF
--- a/packages/extensions/modelerfour/src/quality-precheck/prechecker.ts
+++ b/packages/extensions/modelerfour/src/quality-precheck/prechecker.ts
@@ -225,7 +225,11 @@ export class QualityPreChecker {
 
   fixUpObjectsWithoutType() {
     for (const { name, schema } of this.listSchemas()) {
-      if (<any>schema.type === "file" || <any>schema.format === "file" || (<any>schema.format === "binary" && <any>schema.type !== "string")) {
+      if (
+        <any>schema.type === "file" ||
+        <any>schema.format === "file" ||
+        (<any>schema.format === "binary" && <any>schema.type !== "string")
+      ) {
         // handle inconsistency in file format handling.
         this.session.warning(
           `'The schema ${schema?.["x-ms-metadata"]?.name || name} with 'type: ${schema.type}', format: ${

--- a/packages/extensions/modelerfour/src/quality-precheck/prechecker.ts
+++ b/packages/extensions/modelerfour/src/quality-precheck/prechecker.ts
@@ -225,7 +225,7 @@ export class QualityPreChecker {
 
   fixUpObjectsWithoutType() {
     for (const { name, schema } of this.listSchemas()) {
-      if (<any>schema.type === "file" || <any>schema.format === "file" || <any>schema.format === "binary") {
+      if (<any>schema.type === "file" || <any>schema.format === "file" || (<any>schema.format === "binary" && <any>schema.type !== "string")) {
         // handle inconsistency in file format handling.
         this.session.warning(
           `'The schema ${schema?.["x-ms-metadata"]?.name || name} with 'type: ${schema.type}', format: ${


### PR DESCRIPTION
The warning is pointless for two reasons:

1. Using type=string and format=binary is the correct way to specify blob data in openapi
2. When type=string and format=binary, the block is effectively a no-op