### PR TITLE
Fix final state schema external ref

### DIFF
--- a/common/changes/@autorest/core/fix-final-state-schema-external-ref_2023-07-22-18-53.json
+++ b/common/changes/@autorest/core/fix-final-state-schema-external-ref_2023-07-22-18-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "Fix for final-state-schema with external ref",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core"
+}

--- a/common/changes/@autorest/schemas/fix-final-state-schema-external-ref_2023-07-22-18-53.json
+++ b/common/changes/@autorest/schemas/fix-final-state-schema-external-ref_2023-07-22-18-53.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/schemas",
+      "comment": "Fix for final-state-schema with external ref",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/schemas"
+}

--- a/packages/extensions/core/src/lib/plugins/components-cleaner.ts
+++ b/packages/extensions/core/src/lib/plugins/components-cleaner.ts
@@ -263,11 +263,31 @@ class UnsuedComponentFinder {
           }
           this.crawlObject(componentTypes[componentUid]);
         }
+      } else if (key === "x-ms-long-running-operation-options" && isLroOptionsWithFinalStateSchema(value)) {
+        const refParts = value["final-state-schema"].split("/");
+        const componentUid = refParts.pop() as string;
+        const t: ComponentType = refParts.pop() as ComponentType;
+        if (this.visitedComponents[t] && !this.visitedComponents[t].has(componentUid)) {
+          this.visitedComponents[t].add(componentUid);
+          this.componentsToKeep[t].add(componentUid);
+          const componentTypes = this.components[t];
+          if (componentTypes === undefined) {
+            throw new Error(`Reference '${value}' could not be found.`);
+          }
+          this.crawlObject(componentTypes[componentUid]);
+        }
       } else if (value && typeof value === "object") {
         this.crawlObject(value);
       }
     }
   }
