### PR TITLE
[v2] Backport "Allow x-ms-paths not to start with /" (#4152)

### DIFF
--- a/schema/swagger-extensions.json
+++ b/schema/swagger-extensions.json
@@ -1566,7 +1566,16 @@
       ]
     },
     "xmsPaths": {
-      "$ref": "#/definitions/paths"
+      "type": "object",
+      "description": "Relative paths to the individual endpoints. They must be relative to the 'basePath'.",
+      "patternProperties": {
+        "^x-.*$": {
+          "$ref": "#/definitions/vendorExtension"
+        }
+      },
+      "additionalProperties": {
+        "$ref": "#/definitions/pathItem"
+      }
     },
     "xmsExternal": {
       "type": "boolean"


### PR DESCRIPTION
- Port #4152 from v3 to v2
- Fixes failures in existing specs
