### PR TITLE
Fix: Emitted artifact from csharp on windows use `\` which result in transform not running

### DIFF
--- a/common/changes/@autorest/core/fix-transforms_2022-12-06-17-17.json
+++ b/common/changes/@autorest/core/fix-transforms_2022-12-06-17-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "Fix: Emitted artifact from csharp on windows use `\\` which result in transform not running",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core"
+}

--- a/common/changes/@azure-tools/datastore/fix-transforms_2022-12-06-17-17.json
+++ b/common/changes/@azure-tools/datastore/fix-transforms_2022-12-06-17-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "Add `normalizePath` helper",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/datastore"
+}

--- a/packages/extensions/core/src/lib/pipeline/plugin-endpoint.ts
+++ b/packages/extensions/core/src/lib/pipeline/plugin-endpoint.ts
@@ -13,6 +13,7 @@ import {
   IdentityPathMappings,
   LazyPromise,
   Mapping,
+  normalizePath,
   PathPosition,
 } from "@azure-tools/datastore";
 import { ensureIsFolderUri } from "@azure-tools/uri";
@@ -437,8 +438,8 @@ export class AutoRestExtension extends EventEmitter {
           // wire through `sink` in order to retrieve default artifact type
           const artifactMessage = <ArtifactMessage>message;
           const artifact = artifactMessage.Details;
-
-          await writeFileToSinkAndNotify(artifact.uri, artifact.content, artifact.type, artifact.sourceMap);
+          const filename = normalizePath(artifact.uri);
+          await writeFileToSinkAndNotify(filename, artifact.content, artifact.type, artifact.sourceMap);
         }
 
         onMessage(message);

--- a/packages/libs/datastore/src/data-store/misc.ts
+++ b/packages/libs/datastore/src/data-store/misc.ts
@@ -10,3 +10,7 @@ export function mergePipeStates(result: PipeState, ...pipeStates: Array<PipeStat
   }
   return result;
 }
+
+export function normalizePath(path: string): string {
+  return path.replace(/\\/g, "/");
+}


### PR DESCRIPTION
fix #4681