### PR TITLE
Remove `--model-validator` plugin referencing oav

### DIFF
--- a/common/changes/@autorest/configuration/remove-oav_2022-11-17-17-33.json
+++ b/common/changes/@autorest/configuration/remove-oav_2022-11-17-17-33.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/configuration",
+      "comment": "Remove `--model-validator` flag to load oav as oav autorest plugin is not supported anymore",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@autorest/configuration"
+}

--- a/docs/generate/flags.md
+++ b/docs/generate/flags.md
@@ -34,7 +34,6 @@ Those are flags that affect autorest only
 | --------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--azure-validator`                     | If set, runs the Azure specific validator plugin.                                                                                                        |
 | `--openapi-type=arm│default│data-plane` | Indicates the type of configuration file being passed to the `azure-validator` so that it can run the appropriate class of validation rules accordingly. |
-| `--model-validator`                     | If set, validates the provided OpenAPI definition(s) against provided `examples`.                                                                        |
 | `--skip-semantics-validation`           | Disable the semantic validator plugin.                                                                                                                   |
 
 ## Shared Flags

--- a/packages/libs/configuration/resources/plugin-validators.md
+++ b/packages/libs/configuration/resources/plugin-validators.md
@@ -18,21 +18,10 @@ use-extension:
   "@microsoft.azure/openapi-validator": "^1.7.0"
 ```
 
-```yaml $(model-validator)
-# default the v2 generator to using the last stable @microsoft.azure/autorest-core
-version: ~2.0.4413
-
-use-extension:
-  "oav": "~0.4.20"
-```
-
 #### Validation
 
 ```yaml
 pipeline:
-  swagger-document/model-validator:
-    input: swagger-document/identity
-    scope: model-validator
   swagger-document/semantic-validator:
     input: swagger-document/identity
     scope: semantic-validator
@@ -40,9 +29,6 @@ pipeline:
 
 ```yaml $(notnow)
 pipeline:
-  openapi-document/model-validator:
-    input: openapi-document/identity
-    scope: model-validator
   openapi-document/semantic-validator:
     input: openapi-document/identity
     scope: semantic-validator


### PR DESCRIPTION
closes  #4668

as described here oav shouldn't be run via autorest anymore  [#4668](https://github.com/Azure/oav/issues/904#issuecomment-1317973848)