+}
+
+function isLroOptionsWithFinalStateSchema(value: unknown): value is { "final-state-schema": string } {
+  return (typeof value === "object" &&
+    value != null &&
+    "final-state-schema" in value &&
+    typeof value["final-state-schema"] === "string") as boolean;
 }
 
 async function clean(config: AutorestContext, input: DataSource, sink: DataSink) {

--- a/packages/extensions/core/src/lib/plugins/full-ref-resolver/full-ref-resolver-plugin.ts
+++ b/packages/extensions/core/src/lib/plugins/full-ref-resolver/full-ref-resolver-plugin.ts
@@ -114,6 +114,9 @@ async function crawlRefs(
         for (const [key, mappedRef] of Object.entries(value.mapping)) {
           value.mapping[key] = resolveNewRef(mappedRef);
         }
+      } else if (key === "x-ms-long-running-operation-options" && isLroOptionsWithFinalStateSchema(value)) {
+        // Update ref in x-ms-long-running-operation-options.final-state-schema
+        value["final-state-schema"] = resolveNewRef(value["final-state-schema"]);
       } else if (key === "$ref" && typeof value === "string") {
         obj[key] = resolveNewRef(value);
       } else if (Array.isArray(value)) {
@@ -142,6 +145,10 @@ function isDiscriminatorWithMapping(value: unknown): value is Discriminator & { 
     typeof value.mapping === "object" &&
     value.mapping !== null
   );
+}
+
+function isLroOptionsWithFinalStateSchema(value: unknown): value is { "final-state-schema": string } {
+  return (typeof value === "object" && value != null && "final-state-schema" in value) as boolean;
 }
 
 function checkReferenceIsValid(workspace: OpenAPIWorkspace<any>, file: string, path: string | undefined): boolean {

--- a/packages/extensions/core/test/final-state-schema.test.ts
+++ b/packages/extensions/core/test/final-state-schema.test.ts
@@ -1,0 +1,89 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import assert from "assert";
+import { join } from "path";
+import { AutorestTestLogger } from "@autorest/test-utils";
+import { RealFileSystem } from "@azure-tools/datastore";
+import oai3 from "@azure-tools/openapi";
+import { AutoRest } from "../src/exports";
+import { AppRoot } from "../src/lib/constants";
+
+const generate = async (additionalConfig: any): Promise<oai3.Model> => {
+  const logger = new AutorestTestLogger();
+  const autoRest = new AutoRest(logger, new RealFileSystem());
+  autoRest.AddConfiguration({
+    "input-file": join(AppRoot, "test", "resources", "final-state-schema", "networkcloud.json"),
+    "use-extension": { "@autorest/modelerfour": join(AppRoot, "../modelerfour") },
+    verbose: true,
+    debug: true,
+    "output-artifact": ["openapi-document"],
+  });
+  autoRest.AddConfiguration(additionalConfig);
+
+  let resolvedDocument: oai3.Model | undefined;
+
+  autoRest.GeneratedFile.Subscribe((sender, args) => {
+    if (args.type === "openapi-document") {
+      resolvedDocument = JSON.parse(args.content);
+    }
+  });
+
+  const success = await autoRest.Process().finish;
+
+  if (!success) {
+    // eslint-disable-next-line no-console
+    console.log("Messages", logger.logs.all);
+    throw new Error("Autorest didn't complete with success.");
+  }
+
+  assert(resolvedDocument);
+  return resolvedDocument;
+};
+
+const findModel = (spec: oai3.Model, name: string): oai3.Schema | undefined => {
+  return Object.values(spec.components?.schemas ?? [])
+    .filter((x) => !("$ref" in x))
+    .find((schema: oai3.Schema) => schema["x-ms-metadata"].name === name);
+};
+
+const findOperation = (spec: oai3.Model, name: string): oai3.HttpOperation | undefined => {
+  for (const pathItem of Object.values(spec.paths)) {
+    for (const operation of Object.values(pathItem)) {
+      if (operation.operationId === name) {
+        return operation;
+      }
+    }
+  }
+
+  for (const pathItem of Object.values(spec["x-ms-paths"] ?? [])) {
+    for (const operation of Object.values(pathItem as object)) {
+      if (operation.operationId === name) {
+        return operation;
+      }
+    }
+  }
+  return undefined;
+};
+
+const findParameter = (spec: oai3.Model, name: string): oai3.Parameter | undefined => {
+  return Object.values((spec.components?.parameters as Record<string, oai3.Parameter>) ?? [])
+    .filter((x) => !("$ref" in x))
+    .find((parameter: oai3.Parameter) => parameter.name === name);
+};
+
+describe("final-state-schema", () => {
+  it("Correctly processes final-state-schema with external ref", async () => {
+    const code = await generate({});
+
+    const operation = findOperation(code, "BareMetalMachines_Cordon");
+    expect(operation).toBeDefined();
+
+    const finalStateSchema = operation?.["x-ms-long-running-operation-options"]?.["final-state-schema"];
+    expect(finalStateSchema).toBeDefined();
+
+    const schemaName = finalStateSchema?.split("/").pop();
+    expect(code.components?.schemas?.[schemaName]).toBeDefined();
+  });
+});

--- a/packages/extensions/core/test/resources/final-state-schema/networkcloud.json
+++ b/packages/extensions/core/test/resources/final-state-schema/networkcloud.json
@@ -1,0 +1,117 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "description": "The Network Cloud APIs",
+    "title": "NetworkCloud",
+    "version": "2023-05-01-preview",
+    "contact": {
+      "email": "admin@contoso.com"
+    }
+  },
+  "host": "management.azure.com",
+  "consumes": ["application/json"],
+  "produces": ["application/json"],
+  "schemes": ["https"],
+  "tags": [
+    {
+      "name": "BareMetalMachines",
+      "description": "BareMetalMachines operations."
+    }
+  ],
+  "paths": {
+    "/bareMetalMachines/{bareMetalMachineName}/cordon": {
+      "post": {
+        "description": "Cordon the provided bare metal machine's Kubernetes node.",
+        "summary": "Cordon the bare metal machine.",
+        "operationId": "BareMetalMachines_Cordon",
+        "tags": ["BareMetalMachines"],
+        "parameters": [
+          {
+            "$ref": "./types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "#/parameters/BareMetalMachineNameParameter"
+          },
+          {
+            "description": "The request body.",
+            "name": "bareMetalMachineCordonParameters",
+            "in": "body",
+            "schema": {
+              "$ref": "#/definitions/BareMetalMachineCordonParameters"
+            }
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Accepted",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The URL to retrieve the status of the asynchronous operation."
+              }
+            }
+          },
+          "204": {
+            "description": "No Content"
+          },
+          "default": {
+            "description": "Error response describing why the operation failed.",
+            "schema": {
+              "$ref": "./types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation": true,
+        "x-ms-long-running-operation-options": {
+          "final-state-schema": "./types.json#/definitions/OperationStatusResult",
+          "final-state-via": "location"
+        }
+      }
+    }
+  },
+  "definitions": {
+    "BareMetalMachineCordonParameters": {
+      "type": "object",
+      "title": "BareMetalMachineCordonParameters represents the body of the request to evacuate workloads from node on a bare metal machine.",
+      "properties": {
+        "evacuate": {
+          "description": "The indicator of whether to evacuate the node workload when the bare metal machine is cordoned.",
+          "type": "string",
+          "default": "False",
+          "enum": ["True", "False"],
+          "x-ms-enum": {
+            "modelAsString": true,
+            "name": "BareMetalMachineEvacuate"
+          }
+        }
+      }
+    }
+  },
+  "parameters": {
+    "BareMetalMachineNameParameter": {
+      "pattern": "^([a-zA-Z0-9][a-zA-Z0-9]{0,62}[a-zA-Z0-9])$",
+      "type": "string",
+      "x-ms-parameter-location": "method",
+      "description": "The name of the bare metal machine.",
+      "name": "bareMetalMachineName",
+      "in": "path",
+      "required": true
+    }
+  },
+  "securityDefinitions": {
+    "azure_auth": {
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "type": "oauth2",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "security": [
+    {
+      "azure_auth": ["user_impersonation"]
+    }
+  ]
+}

--- a/packages/extensions/core/test/resources/final-state-schema/types.json
+++ b/packages/extensions/core/test/resources/final-state-schema/types.json
@@ -1,0 +1,71 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "version": "4.0",
+    "title": "Common types"
+  },
+  "paths": {},
+  "definitions": {
+    "ErrorDetail": {
+      "description": "The error detail.",
+      "type": "object",
+      "properties": {
+        "code": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The error code."
+        },
+        "message": {
+          "readOnly": true,
+          "type": "string",
+          "description": "The error message."
+        }
+      }
+    },
+    "ErrorResponse": {
+      "title": "Error response",
+      "description": "Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).",
+      "type": "object",
+      "properties": {
+        "error": {
+          "description": "The error object.",
+          "$ref": "#/definitions/ErrorDetail"
+        }
+      }
+    },
+    "OperationStatusResult": {
+      "description": "The current status of an async operation.",
+      "type": "object",
+      "required": ["status"],
+      "properties": {
+        "id": {
+          "description": "Fully qualified ID for the async operation.",
+          "type": "string",
+          "format": "arm-id"
+        },
+        "name": {
+          "description": "Name of the async operation.",
+          "type": "string"
+        },
+        "status": {
+          "description": "Operation status.",
+          "type": "string"
+        },
+        "error": {
+          "description": "If present, details of the operation error.",
+          "$ref": "#/definitions/ErrorDetail"
+        }
+      }
+    }
+  },
+  "parameters": {
+    "ApiVersionParameter": {
+      "name": "api-version",
+      "in": "query",
+      "required": true,
+      "type": "string",
+      "description": "The API version to use for this operation.",
+      "minLength": 1
+    }
+  }
+}

--- a/packages/libs/autorest-schemas/swagger-extensions.json
+++ b/packages/libs/autorest-schemas/swagger-extensions.json
@@ -1751,6 +1751,10 @@
           "description": "How to determine the final state of the operation. Possible Values:\n- `azure-async-operation` - poll until terminal state, the final response will be available at the uri pointed to by the header `Azure-AsyncOperation`\n- `location`  - poll until terminal state, the final response will be available at the uri pointed to by the header `Location`\n- `operation-location` - poll until terminal state, the final response will be available at the uri pointed to by the header `Operation-Location`",
           "type": "string",
           "enum": ["azure-async-operation", "location", "original-uri", "operation-location"]
+        },
+        "final-state-schema": {
+          "description": "The schema of the response of whichever means is indicated in final-state-via for obtaining the final result.",
+          "type": "string"
         }
       },
       "required": ["final-state-via"]


### PR DESCRIPTION
This PR adds special handling for resolving refs that appear in the value of the `final-state-schema` field of `x-ms-long-running-operation-options`.

Fixes #4762 