### PR TITLE
Log stack trace if `error.stack` is defined

### DIFF
--- a/common/changes/@autorest/core/error-stack_2024-10-30-23-17.json
+++ b/common/changes/@autorest/core/error-stack_2024-10-30-23-17.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "Include stack trace when logging errors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/core"
+}

--- a/packages/extensions/core/src/app.ts
+++ b/packages/extensions/core/src/app.ts
@@ -358,6 +358,9 @@ async function main() {
     if (e !== false) {
       logger.log({ level: "error", message: `!${e}` });
     }
+    if ((e as any).stack) {
+      logger.log({ level: "error", message: `stack: ${(e as any).stack}` });
+    }
     logger.log({
       level: "error",
       message:


### PR DESCRIPTION
- Fixes #5034
