### PR TITLE
[v2] Replace "new Buffer()" with "Buffer.from()"

### DIFF
--- a/src/autorest-core/lib/pipeline/pipeline.ts
+++ b/src/autorest-core/lib/pipeline/pipeline.ts
@@ -322,7 +322,7 @@ export async function RunPipeline(configView: ConfigurationView, fileSystem: IFi
   (configView.Raw as any).__status = new Proxy<any>({}, {
     get(_, key) {
       if (key === "__info") return false;
-      const expr = new Buffer(key.toString(), "base64").toString("ascii");
+      const expr = Buffer.from(key.toString(), "base64").toString("ascii");
       try {
         return FastStringify(safeEval(expr, {
           pipeline: pipeline.pipeline,


### PR DESCRIPTION
- Removes deprecation warning