### PR TITLE
[v2] Remove "required: name" from xmsEnum

### DIFF
--- a/schema/swagger-extensions.json
+++ b/schema/swagger-extensions.json
@@ -1502,7 +1502,6 @@
     },
     "xmsEnum": {
       "type": "object",
-      "required": ["name"],
       "properties": {
         "name": {
           "type": "string"


### PR DESCRIPTION
- Should no longer be required for new or existing specs