### PR TITLE
Fix: `where-operation-match` not working with latest release

### DIFF
--- a/docs/generate/built-in-directives.md
+++ b/docs/generate/built-in-directives.md
@@ -39,7 +39,7 @@ directive:
 
 ```yaml
 directive:
-  - remove-operation: <operationId>  | <regex>
+  - remove-operation: <operationId>
 ```
 
 Examples:

--- a/packages/apps/autorest/package.json
+++ b/packages/apps/autorest/package.json
@@ -43,8 +43,8 @@
   },
   "typings": "./dist/exports.d.ts",
   "devDependencies": {
-    "@autorest/configuration": "~1.10.0",
-    "@autorest/core": "~3.9.0",
+    "@autorest/configuration": "~1.10.1",
+    "@autorest/core": "~3.9.1",
     "@autorest/common": "~1.5.3",
     "@azure-tools/async-io": "~3.0.0",
     "@azure-tools/extension": "~3.6.0",

--- a/packages/extensions/core/CHANGELOG.json
+++ b/packages/extensions/core/CHANGELOG.json
@@ -2,6 +2,23 @@
   "name": "@autorest/core",
   "entries": [
     {
+      "version": "3.9.1",
+      "tag": "@autorest/core_v3.9.1",
+      "date": "Wed, 27 Jul 2022 17:44:10 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Fix `where-operation-match` built-in directive"
+          }
+        ],
+        "dependency": [
+          {
+            "comment": "Updating dependency \"@autorest/configuration\" from `~1.10.0` to `~1.10.1`"
+          }
+        ]
+      }
+    },
+    {
       "version": "3.9.0",
       "tag": "@autorest/core_v3.9.0",
       "date": "Tue, 19 Jul 2022 15:09:55 GMT",

--- a/packages/extensions/core/CHANGELOG.md
+++ b/packages/extensions/core/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/core
 
-This log was last generated on Tue, 19 Jul 2022 15:09:55 GMT and should not be manually modified.
+This log was last generated on Wed, 27 Jul 2022 17:44:10 GMT and should not be manually modified.
+
+## 3.9.1
+Wed, 27 Jul 2022 17:44:10 GMT
+
+### Patches
+
+- Fix `where-operation-match` built-in directive
 
 ## 3.9.0
 Tue, 19 Jul 2022 15:09:55 GMT

--- a/packages/extensions/core/package.json
+++ b/packages/extensions/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/core",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "AutoRest core module",
   "engines": {
     "node": ">=12.0.0"
@@ -43,7 +43,7 @@
   "typings": "./dist/exports.d.ts",
   "devDependencies": {
     "@autorest/common": "~1.5.3",
-    "@autorest/configuration": "~1.10.0",
+    "@autorest/configuration": "~1.10.1",
     "@autorest/schemas": "~1.3.4",
     "@autorest/test-utils": "~0.5.2",
     "@azure-tools/async-io": "~3.0.0",

--- a/packages/extensions/core/test/modifiers.e2e.ts
+++ b/packages/extensions/core/test/modifiers.e2e.ts
@@ -97,6 +97,17 @@ describe("Modifiers", () => {
     expect(findOperation(code, "Cowbell_Get")).toBe(undefined);
   });
 
+  it("remove an operation using a regex", async () => {
+    const code = await generate({
+      directive: {
+        "remove-operation-match": "/^cowbell_g.*/i",
+      },
+    });
+
+    expect(findOperation(code, "Cowbell_Get")).toBe(undefined);
+    expect(findOperation(code, "Cowbell_Add")).toBeDefined();
+  });
+
   it("rename an operation", async () => {
     const code = await generate({
       directive: {

--- a/packages/libs/configuration/CHANGELOG.json
+++ b/packages/libs/configuration/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/configuration",
   "entries": [
     {
+      "version": "1.10.1",
+      "tag": "@autorest/configuration_v1.10.1",
+      "date": "Wed, 27 Jul 2022 17:44:10 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Fix `where-operation-match` built-in directive"
+          }
+        ]
+      }
+    },
+    {
       "version": "1.10.0",
       "tag": "@autorest/configuration_v1.10.0",
       "date": "Tue, 19 Jul 2022 15:09:55 GMT",

--- a/packages/libs/configuration/CHANGELOG.md
+++ b/packages/libs/configuration/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/configuration
 
-This log was last generated on Tue, 19 Jul 2022 15:09:55 GMT and should not be manually modified.
+This log was last generated on Wed, 27 Jul 2022 17:44:10 GMT and should not be manually modified.
+
+## 1.10.1
+Wed, 27 Jul 2022 17:44:10 GMT
+
+### Patches
+
+- Fix `where-operation-match` built-in directive
 
 ## 1.10.0
 Tue, 19 Jul 2022 15:09:55 GMT

--- a/packages/libs/configuration/package.json
+++ b/packages/libs/configuration/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/configuration",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Autorest configuration",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",

--- a/packages/libs/configuration/resources/directives.md
+++ b/packages/libs/configuration/resources/directives.md
@@ -95,11 +95,11 @@ declare-directive:
     (() => {
       switch ($context.from) {
         case "openapi-document":
-          return { from: "openapi-document", where: `$.paths.*[?(@.operationId =~ ${$})]` };
+          return { from: "openapi-document", where: `$.paths.*[?(@.operationId.match(${$}))]` };
 
         case "swagger-document":
         default:
-          return { from: "swagger-document", where: `$.paths.*[?(@.operationId =~ ${$})]` };
+          return { from: "swagger-document", where: `$.paths.*[?(@.operationId.match(${$}))]` };
       }
     })()
   where-model: >-

--- a/packages/testing/test-public-packages/package.json
+++ b/packages/testing/test-public-packages/package.json
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/Azure/autorest#readme",
   "dependencies": {
-    "@autorest/core": "~3.9.0",
+    "@autorest/core": "~3.9.1",
     "autorest": "~3.6.2",
     "source-map-support": "^0.5.19"
   },


### PR DESCRIPTION
fix  #4602