### PR TITLE
Add command to call tsp compilation for test projects

### DIFF
--- a/common/changes/@autorest/openapi-to-typespec/command4947_2024-04-15-10-14.json
+++ b/common/changes/@autorest/openapi-to-typespec/command4947_2024-04-15-10-14.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/openapi-to-typespec",
+      "comment": "Add command to run compilation on test projects",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/openapi-to-typespec"
+}

--- a/common/config/rush/pnpm-lock.yaml
+++ b/common/config/rush/pnpm-lock.yaml
@@ -16,13 +16,16 @@ dependencies:
     version: 3.0.255
   '@azure-tools/typespec-autorest':
     specifier: ^0.39.0
-    version: 0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
+    version: 0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@azure-tools/typespec-client-generator-core@0.39.1)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
   '@azure-tools/typespec-azure-core':
     specifier: ^0.39.0
     version: 0.39.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)
   '@azure-tools/typespec-azure-resource-manager':
     specifier: ^0.39.0
     version: 0.39.0(@azure-tools/typespec-autorest@0.39.0)(@azure-tools/typespec-azure-core@0.39.0)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
+  '@azure-tools/typespec-client-generator-core':
+    specifier: ^0.39.0
+    version: 0.39.1(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
   '@azure-tools/uri':
     specifier: ~3.1.1
     version: 3.1.1
@@ -393,7 +396,7 @@ packages:
     engines: {node: '>=10.12.0'}
     dev: false
 
-  /@azure-tools/typespec-autorest@0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0):
+  /@azure-tools/typespec-autorest@0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@azure-tools/typespec-client-generator-core@0.39.1)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0):
     resolution: {integrity: sha512-jfCPzqroiVD0jHPPJX2IpdC7U0Q2yx5QYzucCp1GcOYKbRKNO3vcIEVHArn9rSKbJQR7IKDozEeubMMHINjsnQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
@@ -406,6 +409,7 @@ packages:
       '@typespec/versioning': ~0.53.0
     dependencies:
       '@azure-tools/typespec-azure-core': 0.39.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)
+      '@azure-tools/typespec-client-generator-core': 0.39.1(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
       '@typespec/compiler': 0.53.0
       '@typespec/http': 0.53.0(@typespec/compiler@0.53.0)
       '@typespec/openapi': 0.53.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)
@@ -438,13 +442,30 @@ packages:
       '@typespec/rest': ~0.53.0
       '@typespec/versioning': ~0.53.0
     dependencies:
-      '@azure-tools/typespec-autorest': 0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
+      '@azure-tools/typespec-autorest': 0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@azure-tools/typespec-client-generator-core@0.39.1)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
       '@azure-tools/typespec-azure-core': 0.39.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)
       '@typespec/compiler': 0.53.0
       '@typespec/http': 0.53.0(@typespec/compiler@0.53.0)
       '@typespec/openapi': 0.53.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)
       '@typespec/rest': 0.53.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)
       '@typespec/versioning': 0.53.0(@typespec/compiler@0.53.0)
+    dev: false
+
+  /@azure-tools/typespec-client-generator-core@0.39.1(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0):
+    resolution: {integrity: sha512-EV3N6IN1i/hXGqYKNfXx6+2QAyZnG4IpC9RUk6fqwSQDWX7HtMcfdXqlOaK3Rz2H6BUAc9OnH+Trq/uJCl/RgA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@typespec/compiler': ~0.53.1
+      '@typespec/http': ~0.53.0
+      '@typespec/rest': ~0.53.0
+      '@typespec/versioning': ~0.53.0
+    dependencies:
+      '@typespec/compiler': 0.53.0
+      '@typespec/http': 0.53.0(@typespec/compiler@0.53.0)
+      '@typespec/rest': 0.53.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)
+      '@typespec/versioning': 0.53.0(@typespec/compiler@0.53.0)
+      change-case: 5.3.0
+      pluralize: 8.0.0
     dev: false
 
   /@azure-tools/uri@3.1.1:
@@ -8704,7 +8725,7 @@ packages:
     dev: false
 
   file:projects/autorest.tgz(ts-node@10.9.1):
