### PR TITLE
Fix small mistake in built-in-directives.md

### DIFF
--- a/docs/generate/built-in-directives.md
+++ b/docs/generate/built-in-directives.md
@@ -140,7 +140,7 @@ Examples:
 directive:
   # Rename property foo to bar on model named MyModel
   - where-model: MyModel
-    remove-property:
+    rename-property:
       from: foo
       to: bar
 ```


### PR DESCRIPTION
In the "Rename property" section, the example is reading "remove-property"