### PR TITLE
Fix: Missing `ArmIdSchema` type info from yaml schema in codemodel

### DIFF
--- a/packages/extensions/modelerfour/CHANGELOG.json
+++ b/packages/extensions/modelerfour/CHANGELOG.json
@@ -2,6 +2,23 @@
   "name": "@autorest/modelerfour",
   "entries": [
     {
+      "version": "4.24.2",
+      "tag": "@autorest/modelerfour_v4.24.2",
+      "date": "Fri, 12 Aug 2022 19:53:22 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Bump @autorest/codemodel with missing `ArmIdSchema` from yaml schema"
+          }
+        ],
+        "dependency": [
+          {
+            "comment": "Updating dependency \"@autorest/codemodel\" from `~4.19.1` to `~4.19.2`"
+          }
+        ]
+      }
+    },
+    {
       "version": "4.24.1",
       "tag": "@autorest/modelerfour_v4.24.1",
       "date": "Mon, 08 Aug 2022 16:48:55 GMT",

--- a/packages/extensions/modelerfour/CHANGELOG.md
+++ b/packages/extensions/modelerfour/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/modelerfour
 
-This log was last generated on Mon, 08 Aug 2022 16:48:55 GMT and should not be manually modified.
+This log was last generated on Fri, 12 Aug 2022 19:53:22 GMT and should not be manually modified.
+
+## 4.24.2
+Fri, 12 Aug 2022 19:53:22 GMT
+
+### Patches
+
+- Bump @autorest/codemodel with missing `ArmIdSchema` from yaml schema
 
 ## 4.24.1
 Mon, 08 Aug 2022 16:48:55 GMT

--- a/packages/extensions/modelerfour/package.json
+++ b/packages/extensions/modelerfour/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/modelerfour",
-  "version": "4.24.1",
+  "version": "4.24.2",
   "description": "AutoRest Modeler Version Four (component)",
   "directories": {
     "doc": "docs"
@@ -39,7 +39,7 @@
   "homepage": "https://github.com/Azure/autorest/tree/main/packages/extensions/modelerfour",
   "readme": "https://github.com/Azure/autorest/tree/main/packages/extensions/modelerfour/readme.md",
   "devDependencies": {
-    "@autorest/codemodel": "~4.19.1",
+    "@autorest/codemodel": "~4.19.2",
     "@autorest/extension-base": "~3.5.0",
     "@autorest/test-utils": "~0.5.2",
     "@azure-tools/async-io": "~3.0.0",

--- a/packages/extensions/modelerfour/readme.md
+++ b/packages/extensions/modelerfour/readme.md
@@ -1,6 +1,5 @@
 # AutoRest Modeler Four
 
-
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/packages/extensions/modelerfour/readme.md
+++ b/packages/extensions/modelerfour/readme.md
@@ -1,5 +1,6 @@
 # AutoRest Modeler Four
 
+
 ## Contributing
 
 This project welcomes contributions and suggestions. Most contributions require you to agree to a

--- a/packages/libs/codemodel/CHANGELOG.json
+++ b/packages/libs/codemodel/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/codemodel",
   "entries": [
     {
+      "version": "4.19.2",
+      "tag": "@autorest/codemodel_v4.19.2",
+      "date": "Fri, 12 Aug 2022 19:53:22 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Fix: missing `ArmIdSchema` from yaml schema"
+          }
+        ]
+      }
+    },
+    {
       "version": "4.19.1",
       "tag": "@autorest/codemodel_v4.19.1",
       "date": "Mon, 08 Aug 2022 16:48:55 GMT",

--- a/packages/libs/codemodel/CHANGELOG.md
+++ b/packages/libs/codemodel/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/codemodel
 
-This log was last generated on Mon, 08 Aug 2022 16:48:55 GMT and should not be manually modified.
+This log was last generated on Fri, 12 Aug 2022 19:53:22 GMT and should not be manually modified.
+
+## 4.19.2
+Fri, 12 Aug 2022 19:53:22 GMT
+
+### Patches
+
+- Fix: missing `ArmIdSchema` from yaml schema
 
 ## 4.19.1
 Mon, 08 Aug 2022 16:48:55 GMT

--- a/packages/libs/codemodel/package.json
+++ b/packages/libs/codemodel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@autorest/codemodel",
-  "version": "4.19.1",
+  "version": "4.19.2",
   "description": "AutoRest code model library",
   "directories": {
     "doc": "docs"

--- a/packages/libs/codemodel/src/model/yaml-schema.ts
+++ b/packages/libs/codemodel/src/model/yaml-schema.ts
@@ -24,7 +24,14 @@ import { NumberSchema } from "./common/schemas/number";
 import { GroupSchema, ObjectSchema, Discriminator, Relations, GroupProperty } from "./common/schemas/object";
 import { BooleanSchema, CharSchema } from "./common/schemas/primitive";
 import { OrSchema, XorSchema } from "./common/schemas/relationship";
-import { StringSchema, ODataQuerySchema, CredentialSchema, UriSchema, UuidSchema } from "./common/schemas/string";
+import {
+  StringSchema,
+  ODataQuerySchema,
+  CredentialSchema,
+  UriSchema,
+  UuidSchema,
+  ArmIdSchema,
+} from "./common/schemas/string";
 import { DurationSchema, DateTimeSchema, DateSchema, UnixTimeSchema, TimeSchema } from "./common/schemas/time";
 import { OAuth2SecurityScheme, KeySecurityScheme, Security } from "./common/security";
 import { Value } from "./common/value";
@@ -111,6 +118,7 @@ export const codeModelSchema = DEFAULT_SCHEMA.extend([
   TypeInfo(ODataQuerySchema),
   TypeInfo(CredentialSchema),
   TypeInfo(UriSchema),
+  TypeInfo(ArmIdSchema),
   TypeInfo(UuidSchema),
   TypeInfo(DurationSchema),
   TypeInfo(DateTimeSchema),


### PR DESCRIPTION
fix #4614