-    resolution: {integrity: sha512-IVX851LfnNuOOa9ogcw5VrtP6DCEU6SGwdbWohC8SPyIc+NvkDHMNPn4YEVQFKboieTbliTRogzKi1Lqupu/kA==, tarball: file:projects/autorest.tgz}
+    resolution: {integrity: sha512-zmT8H4TPYLbIAfpAIuWq2Fl5ElGAw/YDNepBCev66YxQpJQ764g2UyRcfWksA/YxHSIrpCALm0aKJ/t/TbfdNQ==, tarball: file:projects/autorest.tgz}
     id: file:projects/autorest.tgz
     name: '@rush-temp/autorest'
     version: 0.0.0
@@ -8762,7 +8783,7 @@ packages:
     dev: false
 
   file:projects/cadl.tgz(ts-node@10.9.1)(webpack-cli@5.1.4)(webpack@5.89.0):
-    resolution: {integrity: sha512-GO2iRP6pv3OR2QwYUE+tb7TP6nC+o6bv5ErnrT1vleUz33DH9Kz1Jb9obYFl+4GgtXAaT0fSvCUNgm3pA5ej+A==, tarball: file:projects/cadl.tgz}
+    resolution: {integrity: sha512-av7i43qPFgwFiE7GHT5KJPa4d0FHlFTbx/y04efEF/83afKlgZ5HVMrFi7N/+lYpm1lHBMPZ0aPn4gK6m23EsQ==, tarball: file:projects/cadl.tgz}
     id: file:projects/cadl.tgz
     name: '@rush-temp/cadl'
     version: 0.0.0
@@ -8808,7 +8829,7 @@ packages:
     dev: false
 
   file:projects/codegen.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-VovTenml5aFvdxVxeubTWgNxH95b97qPKSJfccqCog+K5N1MLKQ8OyLfHBIj1we1u2OWAwsUVfDAJDBRsZvCmQ==, tarball: file:projects/codegen.tgz}
+    resolution: {integrity: sha512-3C8weoCa1kCOKeoOVrLzpSZo5dzm6rUBu6GpSekpssx7TPkHZP/9D2Zk7gaMX3IdLiJe9UHH8mMtNEUZM07QMQ==, tarball: file:projects/codegen.tgz}
     id: file:projects/codegen.tgz
     name: '@rush-temp/codegen'
     version: 0.0.0
@@ -8848,7 +8869,7 @@ packages:
     dev: false
 
   file:projects/codemodel.tgz(jest@29.7.0)(prettier@3.1.0):
-    resolution: {integrity: sha512-eciCOrz1bsEKinYsI0hZwEsNX/tZZSbOwiI6BGzznOoVjf7gZ/bE9IhoVnRz6rQ192Qtrkz0IzsoAmCHNZQ1cw==, tarball: file:projects/codemodel.tgz}
+    resolution: {integrity: sha512-XU/8wU9Jo2eyvIFEVi22uh9YHNGK2X69RZ3fhSsdx9e6Ccp2ajm3QX++m7rV8b1FthMVeIn3FHFGIC7miuT2/Q==, tarball: file:projects/codemodel.tgz}
     id: file:projects/codemodel.tgz
     name: '@rush-temp/codemodel'
     version: 0.0.0
@@ -8880,7 +8901,7 @@ packages:
     dev: false
 
   file:projects/common.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-Dr5MV/1kdgzhxptcFbe1cla9YfQKIIPgZ+KjDwrrSlUGr8B4449Bq++2So07dJMQANDoyXjEPYVWoMAUB3YndA==, tarball: file:projects/common.tgz}
+    resolution: {integrity: sha512-dr0VbBpkYbGLe+5tnqwXZcU37okgm1NFocwBAyMKuwD8M7QRNEBSw+CWz04fKcO6bFUc4QZHbNQyM9RiDZs8pg==, tarball: file:projects/common.tgz}
     id: file:projects/common.tgz
     name: '@rush-temp/common'
     version: 0.0.0
@@ -8913,7 +8934,7 @@ packages:
     dev: false
 
   file:projects/compare.tgz(prettier@3.1.0):
