### PR TITLE
[v2] Report full error for schema violations

### DIFF
--- a/src/autorest-core/lib/pipeline/schema-validation.ts
+++ b/src/autorest-core/lib/pipeline/schema-validation.ts
@@ -11,6 +11,7 @@ import { Parse } from '../ref/yaml';
 import { CreatePerFilePlugin, PipelinePlugin } from "./common";
 import { Channel } from "../message";
 import { OperationAbortedException } from '../exception';
+import { inspect } from 'util';
 
 export function GetPlugin_SchemaValidator(): PipelinePlugin {
   const validator = new SchemaValidator({ breakOnFirstError: false });
@@ -23,7 +24,8 @@ export function GetPlugin_SchemaValidator(): PipelinePlugin {
     const errors = await new Promise<{ code: string, params: string[], message: string, path: string }[] | null>(res => validator.validate(obj, extendedSwaggerSchema, (err, valid) => res(valid ? null : err)));
     if (errors !== null) {
       for (const error of errors) {
-        const errorString = JSON.stringify(error, null, 2);
+        // Replace '_' with '-' to avoid output formatter interpreting as italics
+        const errorString = inspect(error).replaceAll('_', '-');
 
         config.Message({
           Channel: Channel.Error,

--- a/src/autorest-core/lib/pipeline/schema-validation.ts
+++ b/src/autorest-core/lib/pipeline/schema-validation.ts
@@ -25,14 +25,14 @@ export function GetPlugin_SchemaValidator(): PipelinePlugin {
     if (errors !== null) {
       for (const error of errors) {
         // Replace '_' with '-' to avoid output formatter interpreting as italics
-        const errorString = inspect(error).replaceAll('_', '-');
+        const errorLog = inspect(error).replaceAll('_', '-');
 
         config.Message({
           Channel: Channel.Error,
           Details: error,
           Plugin: "schema-validator",
           Source: [{ document: fileIn.key, Position: { path: parseJsonPointer(error.path) } as any }],
-          Text: `Schema violation:\n${errorString}`
+          Text: `Schema violation: ${error.message}\n${errorLog}`
         });
       }
       throw new OperationAbortedException();

--- a/src/autorest-core/lib/pipeline/schema-validation.ts
+++ b/src/autorest-core/lib/pipeline/schema-validation.ts
@@ -23,12 +23,14 @@ export function GetPlugin_SchemaValidator(): PipelinePlugin {
     const errors = await new Promise<{ code: string, params: string[], message: string, path: string }[] | null>(res => validator.validate(obj, extendedSwaggerSchema, (err, valid) => res(valid ? null : err)));
     if (errors !== null) {
       for (const error of errors) {
+        const errorString = JSON.stringify(error, null, 2);
+
         config.Message({
           Channel: Channel.Error,
           Details: error,
           Plugin: "schema-validator",
           Source: [{ document: fileIn.key, Position: { path: parseJsonPointer(error.path) } as any }],
-          Text: `Schema violation: ${error.message}`
+          Text: `Schema violation:\n${errorString}`
         });
       }
       throw new OperationAbortedException();

--- a/src/autorest-core/lib/pipeline/schema-validation.ts
+++ b/src/autorest-core/lib/pipeline/schema-validation.ts
@@ -25,7 +25,7 @@ export function GetPlugin_SchemaValidator(): PipelinePlugin {
     if (errors !== null) {
       for (const error of errors) {
         // Replace '_' with '-' to avoid output formatter interpreting as italics
-        const errorLog = inspect(error).replaceAll('_', '-');
+        const errorLog = inspect(error, { depth: 3 }).replaceAll('_', '-');
 
         config.Message({
           Channel: Channel.Error,


### PR DESCRIPTION
- Fixes #4933

## Before
```
ERROR: Schema violation: Data does not match any schemas from 'oneOf'
```

## After
```
ERROR: Schema violation: Data does not match any schemas from 'oneOf'
{
  code: 'ONE-OF-MISSING',
  message: "Data does not match any schemas from 'oneOf'",
  inner: [
    {
      code: 'OBJECT-MISSING-REQUIRED-PROPERTY',
      message: 'Missing required property: parameters',
      description: 'Describes the format of an example defined using the x-ms-examples extension.'
    },
    {
      code: 'OBJECT-MISSING-REQUIRED-PROPERTY',
      message: 'Missing required property: $ref',
    }
  ]
}
```