### PR TITLE
[Openapi-to-cadl] Fix output-folder issue

### DIFF
--- a/common/changes/@autorest/openapi-to-cadl/fix-output-folder_2023-01-24-03-25.json
+++ b/common/changes/@autorest/openapi-to-cadl/fix-output-folder_2023-01-24-03-25.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/openapi-to-cadl",
+      "comment": "Fix issue with output-folder",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/openapi-to-cadl"
+}

--- a/packages/extensions/openapi-to-cadl/src/emiters/emit-cadl-config.ts
+++ b/packages/extensions/openapi-to-cadl/src/emiters/emit-cadl-config.ts
@@ -1,4 +1,5 @@
 import { writeFileSync } from "fs";
+import { getSession } from "../autorest-session";
 import { formatFile } from "../utils/format";
 
 export async function emitCadlConfig(filePath: string): Promise<void> {
@@ -19,5 +20,6 @@ export async function emitCadlConfig(filePath: string): Promise<void> {
     # "@azure-tools/cadl-typescript": true
 `;
 
-  writeFileSync(filePath, formatFile(content, filePath));
+  const session = getSession();
+  session.writeFile({ filename: filePath, content: formatFile(content, filePath) });
 }

--- a/packages/extensions/openapi-to-cadl/src/emiters/emit-main.ts
+++ b/packages/extensions/openapi-to-cadl/src/emiters/emit-main.ts
@@ -1,11 +1,12 @@
-import { writeFile } from "fs/promises";
+import { getSession } from "../autorest-session";
 import { generateServiceInformation } from "../generate/generate-service-information";
 import { CadlProgram } from "../interfaces";
 import { formatCadlFile } from "../utils/format";
 
 export async function emitMain(filePath: string, program: CadlProgram): Promise<void> {
   const content = getServiceInformation(program);
-  await writeFile(filePath, formatCadlFile(content, filePath));
+  const session = getSession();
+  session.writeFile({ filename: filePath, content: formatCadlFile(content, filePath) });
 }
 
 function getServiceInformation(program: CadlProgram) {

--- a/packages/extensions/openapi-to-cadl/src/emiters/emit-models.ts
+++ b/packages/extensions/openapi-to-cadl/src/emiters/emit-models.ts
@@ -1,4 +1,5 @@
 import { writeFile } from "fs/promises";
+import { getSession } from "../autorest-session";
 import { generateEnums } from "../generate/generate-enums";
 import { generateObject } from "../generate/generate-object";
 import { CadlEnum, CadlProgram } from "../interfaces";
@@ -9,7 +10,8 @@ import { getNamespace } from "../utils/namespace";
 export async function emitModels(filePath: string, program: CadlProgram): Promise<void> {
   const content = generateModels(program);
 
-  await writeFile(filePath, formatCadlFile(content, filePath));
+  const session = getSession();
+  session.writeFile({ filename: filePath, content: formatCadlFile(content, filePath) });
 }
 
 function generateModels(program: CadlProgram) {

--- a/packages/extensions/openapi-to-cadl/src/emiters/emit-package.ts
+++ b/packages/extensions/openapi-to-cadl/src/emiters/emit-package.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "fs/promises";
+import { getSession } from "../autorest-session";
 import { CadlProgram } from "../interfaces";
 import { formatFile } from "../utils/format";
 
@@ -6,7 +6,8 @@ export async function emitPackage(filePath: string, program: CadlProgram): Promi
   const name = program.serviceInformation.name.toLowerCase().replace(/ /g, "-");
   const description = program.serviceInformation.doc;
   const content = JSON.stringify(getPackage(name, description as string));
-  await writeFile(filePath, formatFile(content, filePath));
+  const session = getSession();
+  session.writeFile({ filename: filePath, content: formatFile(content, filePath) });
 }
 
 const getPackage = (name: string, description: string) => ({

--- a/packages/extensions/openapi-to-cadl/src/emiters/emit-routes.ts
+++ b/packages/extensions/openapi-to-cadl/src/emiters/emit-routes.ts
@@ -1,4 +1,4 @@
-import { writeFile } from "fs/promises";
+import { getSession } from "../autorest-session";
 import { generateOperationGroup } from "../generate/generate-operations";
 import { CadlProgram } from "../interfaces";
 import { formatCadlFile } from "../utils/format";
@@ -7,7 +7,8 @@ import { getNamespace } from "../utils/namespace";
 
 export async function emitRoutes(filePath: string, program: CadlProgram): Promise<void> {
   const content = generateRoutes(program);
-  await writeFile(filePath, formatCadlFile(content, filePath));
+  const session = getSession();
+  session.writeFile({ filename: filePath, content: formatCadlFile(content, filePath) });
 }
 
 function generateRoutes(program: CadlProgram) {

--- a/packages/extensions/openapi-to-cadl/src/main.ts
+++ b/packages/extensions/openapi-to-cadl/src/main.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { existsSync, mkdirSync } from "fs";
 import { join } from "path";
 import { CodeModel, codeModelSchema } from "@autorest/codemodel";
 import { AutoRestExtension, AutorestExtensionHost, Session, startSession } from "@autorest/extension-base";
@@ -25,7 +24,6 @@ export async function processRequest(host: AutorestExtensionHost) {
   markErrorModels(codeModel);
   markResources(codeModel);
   const cadlProgramDetails = getModel(codeModel);
-  createOutputFolder(getFilePath(session, ""));
   await emitModels(getFilePath(session, "models.cadl"), cadlProgramDetails);
   await emitRoutes(getFilePath(session, "routes.cadl"), cadlProgramDetails);
   await emitMain(getFilePath(session, "main.cadl"), cadlProgramDetails);
@@ -33,16 +31,9 @@ export async function processRequest(host: AutorestExtensionHost) {
   await emitCadlConfig(getFilePath(session, "cadl-project.yaml"));
 }
 
-function createOutputFolder(dir: string) {
-  if (!existsSync(dir)) {
-    mkdirSync(dir, { recursive: true });
-  }
-}
 
 function getOutuptDirectory(session: Session<CodeModel>) {
-  const outputFolder = session.configuration["output-folder"] ?? ".";
-  const srcPath = session.configuration["src-path"] ?? "";
-  return join(outputFolder, srcPath);
+  return session.configuration["src-path"] ?? "";
 }
 
 function getFilePath(session: Session<CodeModel>, fileName: string) {

--- a/packages/extensions/openapi-to-cadl/src/main.ts
+++ b/packages/extensions/openapi-to-cadl/src/main.ts
@@ -31,7 +31,6 @@ export async function processRequest(host: AutorestExtensionHost) {
   await emitCadlConfig(getFilePath(session, "cadl-project.yaml"));
 }
 
-
 function getOutuptDirectory(session: Session<CodeModel>) {
   return session.configuration["src-path"] ?? "";
 }

--- a/packages/extensions/openapi-to-cadl/src/utils/docs.ts
+++ b/packages/extensions/openapi-to-cadl/src/utils/docs.ts
@@ -10,6 +10,7 @@ export function generateDocs({ doc }: WithDocs): string {
   }
 
   let docString = Array.isArray(doc) ? doc.join("\n") : doc;
+  docString = docString.replace(/\r\n/g, "\n");
   docString = docString.replace(/\\/g, "\\\\");
   docString = docString.replace(/"/g, '\\"');
   docString = lineWrap(docString);
@@ -28,7 +29,7 @@ export function generateSummary({ summary }: WithSummary): string {
 function lineWrap(doc: string) {
   const maxLength = 80;
 
-  if (doc.length <= maxLength) {
+  if (doc.length <= maxLength && !doc.includes("\n")) {
     return `"${doc}"`;
   }
 


### PR DESCRIPTION
- Autorest handles internally output-folder. The plugin was using FS directly and not leveraging the functionality in Autorest. Switching to autorest's `writeFile` function fixes the issue.

- Additionally, fix an issue with multi-line descriptions

Fixes https://github.com/Azure/autorest/issues/4698