-    resolution: {integrity: sha512-+V9SrJtEo0ilGKK7vr0UsFzAxl0GfRPB+MxBS8dl9KkR0/YTOIOgbY2nKDXPxsG5vkaFZ71hgDAwAbdqVOxhWg==, tarball: file:projects/compare.tgz}
+    resolution: {integrity: sha512-TdSUwopQGGjakA2XILTfCpdkmPjMt0tg/U2uHdTsRPS3cBco9dE42Lzg2fQWuqo8kpP54tIAQ38w2mIg9IYiLw==, tarball: file:projects/compare.tgz}
     id: file:projects/compare.tgz
     name: '@rush-temp/compare'
     version: 0.0.0
@@ -8959,7 +8980,7 @@ packages:
     dev: false
 
   file:projects/configuration.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-refACiofNn9MEmuxOHQ+FlnM1QVGK7jt1n0cTpoK3vUp9A865OmlIPq6GPuSRw6WqGD1vJFX4IS+ng7+fJwGIA==, tarball: file:projects/configuration.tgz}
+    resolution: {integrity: sha512-QIvRtuY4X8HzqQc5WSZSnxTEMte4WOqY5CcI2VgvRWeuj9X/BpUwCvUJG7qQc7FhQ/KUlTLC4Qqfsy3DzD+/gA==, tarball: file:projects/configuration.tgz}
     id: file:projects/configuration.tgz
     name: '@rush-temp/configuration'
     version: 0.0.0
@@ -9000,7 +9021,7 @@ packages:
     dev: false
 
   file:projects/core.tgz(ts-node@10.9.1):
-    resolution: {integrity: sha512-eYt9hPHj/gnuPH1z8V/POm8I7Qk5f3sPhKQSrtz0vDmpXFeBmOQjku6UizVNGdIsjYAYmKM6sxOsjRdHRYv5aA==, tarball: file:projects/core.tgz}
+    resolution: {integrity: sha512-zdm2pbBeVnYjQfB4bYGn+EDY8BISYjyHr1MIPfuq2kjXIdsQIeE0+rX5dBJ22dJWZrbwX8lv77SAsa5wTH5IAg==, tarball: file:projects/core.tgz}
     id: file:projects/core.tgz
     name: '@rush-temp/core'
     version: 0.0.0
@@ -9065,7 +9086,7 @@ packages:
     dev: false
 
   file:projects/datastore.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-rw9TMnec+y4rClT4qX7eiU/MnaDL4sxvFHk5dFVa3n0W2aK8BSvOKfnYezMGXEQ6AcBwC1b3jOIQyGGl/y7LHg==, tarball: file:projects/datastore.tgz}
+    resolution: {integrity: sha512-6/wu2bBUSvArdPUcvguk4iP5weUXdYt6po8oTByiu4MOKai2WH6T2elniSQVeNa8i0nspiwRrrKZfBA1LRYNfw==, tarball: file:projects/datastore.tgz}
     id: file:projects/datastore.tgz
     name: '@rush-temp/datastore'
     version: 0.0.0
@@ -9106,7 +9127,7 @@ packages:
     dev: false
 
   file:projects/deduplication.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-v0Qz78yfJ+q4XeJE/VJp9JDKvIjRt264L4SrYTs+m85UIFpBl4XoP7sSUOk5yuTSeJlaEbaAQ5WRwJcnT+Q8vw==, tarball: file:projects/deduplication.tgz}
+    resolution: {integrity: sha512-OeYQ73RhcmGwZbW6Ctnuh+q4vIjgRR2880FOuFYSGSAia3/ROZGlAzQqZrHn2/vsOcYXRWZHXy/84HCRcSsIww==, tarball: file:projects/deduplication.tgz}
     id: file:projects/deduplication.tgz
     name: '@rush-temp/deduplication'
     version: 0.0.0
@@ -9140,7 +9161,7 @@ packages:
     dev: false
 
   file:projects/extension-base.tgz(jest@29.7.0)(prettier@3.1.0):
-    resolution: {integrity: sha512-MBEh+961tu6edrkkdRYUrNtAngts+uuekG3CzzYbIpmsTup2RzIk57euiWSh8zA0d3375iPVMwuHd6m6ORcaxA==, tarball: file:projects/extension-base.tgz}
+    resolution: {integrity: sha512-tooRuR6QsOAqpII/MvkKbICjhyRxKFNPhT1y05CG5wlgrqTrwok6sYt0M6bGb73apeC0n7MZbPpWvSR7kQKdrQ==, tarball: file:projects/extension-base.tgz}
     id: file:projects/extension-base.tgz
     name: '@rush-temp/extension-base'
     version: 0.0.0
