### PR TITLE
Update final-state-schema references in merger

### DIFF
--- a/common/changes/@autorest/core/fix-final-state-schema-in-merger_2023-05-13-00-54.json
+++ b/common/changes/@autorest/core/fix-final-state-schema-in-merger_2023-05-13-00-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "Update final-state-schema references in merger",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core"
+}

--- a/packages/extensions/core/src/lib/plugins/merger.ts
+++ b/packages/extensions/core/src/lib/plugins/merger.ts
@@ -375,6 +375,14 @@ export class MultiAPIMerger extends Transformer<any, oai.Model> {
             value.mapping[key] = newRef;
           }
         }
+
+        // Update ref in x-ms-long-running-operation-options.final-state-schema
+        if (key === "x-ms-long-running-operation-options" && value["final-state-schema"]) {
+          const ref = value["final-state-schema"];
+          const newRef = this.refs[ref];
+          value["final-state-schema"] = newRef;
+        }
+
         // now, recurse into this object
         this.updateRefs(value);
       }

--- a/packages/extensions/core/test/plugins/merger/expected/final-state-schema.json
+++ b/packages/extensions/core/test/plugins/merger/expected/final-state-schema.json
@@ -1,0 +1,293 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "x-ms-metadata": {
+      "merged": true,
+      "apiVersions": [
+        "2023-01-01"
+      ]
+    },
+    "title": "Azure Monitor",
+    "version": "2023-01-01"
+  },
+  "security": [
+    {
+      "azure_auth": [
+        "user_impersonation"
+      ]
+    }
+  ],
+  "paths": {
+    "path:0": {
+      "x-ms-metadata": {
+        "apiVersions": [
+          "2023-01-01"
+        ],
+        "filename": [
+          "mem://final-state-schema/actionGroups.json"
+        ],
+        "path": "/createNotifications",
+        "originalLocations": [
+          "mem://final-state-schema/actionGroups.json#/paths/~1createNotifications"
+        ]
+      }
+    },
+    "path:0.post": {
+      "x-ms-metadata": {
+        "apiVersions": [
+          "2023-01-01"
+        ],
+        "filename": [
+          "mem://final-state-schema/actionGroups.json"
+        ],
+        "path": "/createNotifications",
+        "originalLocations": [
+          "mem://final-state-schema/actionGroups.json#/paths/~1createNotifications"
+        ]
+      },
+      "post": {
+        "description": "Send test notifications to a set of provided receivers",
+        "operationId": "ActionGroups_CreateNotificationsAtActionGroupResourceLevel",
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/components/schemas/schemas:0"
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/schemas:1"
+              }
+            }
+          },
+          "description": "The notification request body which includes the contact details",
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "The notification request accepted"
+          },
+          "default": {
+            "description": "An error occurred while sending the test notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/schemas:2"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "path:1": {
+      "x-ms-metadata": {
+        "apiVersions": [
+          "2023-01-01"
+        ],
+        "filename": [
+          "mem://final-state-schema/actionGroups.json"
+        ],
+        "path": "/notificationStatus/{notificationId}",
+        "originalLocations": [
+          "mem://final-state-schema/actionGroups.json#/paths/~1notificationStatus~1{notificationId}"
+        ]
+      }
+    },
+    "path:1.get": {
+      "x-ms-metadata": {
+        "apiVersions": [
+          "2023-01-01"
+        ],
+        "filename": [
+          "mem://final-state-schema/actionGroups.json"
+        ],
+        "path": "/notificationStatus/{notificationId}",
+        "originalLocations": [
+          "mem://final-state-schema/actionGroups.json#/paths/~1notificationStatus~1{notificationId}"
+        ]
+      },
+      "get": {
+        "description": "Get the test notifications by the notification id",
+        "operationId": "ActionGroups_GetTestNotificationsAtActionGroupResourceLevel",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/parameters:0"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The notification details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/schemas:0"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An error occurred while sending the test notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/schemas:2"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://management.azure.com"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "parameters:0": {
+        "x-ms-metadata": {
+          "apiVersions": [
+            "2023-01-01"
+          ],
+          "filename": [
+            "mem://final-state-schema/actionGroups.json"
+          ],
+          "name": "NotificationIdParameter",
+          "originalLocations": [
+            "mem://final-state-schema/actionGroups.json#/components/parameters/NotificationIdParameter"
+          ],
+          "x-ms-secondary-file": false
+        },
+        "name": "notificationId",
+        "in": "path",
+        "required": true,
+        "description": "The notification id",
+        "x-ms-parameter-location": "method",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "securitySchemes": {
+      "securitySchemes:0": {
+        "x-ms-metadata": {
+          "apiVersions": [
+            "2023-01-01"
+          ],
+          "filename": [
+            "mem://final-state-schema/actionGroups.json"
+          ],
+          "name": "azure_auth",
+          "originalLocations": [
+            "mem://final-state-schema/actionGroups.json#/components/securitySchemes/azure_auth"
+          ],
+          "x-ms-secondary-file": false
+        },
+        "type": "oauth2",
+        "description": "Azure Active Directory OAuth2 Flow",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+            "scopes": {
+              "user_impersonation": "impersonate your user account"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "schemas:0": {
+        "x-ms-metadata": {
+          "apiVersions": [
+            "2023-01-01"
+          ],
+          "filename": [
+            "mem://final-state-schema/actionGroups.json"
+          ],
+          "name": "TestNotificationDetailsResponse",
+          "originalLocations": [
+            "mem://final-state-schema/actionGroups.json#/components/schemas/TestNotificationDetailsResponse"
+          ],
+          "x-ms-secondary-file": false
+        },
+        "description": "The details of the test notification results.",
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "The overall state"
+          },
+          "completedTime": {
+            "type": "string",
+            "description": "The completed time"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The created time"
+          }
+        },
+        "required": [
+          "state"
+        ]
+      },
+      "schemas:1": {
+        "x-ms-metadata": {
+          "apiVersions": [
+            "2023-01-01"
+          ],
+          "filename": [
+            "mem://final-state-schema/actionGroups.json"
+          ],
+          "name": "NotificationRequestBody",
+          "originalLocations": [
+            "mem://final-state-schema/actionGroups.json#/components/schemas/NotificationRequestBody"
+          ],
+          "x-ms-secondary-file": false
+        },
+        "description": "The request body which contain contact detail metadata",
+        "type": "object",
+        "properties": {
+          "alertType": {
+            "type": "string",
+            "maxLength": 30,
+            "description": "The value of the supported alert type. Supported alert type values are: servicehealth, metricstaticthreshold, metricsdynamicthreshold, logalertv2, smartalert, webtestalert, logalertv1numresult, logalertv1metricmeasurement, resourcehealth, activitylog, actualcostbudget, forecastedbudget"
+          }
+        },
+        "required": [
+          "alertType"
+        ]
+      },
+      "schemas:2": {
+        "x-ms-metadata": {
+          "apiVersions": [
+            "2023-01-01"
+          ],
+          "filename": [
+            "mem://final-state-schema/actionGroups.json"
+          ],
+          "name": "ErrorResponse",
+          "originalLocations": [
+            "mem://final-state-schema/actionGroups.json#/components/schemas/ErrorResponse"
+          ],
+          "x-ms-secondary-file": false
+        },
+        "description": "Describes the format of Error response.",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "Error code",
+            "type": "string"
+          },
+          "message": {
+            "description": "Error message indicating why the operation failed.",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/extensions/core/test/plugins/merger/inputs/final-state-schema/actionGroups.json
+++ b/packages/extensions/core/test/plugins/merger/inputs/final-state-schema/actionGroups.json
@@ -1,0 +1,164 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Azure Monitor",
+    "version": "2023-01-01"
+  },
+  "security": [
+    {
+      "azure_auth": ["user_impersonation"]
+    }
+  ],
+  "paths": {
+    "/createNotifications": {
+      "post": {
+        "description": "Send test notifications to a set of provided receivers",
+        "operationId": "ActionGroups_CreateNotificationsAtActionGroupResourceLevel",
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location",
+          "final-state-schema": "#/components/schemas/TestNotificationDetailsResponse"
+        },
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/NotificationRequestBody"
+              }
+            }
+          },
+          "description": "The notification request body which includes the contact details",
+          "required": true
+        },
+        "responses": {
+          "202": {
+            "description": "The notification request accepted"
+          },
+          "default": {
+            "description": "An error occurred while sending the test notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/notificationStatus/{notificationId}": {
+      "get": {
+        "description": "Get the test notifications by the notification id",
+        "operationId": "ActionGroups_GetTestNotificationsAtActionGroupResourceLevel",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/NotificationIdParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The notification details",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TestNotificationDetailsResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "description": "An error occurred while sending the test notifications",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "servers": [
+    {
+      "url": "https://management.azure.com"
+    }
+  ],
+  "components": {
+    "parameters": {
+      "NotificationIdParameter": {
+        "name": "notificationId",
+        "in": "path",
+        "required": true,
+        "description": "The notification id",
+        "x-ms-parameter-location": "method",
+        "schema": {
+          "type": "string"
+        }
+      }
+    },
+    "securitySchemes": {
+      "azure_auth": {
+        "type": "oauth2",
+        "description": "Azure Active Directory OAuth2 Flow",
+        "flows": {
+          "implicit": {
+            "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+            "scopes": {
+              "user_impersonation": "impersonate your user account"
+            }
+          }
+        }
+      }
+    },
+    "schemas": {
+      "TestNotificationDetailsResponse": {
+        "description": "The details of the test notification results.",
+        "type": "object",
+        "properties": {
+          "state": {
+            "type": "string",
+            "description": "The overall state"
+          },
+          "completedTime": {
+            "type": "string",
+            "description": "The completed time"
+          },
+          "createdTime": {
+            "type": "string",
+            "description": "The created time"
+          }
+        },
+        "required": ["state"]
+      },
+      "NotificationRequestBody": {
+        "description": "The request body which contain contact detail metadata",
+        "type": "object",
+        "properties": {
+          "alertType": {
+            "type": "string",
+            "maxLength": 30,
+            "description": "The value of the supported alert type. Supported alert type values are: servicehealth, metricstaticthreshold, metricsdynamicthreshold, logalertv2, smartalert, webtestalert, logalertv1numresult, logalertv1metricmeasurement, resourcehealth, activitylog, actualcostbudget, forecastedbudget"
+          }
+        },
+        "required": ["alertType"]
+      },
+      "ErrorResponse": {
+        "description": "Describes the format of Error response.",
+        "type": "object",
+        "properties": {
+          "code": {
+            "description": "Error code",
+            "type": "string"
+          },
+          "message": {
+            "description": "Error message indicating why the operation failed.",
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/packages/extensions/core/test/plugins/merger/merger.test.ts
+++ b/packages/extensions/core/test/plugins/merger/merger.test.ts
@@ -1,6 +1,6 @@
-import { MultiAPIMerger } from "../../../src/lib/plugins/merger";
 import fs from "fs";
 import { createDataHandle } from "@autorest/test-utils";
+import { MultiAPIMerger } from "../../../src/lib/plugins/merger";
 
 async function readData(file: string, name?: string) {
   const content = await fs.promises.readFile(`${__dirname}/inputs/${file}`);
@@ -25,6 +25,11 @@ describe("MultiAPIMerger", () => {
   it("convert oai3 discriminator mapping references", async () => {
     // Here we should expect the mapping references to have been updated to the new "schemas:{id}" name.
     await expectScenarioToMatchSnapshot("discriminator-mapping", ["discriminator-mapping/discriminator-mapping.json"]);
+  });
+
+  it("convert final-state-schema references", async () => {
+    // Here we should expect the final-state-schema references to have been updated to the new "schemas:{id}" name.
+    await expectScenarioToMatchSnapshot("final-state-schema", ["final-state-schema/actionGroups.json"]);
   });
 
   describe("resolve server relative urls", () => {


### PR DESCRIPTION
This PR fixes a problem with the new `final-state-schema` long-running-operation-options when used in a file that is processed with the autorest "multiapi" option.  In this case, the value of `final-state-schema` must be mapped to the appropriate renamed schema name. I included a test case to verify the new behavior. 