### PR TITLE
Rename autorest.csharp branch feature/v3 to main

### DIFF
--- a/docs/client/readme.md
+++ b/docs/client/readme.md
@@ -11,5 +11,5 @@ This is highly-language specific, so please refer to the documentation we have f
 
 [python]: https://github.com/Azure/autorest.python/tree/autorestv3/docs/client/readme.md
 [java]: https://github.com/Azure/autorest.java/blob/main/docs/client/readme.md
-[csharp]: https://github.com/Azure/autorest.csharp/tree/feature/v3/docs/client/readme.md
+[csharp]: https://github.com/Azure/autorest.csharp/tree/main/docs/client/readme.md
 [typescript]: https://github.com/Azure/autorest.typescript/blob/main/packages/autorest.typescript/docs/client/readme.md

--- a/docs/generate/flags.md
+++ b/docs/generate/flags.md
@@ -204,8 +204,8 @@ The flags listed here are still provisional. Code generated with these flags can
 [namespace_folders]: https://packaging.python.org/guides/packaging-namespace-packages/#pkgutil-style-namespace-packages
 [bearer_token_credential_policy]: https://docs.microsoft.com/en-us/python/api/azure-core/azure.core.pipeline.policies.bearertokencredentialpolicy?view=azure-python
 [azure_key_credential_policy]: https://docs.microsoft.com/en-us/python/api/azure-core/azure.core.pipeline.policies.azurekeycredentialpolicy?view=azure-python
-[shared_generator_assets]: https://github.com/Azure/autorest.csharp/tree/feature/v3/src/assets/Generator.Shared
-[shared_azure_core_assets]: https://github.com/Azure/autorest.csharp/tree/feature/v3/src/assets/Azure.Core.Shared
+[shared_generator_assets]: https://github.com/Azure/autorest.csharp/tree/main/src/assets/Generator.Shared
+[shared_azure_core_assets]: https://github.com/Azure/autorest.csharp/tree/main/src/assets/Azure.Core.Shared
 [autorest_csharp]: https://github.com/Azure/autorest.csharp
 [azure_sdk_for_java]: https://github.com/Azure/azure-sdk-for-java/tree/main/sdk
 [pom]: https://maven.apache.org/guides/introduction/introduction-to-the-pom.html#what-is-a-pom

--- a/docs/generate/readme.md
+++ b/docs/generate/readme.md
@@ -416,7 +416,7 @@ For language-specific information about generation, please refer to our language
 [how_autorest]: ./how-autorest-generates-code-from-openapi.md
 [python]: https://github.com/Azure/autorest.python/tree/autorestv3/docs/generate/readme.md
 [java]: https://github.com/Azure/autorest.java/blob/main/docs/generate/readme.md
-[csharp]: https://github.com/Azure/autorest.csharp/tree/feature/v3/readme.md
+[csharp]: https://github.com/Azure/autorest.csharp/tree/main/readme.md
 [azure_sdk_for_python]: https://github.com/Azure/azure-sdk-for-python/tree/master/sdk
 [azure_sdk_for_java]: https://github.com/Azure/azure-sdk-for-java/tree/master/sdk
 [client]: https://github.com/Azure/autorest/blob/main/docs/client/readme.md

--- a/docs/migrate/readme.md
+++ b/docs/migrate/readme.md
@@ -42,5 +42,5 @@ For language-specific information about migration and changes, please refer to o
 [guidelines]: https://azure.github.io/azure-sdk/general_introduction.html
 [python]: https://github.com/Azure/autorest.python/tree/autorestv3/docs/migrate/readme.md
 [java]: https://github.com/Azure/autorest.java/blob/main/docs/migrate/readme.md
-[csharp]: https://github.com/Azure/autorest.csharp/tree/feature/v3/docs/migrate/readme.md
+[csharp]: https://github.com/Azure/autorest.csharp/tree/main/docs/migrate/readme.md
 [typescript]: https://github.com/Azure/autorest.typescript/blob/main/packages/autorest.typescript/docs/migrate/readme.md

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -43,9 +43,9 @@ If you would like to actually debug through a language generator's code, see our
 [autorest_python_repo]: https://github.com/Azure/autorest.python/tree/autorestv3
 [debugging_flags]: https://github.com/Azure/autorest/blob/main/docs/generate/flags.md#debugging-flags
 [python_generation]: https://github.com/Azure/autorest.python/tree/autorestv3/docs/troubleshooting.md#generation-errors
-[csharp_generation]: https://github.com/Azure/autorest.csharp/tree/feature/v3/docs/troubleshooting.md#generation-errors
+[csharp_generation]: https://github.com/Azure/autorest.csharp/tree/main/docs/troubleshooting.md#generation-errors
 [typescript_generation]: https://github.com/Azure/autorest.typescript/blob/main/packages/autorest.typescript/docs/troubleshooting.md#generation-errors
 [python_debug]: https://github.com/Azure/autorest.python/tree/autorestv3/docs/troubleshooting.md#debugging
 [java_debug]: https://github.com/Azure/autorest.java/blob/main/docs/client/troubleshooting.md#debugging
-[csharp_debug]: https://github.com/Azure/autorest.csharp/tree/feature/v3/docs/troubleshooting.md#debugging
+[csharp_debug]: https://github.com/Azure/autorest.csharp/tree/main/docs/troubleshooting.md#debugging
 [typescript_debug]: https://github.com/Azure/autorest.typescript/blob/main/packages/autorest.typescript/docs/troubleshooting.md#debugging


### PR DESCRIPTION
The default branch for autorest.csharp is being renamed from feature/v3 to main