@@ -9168,7 +9189,7 @@ packages:
     dev: false
 
   file:projects/extension.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-BtX8trhAIukgMnSIDC0Ou3fn3IKV9dNyF4oVHAqvudItaLrJSLRfzg6wxyXabSFFSRrohWNSx3ZdnNRgJsRSWw==, tarball: file:projects/extension.tgz}
+    resolution: {integrity: sha512-YXVy7zorVQE5y0/DwaZobVpgJKsMg8FN2/17G/IXxFH8qzEmEoC6gJPE26mf10HTI0noSGV3NCWCSyzsReEb7w==, tarball: file:projects/extension.tgz}
     id: file:projects/extension.tgz
     name: '@rush-temp/extension'
     version: 0.0.0
@@ -9213,7 +9234,7 @@ packages:
     dev: false
 
   file:projects/fixer.tgz(ts-node@10.9.1):
-    resolution: {integrity: sha512-hgI1LGdKk3LtK5qtwPy1GcbgVQyo6jHY/+eKB7lgrg0YQHQtbOOx66NJcV9CYLuYl5eWEwHcI94wnGOy7ehkGA==, tarball: file:projects/fixer.tgz}
+    resolution: {integrity: sha512-ZyqP7Gub1FyIjYmv7IBtE8jOfK/dp5fTUcRo5WjMCldnLJlqLvZrteccdnVqeKd+TRi3PDnanrW1k6z+CekfQw==, tarball: file:projects/fixer.tgz}
     id: file:projects/fixer.tgz
     name: '@rush-temp/fixer'
     version: 0.0.0
@@ -9257,7 +9278,7 @@ packages:
     dev: false
 
   file:projects/json.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-8ePBJH0KNMHYtw84tnP/BDhe2srShAUkXkcow/UjMU5FbaGBouPvLYlYzqA2ZDDYIlsKDEEKxQu594xORCCFYw==, tarball: file:projects/json.tgz}
+    resolution: {integrity: sha512-TWVpPxmRslYdAtw0qUukBOH0VgsqWuIxh7p1KWAysUa5kQ1OhGT8XqG5+ADb70+RgXFbHGYYN9iqjOAapp4QMw==, tarball: file:projects/json.tgz}
     id: file:projects/json.tgz
     name: '@rush-temp/json'
     version: 0.0.0
@@ -9286,7 +9307,7 @@ packages:
     dev: false
 
   file:projects/jsonschema.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-TlSf9AgX2HVChk9Rc4GyUIPrZrOyrE91SPpFJlYKkK4FASq6oAEstJvpL/+GRBL8KRP2aY2JWQ8AyYEDbEDG0Q==, tarball: file:projects/jsonschema.tgz}
+    resolution: {integrity: sha512-w+3HeMxVDFR0oXDmQegTFnxPoC15xfB20qKeGDyhs10ODDeBw3P5+sdokfFu/n/jzUWtyB71vrwaUOzxhr/fbA==, tarball: file:projects/jsonschema.tgz}
     id: file:projects/jsonschema.tgz
     name: '@rush-temp/jsonschema'
     version: 0.0.0
@@ -9315,7 +9336,7 @@ packages:
     dev: false
 
   file:projects/modelerfour.tgz(ts-node@10.9.1):
-    resolution: {integrity: sha512-yqvv8uLcXaCtMnHap9s3Ks9ozN6NLDmS8EzHhCP5XgKAQCnQoBuX2J64Kkt5WRdtuvIEJqDtx8kX/qKapZeQWg==, tarball: file:projects/modelerfour.tgz}
+    resolution: {integrity: sha512-6jJDUoekbhc7cEhjyadfzwunHkiOCehYPZh/QEEuOzzTJSixWUIle6ejSyptngSe8uxSsVpDJ/4QSTj6UvFoPw==, tarball: file:projects/modelerfour.tgz}
     id: file:projects/modelerfour.tgz
     name: '@rush-temp/modelerfour'
     version: 0.0.0
@@ -9366,7 +9387,7 @@ packages:
     dev: false
 
   file:projects/oai2-to-oai3.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-429l1k8VRbB/Qk1N0kCG+c70ZG5B2ixgF3RQCrm1dF6T0946z327MpAITNIfL0qtD5vC0jW3hzBasXPaMXc7Mw==, tarball: file:projects/oai2-to-oai3.tgz}
+    resolution: {integrity: sha512-EmqXeZJWuoXi6p1c9Flme9Km7H1ISlOOEX1rMEhn/G14Fxe2BJujI8iheV/3eN7CyqwhdBr3Zko2CY77132LDQ==, tarball: file:projects/oai2-to-oai3.tgz}
     id: file:projects/oai2-to-oai3.tgz
     name: '@rush-temp/oai2-to-oai3'
     version: 0.0.0
@@ -9403,14 +9424,15 @@ packages:
     dev: false
 
   file:projects/openapi-to-typespec.tgz(jest@29.7.0):
-    resolution: {integrity: sha512-iVH6kegt5UtBjQgeWeabDI/24my7TkNLpazOi2HQumK3e4H0EVV5vygE1RPNoq/oFuYqlgV6/n6OmUQRyaM5aQ==, tarball: file:projects/openapi-to-typespec.tgz}
+    resolution: {integrity: sha512-Kyx+8ZG2xUGZAHqW8HRY0eqqm1ChOuTY+KZwhJJfDmoCJf5BWyjyaCCYwpY65+KrWJ5mmWo7IDvbBOOKutA2ww==, tarball: file:projects/openapi-to-typespec.tgz}
     id: file:projects/openapi-to-typespec.tgz
     name: '@rush-temp/openapi-to-typespec'
     version: 0.0.0
     dependencies:
-      '@azure-tools/typespec-autorest': 0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
+      '@azure-tools/typespec-autorest': 0.39.0(@azure-tools/typespec-azure-core@0.39.0)(@azure-tools/typespec-client-generator-core@0.39.1)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
       '@azure-tools/typespec-azure-core': 0.39.0(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)
       '@azure-tools/typespec-azure-resource-manager': 0.39.0(@azure-tools/typespec-autorest@0.39.0)(@azure-tools/typespec-azure-core@0.39.0)(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/openapi@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
+      '@azure-tools/typespec-client-generator-core': 0.39.1(@typespec/compiler@0.53.0)(@typespec/http@0.53.0)(@typespec/rest@0.53.0)(@typespec/versioning@0.53.0)
       '@types/fs-extra': 9.0.13
       '@types/lodash': 4.14.201
       '@types/node': 20.9.0
@@ -9446,7 +9468,6 @@ packages:
       webpack: 5.89.0(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.89.0)
     transitivePeerDependencies:
-      - '@azure-tools/typespec-client-generator-core'
       - '@swc/core'
       - '@swc/wasm'
       - '@types/eslint'
@@ -9461,7 +9482,7 @@ packages:
     dev: false
 
   file:projects/openapi.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-HE2/rfH9QyCccaXSR+AEAe/wGVAe/l37tqzQYSU1sFWE+u4MkZA1p7IoBgXOit6m8qOi9HGYFbm4TlpkPLKUrQ==, tarball: file:projects/openapi.tgz}
+    resolution: {integrity: sha512-jeOfewor/wxa+HdeUSgWjhsV4FbhMs9QX8uxqJxh7KZvTBxcvw1XhQkrriRoSEXnBXmHDuAvxKG6gEImlL6c7w==, tarball: file:projects/openapi.tgz}
     id: file:projects/openapi.tgz
     name: '@rush-temp/openapi'
     version: 0.0.0
@@ -9490,13 +9511,13 @@ packages:
     dev: false
 
   file:projects/schemas.tgz:
-    resolution: {integrity: sha512-aeHJHwq6RJNeECiY4g86CukjYKRNg8eHFoxQVmU/aCtNct/TMpfrAc19FVV4JyuNRKtXdFrVNjO2hUJxZXQSQA==, tarball: file:projects/schemas.tgz}
+    resolution: {integrity: sha512-R4SNYE56Q0TOMYcT8gSTZIInxE9vVJH1k54SR8Ksvg8HNkzG+Pko1NIxb8zpWFB74VEmx3TDaruHnodgJjUrvQ==, tarball: file:projects/schemas.tgz}
     name: '@rush-temp/schemas'
     version: 0.0.0
     dev: false
 
   file:projects/system-requirements.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-2/b/vgr/a7FOjk7eTBfvo9o+w4QywiBeIgIHzYhVYTJcy5Huxm1ce0sNnId9Bay+/MrR8aw3lvRDlPUrWdbJUQ==, tarball: file:projects/system-requirements.tgz}
+    resolution: {integrity: sha512-z9xJ+0SQtAhIFr9wve8giTZZxNxdWfI6JxRdXLqEpRLZHHakvBWugiaIe/sfMbYBz+2tFyvHVmI1g6MqA5w1EA==, tarball: file:projects/system-requirements.tgz}
     id: file:projects/system-requirements.tgz
     name: '@rush-temp/system-requirements'
     version: 0.0.0
@@ -9531,7 +9552,7 @@ packages:
     dev: false
 
   file:projects/test-public-packages.tgz(prettier@3.1.0):
-    resolution: {integrity: sha512-ToosHldq4gjvV7xkx1oaD/rVcFWYokbdUgfd6vA3Uzx38HO4HaKY0wqNROzocyDrqwT6IWTMPMo2YATka/49vg==, tarball: file:projects/test-public-packages.tgz}
+    resolution: {integrity: sha512-4kAwPf9RR49MJI4A3gfHMTkVAOcI+r5jV9HKcXAQzs0sr5z/XZbsjTT0gOIu2uLz1KvrVZxxmx/5m1scKzFQgg==, tarball: file:projects/test-public-packages.tgz}
     id: file:projects/test-public-packages.tgz
     name: '@rush-temp/test-public-packages'
     version: 0.0.0
@@ -9552,7 +9573,7 @@ packages:
     dev: false
 
   file:projects/test-utils.tgz(@types/node@20.9.0)(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-tit5MjyO3D/0svfHHHE79slcHCUmLc+cyL2DJ+jLP/LFZ1FCDGzyNhW04+fJbCd0LIM05efwORznprhNtesO9A==, tarball: file:projects/test-utils.tgz}
+    resolution: {integrity: sha512-PjGDVMkoTdQpgj3j0MSrYPkMoilJ3rXaramucEQu/DXD2iUlUqLbATiDxEeOeeJcbyChAWoj8U/ZPV0UG3JdZg==, tarball: file:projects/test-utils.tgz}
     id: file:projects/test-utils.tgz
     name: '@rush-temp/test-utils'
     version: 0.0.0
@@ -9579,7 +9600,7 @@ packages:
     dev: false
 
   file:projects/yaml.tgz(prettier@3.1.0)(ts-node@10.9.1):
-    resolution: {integrity: sha512-H8/9GzwHHWTFw9aj6TqJWA8Hnb0a2ZwNMDALfKiPxzqK8qkqA7ddM9XXKwrK9Vn4Hfry5Lf80q59WoI5KkzaJw==, tarball: file:projects/yaml.tgz}
+    resolution: {integrity: sha512-BKdiJVcGwcy3siN8gBZEoV3uGhFsHHp2cz7xx1bhy7yUgO8mU1utB0CClwHw575UMrMfxJ/2/tOwWZZ6YRzNVA==, tarball: file:projects/yaml.tgz}
     id: file:projects/yaml.tgz
     name: '@rush-temp/yaml'
     version: 0.0.0

--- a/packages/extensions/openapi-to-typespec/package.json
+++ b/packages/extensions/openapi-to-typespec/package.json
@@ -68,6 +68,7 @@
     "@types/fs-extra": "^9.0.13",
     "chalk": "^4.1.0",
     "@azure-tools/typespec-autorest": "^0.39.0",
+    "@azure-tools/typespec-client-generator-core": "^0.39.0",
     "webpack-cli": "~5.1.4",
     "webpack": "~5.89.0",
     "@typescript-eslint/eslint-plugin": "^6.11.0",

--- a/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
+++ b/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
@@ -1,8 +1,10 @@
-import { spawnSync } from "child_process";
+import { execSync, spawnSync } from "child_process";
 import { readFileSync } from "fs";
 import { readdir } from "fs/promises";
 import { join, dirname, extname, resolve } from "path";
 import { resolveProject } from "./resolve-root";
+
+const brownFieldProjects = ["arm-agrifood", "arm-alertsmanagement", "arm-analysisservices", "arm-apimanagement", "arm-authorization", "arm-azureintegrationspaces", "arm-compute", "arm-dns", "arm-machinelearningservices", "arm-storage"];
 
 export async function generateTypespec(repoRoot: string, folder: string, debug = false, isFullCompatible = false) {
   const { path: root } = await resolveProject(__dirname);
@@ -22,6 +24,18 @@ export async function generateTypespec(repoRoot: string, folder: string, debug =
 
   const swaggerPath = join(path, firstSwagger);
   generate(repoRoot, swaggerPath, debug, isFullCompatible);
+}
+
+export async function generateSwagger(folder: string) {
+  if (brownFieldProjects.includes(folder)) {
+    console.log(`Skipping brown field project ${folder}`);
+    return;
+  }
+
+  const { path: root } = await resolveProject(__dirname);
+  const path = join(root, "test", folder, "tsp-output");
+  const command = "tsp compile . --emit=@azure-tools/typespec-autorest";
+  execSync(command, { cwd: path, stdio: "inherit" });
 }
 
 function generate(root: string, path: string, debug = false, isFullCompatible = false) {
@@ -55,6 +69,7 @@ function generate(root: string, path: string, debug = false, isFullCompatible = 
 }
 
 async function main() {
+  const swagger = process.argv[3] === "swagger";
   const folder = process.argv[4];
   const debug = process.argv[5] === "--debug";
   const { path: root } = await resolveProject(__dirname);
@@ -67,6 +82,9 @@ async function main() {
     const folder = folders[i];
     try {
       await generateTypespec(repoRoot, folder, debug, i % 2 === 0);
+      if (swagger) {
+        await generateSwagger(folder);
+      }
     } catch (e) {
       throw new Error(`Failed to generate ${folder}, error:\n${e}`);
     }

--- a/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
+++ b/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
@@ -4,7 +4,18 @@ import { readdir } from "fs/promises";
 import { join, dirname, extname, resolve } from "path";
 import { resolveProject } from "./resolve-root";
 
-const brownFieldProjects = ["arm-agrifood", "arm-alertsmanagement", "arm-analysisservices", "arm-apimanagement", "arm-authorization", "arm-azureintegrationspaces", "arm-compute", "arm-dns", "arm-machinelearningservices", "arm-storage"];
+const brownFieldProjects = [
+  "arm-agrifood",
+  "arm-alertsmanagement",
+  "arm-analysisservices",
+  "arm-apimanagement",
+  "arm-authorization",
+  "arm-azureintegrationspaces",
+  "arm-compute",
+  "arm-dns",
+  "arm-machinelearningservices",
+  "arm-storage",
+];
 
 export async function generateTypespec(repoRoot: string, folder: string, debug = false, isFullCompatible = false) {
   const { path: root } = await resolveProject(__dirname);

--- a/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
+++ b/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
@@ -4,19 +4,6 @@ import { readdir } from "fs/promises";
 import { join, dirname, extname, resolve } from "path";
 import { resolveProject } from "./resolve-root";
 
-const brownFieldProjects = [
-  "arm-agrifood",
-  "arm-alertsmanagement",
-  "arm-analysisservices",
-  "arm-apimanagement",
-  "arm-authorization",
-  "arm-azureintegrationspaces",
-  "arm-compute",
-  "arm-dns",
-  "arm-machinelearningservices",
-  "arm-storage",
-];
-
 export async function generateTypespec(repoRoot: string, folder: string, debug = false, isFullCompatible = false) {
   const { path: root } = await resolveProject(__dirname);
   const path = join(root, "test", folder);
@@ -38,11 +25,6 @@ export async function generateTypespec(repoRoot: string, folder: string, debug =
 }
 
 export async function generateSwagger(folder: string) {
-  if (brownFieldProjects.includes(folder)) {
-    console.log(`Skipping brown field project ${folder}`);
-    return;
-  }
-
   const { path: root } = await resolveProject(__dirname);
   const path = join(root, "test", folder, "tsp-output");
   const command = "tsp compile . --emit=@azure-tools/typespec-autorest";


### PR DESCRIPTION
This is part of https://github.com/Azure/autorest/issues/4947

We could call `npm run generate swagger {project folder}` to run the compilation.