### PR TITLE
Resource model envelope properties

### DIFF
--- a/common/changes/@autorest/openapi-to-typespec/resourceModel_2025-01-27-06-54.json
+++ b/common/changes/@autorest/openapi-to-typespec/resourceModel_2025-01-27-06-54.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/openapi-to-typespec",
+      "comment": "Add resourcemodel envelope properties",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/openapi-to-typespec"
+}

--- a/packages/extensions/openapi-to-typespec/src/autorest-session.ts
+++ b/packages/extensions/openapi-to-typespec/src/autorest-session.ts
@@ -2,7 +2,7 @@ import { CodeModel } from "@autorest/codemodel";
 import { Session } from "@autorest/extension-base";
 
 let _session: Session<CodeModel>;
-let _armCommonTypeVersion: string;
+let _armCommonTypeVersion: ArmCommonTypeVersion | undefined;
 let _userSetArmCommonTypeVersion: string;
 
 export function setSession(session: Session<CodeModel>): void {
@@ -17,10 +17,12 @@ export function setArmCommonTypeVersion(version: string): void {
   _userSetArmCommonTypeVersion = version;
 }
 
-export function getArmCommonTypeVersion(): string {
+export type ArmCommonTypeVersion = "v3" | "v4" | "v5" | "v6";
+
+export function getArmCommonTypeVersion(): ArmCommonTypeVersion {
   if (!_armCommonTypeVersion) {
     if (["v3", "v4", "v5", "v6"].includes(_userSetArmCommonTypeVersion)) {
-      _armCommonTypeVersion = _userSetArmCommonTypeVersion;
+      _armCommonTypeVersion = _userSetArmCommonTypeVersion as ArmCommonTypeVersion;
     } else {
       _armCommonTypeVersion = "v3"; // We hardcode the common type version to v3 if it's not set or the value is not valid, otherwise no model can extend a resource model.
     }

--- a/packages/extensions/openapi-to-typespec/src/autorest-session.ts
+++ b/packages/extensions/openapi-to-typespec/src/autorest-session.ts
@@ -3,6 +3,7 @@ import { Session } from "@autorest/extension-base";
 
 let _session: Session<CodeModel>;
 let _armCommonTypeVersion: string;
+let _userSetArmCommonTypeVersion: string;
 
 export function setSession(session: Session<CodeModel>): void {
   _session = session;
@@ -13,9 +14,20 @@ export function getSession(): Session<CodeModel> {
 }
 
 export function setArmCommonTypeVersion(version: string): void {
-  _armCommonTypeVersion = version;
+  _userSetArmCommonTypeVersion = version;
 }
 
 export function getArmCommonTypeVersion(): string {
+  if (!_armCommonTypeVersion) {
+    if (["v3", "v4", "v5", "v6"].includes(_userSetArmCommonTypeVersion)) {
+      _armCommonTypeVersion = _userSetArmCommonTypeVersion;
+    } else {
+      _armCommonTypeVersion = "v3"; // We hardcode the common type version to v3 if it's not set or the value is not valid, otherwise no model can extend a resource model.
+    }
+  }
   return _armCommonTypeVersion;
+}
+
+export function getUserSetArmCommonTypeVersion(): string {
+  return _userSetArmCommonTypeVersion;
 }

--- a/packages/extensions/openapi-to-typespec/src/generate/generate-client.ts
+++ b/packages/extensions/openapi-to-typespec/src/generate/generate-client.ts
@@ -59,6 +59,7 @@ export function generateArmResourceClientDecorator(resource: TspArmResource): st
   }
 
   for (const property of resource.properties) {
+    if (property.kind !== "property") continue;
     const decorators = generateAugmentedDecorators(`${targetName}.${property.name}`, property.clientDecorators);
     decorators && definitions.push(decorators);
   }

--- a/packages/extensions/openapi-to-typespec/src/generate/generate-enums.ts
+++ b/packages/extensions/openapi-to-typespec/src/generate/generate-enums.ts
@@ -2,17 +2,19 @@ import { TypespecEnum } from "../interfaces";
 import { getOptions } from "../options";
 import { generateDecorators } from "../utils/decorators";
 import { generateDocs } from "../utils/docs";
-import {
-  generateSuppressionForDocumentRequired,
-  generateSuppressionForNoEnum,
-  generateSuppressions,
-} from "../utils/suppressions";
+import { generateSuppressionForNoEnum, generateSuppressions, getSuppresssionWithCode } from "../utils/suppressions";
 
 export function generateEnums(typespecEnum: TypespecEnum) {
   const { isFullCompatible } = getOptions();
   const definitions: string[] = [];
   const doc = generateDocs(typespecEnum);
-  definitions.push(doc.length > 0 || !isFullCompatible ? doc : `${generateSuppressionForDocumentRequired()}\n`);
+  definitions.push(
+    doc.length > 0 || !isFullCompatible
+      ? doc
+      : `${generateSuppressions([
+          getSuppresssionWithCode("@azure-tools/typespec-azure-core/documentation-required"),
+        ])}\n`,
+  );
 
   const isExtensible = typespecEnum.isExtensible && !["ApiVersion"].includes(typespecEnum.name);
   if (!isExtensible && isFullCompatible) definitions.push(`${generateSuppressionForNoEnum()}\n`);
@@ -37,7 +39,10 @@ export function generateEnums(typespecEnum: TypespecEnum) {
             const doc = generateDocs(m);
             const kv = `"${m.name}": ${m.value}`;
             if (doc.length > 0 || !isFullCompatible) return `${doc}${kv}`;
-            else return `${generateSuppressionForDocumentRequired()}\n${kv}`;
+            else
+              return `${generateSuppressions([
+                getSuppresssionWithCode("@azure-tools/typespec-azure-core/documentation-required"),
+              ])}\n${kv}`;
           })
           .join(", ")}
     }\n\n`

--- a/packages/extensions/openapi-to-typespec/src/generate/generate-object.ts
+++ b/packages/extensions/openapi-to-typespec/src/generate/generate-object.ts
@@ -3,17 +3,15 @@ import { getOptions } from "../options";
 import { generateDecorators } from "../utils/decorators";
 import { generateDocs } from "../utils/docs";
 import { getModelPropertiesDeclarations } from "../utils/model-generation";
-import { generateSuppressionForDocumentRequired, generateSuppressions } from "../utils/suppressions";
+import { generateSuppressions } from "../utils/suppressions";
 
 export function generateObject(typespecObject: TypespecObject) {
-  const { isFullCompatible } = getOptions();
   let definitions: string[] = [];
 
   const fixme = getFixme(typespecObject);
   fixme && definitions.push(fixme);
 
   const doc = generateDocs(typespecObject);
-  if (doc === "" && isFullCompatible) definitions.push(generateSuppressionForDocumentRequired());
   definitions.push(doc);
 
   const decorators = generateDecorators(typespecObject.decorators);

--- a/packages/extensions/openapi-to-typespec/src/generate/generate-parameter.ts
+++ b/packages/extensions/openapi-to-typespec/src/generate/generate-parameter.ts
@@ -2,7 +2,7 @@ import { TypespecParameter } from "../interfaces";
 import { getOptions } from "../options";
 import { generateDecorators } from "../utils/decorators";
 import { generateDocs } from "../utils/docs";
-import { generateSuppressionForDocumentRequired, generateSuppressions } from "../utils/suppressions";
+import { generateSuppressions } from "../utils/suppressions";
 
 const _ARM_PARAM_REPLACEMENTS: { [key: string]: string } = {
   subscriptionId: "...SubscriptionIdParameter",

--- a/packages/extensions/openapi-to-typespec/src/generate/generate-service-information.ts
+++ b/packages/extensions/openapi-to-typespec/src/generate/generate-service-information.ts
@@ -4,8 +4,6 @@ import { getOptions } from "../options";
 import { generateDocs } from "../utils/docs";
 import { getNamespaceStatement } from "../utils/namespace";
 
-const VALID_VERSIONS = ["v3", "v4", "v5"];
-
 export function generateServiceInformation(program: TypespecProgram) {
   const { serviceInformation } = program;
   const definitions: string[] = [];
@@ -24,18 +22,18 @@ export function generateServiceInformation(program: TypespecProgram) {
   }
 
   if (isArm && serviceInformation.armCommonTypeVersion) {
-    if (VALID_VERSIONS.includes(serviceInformation.armCommonTypeVersion)) {
+    if (serviceInformation.armCommonTypeVersion !== serviceInformation.userSetArmCommonTypeVersion) {
       definitions.push(
-        `@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.${serviceInformation.armCommonTypeVersion})`,
-      );
-    } else {
-      definitions.push(
-        `// FIXME: Common type version ${serviceInformation.armCommonTypeVersion} is not supported for now.`,
-      );
-      definitions.push(
-        `// @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.${serviceInformation.armCommonTypeVersion})`,
+        `// FIXME: ${
+          serviceInformation.userSetArmCommonTypeVersion
+            ? `Common type version ${serviceInformation.userSetArmCommonTypeVersion} is not supported for now.`
+            : "Common type version not set."
+        } Set to v3.`,
       );
     }
+    definitions.push(
+      `@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.${serviceInformation.armCommonTypeVersion})`,
+    );
   }
 
   if (!isArm && serviceInformation.endpoint) {

--- a/packages/extensions/openapi-to-typespec/src/interfaces.ts
+++ b/packages/extensions/openapi-to-typespec/src/interfaces.ts
@@ -31,6 +31,7 @@ export interface WithSummary {
 export interface WithDecorators {
   decorators?: TypespecDecorator[];
   clientDecorators?: TypespecDecorator[];
+  augmentDecorators?: TypespecDecorator[];
 }
 
 export interface TypespecOperationGroup extends WithDoc, WithSuppressDirectives {
@@ -101,6 +102,7 @@ export interface ServiceInformation extends WithDoc {
   consumes?: string[];
   authentication?: Auth[];
   armCommonTypeVersion?: string;
+  userSetArmCommonTypeVersion?: string;
 }
 
 export interface EndpointParameter extends WithDoc {
@@ -122,6 +124,7 @@ export type TypespecModel = TypespecTemplateModel | TypespecDataType;
 export interface TypespecTemplateModel extends TypespecDataType {
   kind: "template";
   arguments?: TypespecModel[];
+  namedArguments?: Record<string, string>; // TO-DO: value is string for now, should be refacted to some object type
   additionalProperties?: TypespecParameter[]; // Currently for body purpose
   additionalTemplateModel?: string; // Currently for LRO header purpose
 }
@@ -180,6 +183,12 @@ export interface TypespecObjectProperty extends TypespecDataType, WithSuppressDi
   decorators?: TypespecDecorator[];
   clientDecorators?: TypespecDecorator[];
   defaultValue?: any;
+}
+
+// A spread statement is always spreading some model or template from library
+export interface TypespecSpreadStatement extends WithSuppressDirectives, WithDecorators, WithDoc {
+  kind: "spread";
+  model: TypespecTemplateModel;
 }
 
 export interface TypespecDecorator extends WithFixMe, WithSuppressDirective {
@@ -321,17 +330,15 @@ export interface TspArmProviderActionOperation extends WithDoc, WithSummary, Wit
   lroHeaders?: TspLroHeaders;
 }
 
-export interface TspArmResource extends TypespecObject {
+export interface TspArmResource extends TypespecDataType, WithFixMe, WithDoc, WithDecorators {
   resourceKind: ArmResourceKind;
-  keyExpression: string | undefined;
+  properties: (TypespecObjectProperty | TypespecSpreadStatement)[];
   propertiesModelName: string;
   propertiesPropertyRequired: boolean;
   propertiesPropertyDescription: string;
   propertiesPropertyClientDecorator: TypespecDecorator[];
   resourceParent?: TspArmResource;
   resourceOperationGroups: TspArmResourceOperationGroup[];
-  optionalStandardProperties: string[];
-  baseModelName?: string;
   locationParent?: string;
 }
 

--- a/packages/extensions/openapi-to-typespec/src/transforms/transform-arm-resources.ts
+++ b/packages/extensions/openapi-to-typespec/src/transforms/transform-arm-resources.ts
@@ -1,7 +1,7 @@
 import { Operation, Parameter, Property, SchemaType } from "@autorest/codemodel";
 import _ from "lodash";
 import pluralize, { singular } from "pluralize";
-import { getArmCommonTypeVersion, getSession } from "../autorest-session";
+import { getSession } from "../autorest-session";
 import { getDataTypes } from "../data-types";
 import {
   ArmResourceKind,

--- a/packages/extensions/openapi-to-typespec/src/transforms/transform-service-information.ts
+++ b/packages/extensions/openapi-to-typespec/src/transforms/transform-service-information.ts
@@ -6,7 +6,7 @@ import {
   ParameterLocation,
   SecurityScheme,
 } from "@autorest/codemodel";
-import { getArmCommonTypeVersion } from "../autorest-session";
+import { getArmCommonTypeVersion, getUserSetArmCommonTypeVersion } from "../autorest-session";
 import { ApiVersion } from "../constants";
 import { AadOauth2AuthFlow, ApiKeyAuthentication, Auth, EndpointParameter, ServiceInformation } from "../interfaces";
 import { getOptions } from "../options";
@@ -22,6 +22,7 @@ export function transformServiceInformation(model: CodeModel): ServiceInformatio
     endpointParameters: transformEndpointParameters(model),
     versions: getApiVersions(model),
     armCommonTypeVersion: isArm ? getArmCommonTypeVersion() : undefined,
+    userSetArmCommonTypeVersion: isArm ? getUserSetArmCommonTypeVersion() : undefined,
     authentication: getAuth(model),
   };
 }

--- a/packages/extensions/openapi-to-typespec/src/utils/common-type-mapping.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/common-type-mapping.ts
@@ -1,0 +1,186 @@
+import { isObjectSchema, Schema } from "@autorest/codemodel";
+import { getArmCommonTypeVersion } from "../autorest-session";
+import { isChoiceSchema, isDictionarySchema, isSealedChoiceSchema, isUriSchema, isUuidSchema } from "./schemas";
+
+export function isSku(schema: Schema): boolean {
+  if (!isObjectSchema(schema) || schema.properties?.length !== 5) return false;
+
+  let nameFound = false;
+  let tierFound = false;
+  let sizeFound = false;
+  let familyFound = false;
+  let capacityFound = false;
+
+  for (const property of schema.properties) {
+    if (property.serializedName === "name" && property.required && property.schema.type === "string") {
+      nameFound = true;
+    } else if (property.serializedName === "tier" && !property.required && isSkuTier(property.schema)) {
+      tierFound = true;
+    } else if (property.serializedName === "size" && !property.required && property.schema.type === "string") {
+      sizeFound = true;
+    } else if (property.serializedName === "family" && !property.required && property.schema.type === "string") {
+      familyFound = true;
+    } else if (property.serializedName === "capacity" && !property.required && property.schema.type === "integer") {
+      capacityFound = true;
+    }
+  }
+  return nameFound && tierFound && sizeFound && familyFound && capacityFound;
+}
+
+function isSkuTier(schema: Schema): boolean {
+  if (!isSealedChoiceSchema(schema) || schema.choices.length !== 4) return false;
+
+  let freeFound = false;
+  let basicFound = false;
+  let standardFound = false;
+  let premiumFound = false;
+  for (const choice of schema.choices) {
+    if (choice.value === "Free") {
+      freeFound = true;
+    } else if (choice.value === "Basic") {
+      basicFound = true;
+    } else if (choice.value === "Standard") {
+      standardFound = true;
+    } else if (choice.value === "Premium") {
+      premiumFound = true;
+    }
+  }
+  return freeFound && basicFound && standardFound && premiumFound;
+}
+
+export function isExtendedLocation(schema: Schema): boolean {
+  if (!isObjectSchema(schema) || schema.properties?.length !== 2) return false;
+
+  let typeFound = false;
+  let nameFound = false;
+
+  for (const property of schema.properties) {
+    if (property.serializedName === "type" && property.required && isExtendedLocationType(property.schema)) {
+      typeFound = true;
+    } else if (property.serializedName === "name" && property.required && property.schema.type === "string") {
+      nameFound = true;
+    }
+  }
+  return typeFound && nameFound;
+}
+
+function isExtendedLocationType(schema: Schema): boolean {
+  if (!isChoiceSchema(schema) || schema.choices.length !== 2) return false;
+
+  let edgeFound = false;
+  let customLocationFound = false;
+
+  for (const choice of schema.choices) {
+    if (choice.value === "Edge") {
+      edgeFound = true;
+    } else if (choice.value === "CustomLocation") {
+      customLocationFound = true;
+    }
+  }
+  return edgeFound && customLocationFound;
+}
+
+export function isPlan(schema: Schema): boolean {
+  if (!isObjectSchema(schema) || schema.properties?.length !== 5) return false;
+
+  let nameFound = false;
+  let publisherFound = false;
+  let productFound = false;
+  let promotionCodeFound = false;
+  let versionFound = false;
+
+  for (const property of schema.properties) {
+    if (property.serializedName === "name" && property.required && property.schema.type === "string") {
+      nameFound = true;
+    } else if (property.serializedName === "publisher" && property.required && property.schema.type === "string") {
+      publisherFound = true;
+    } else if (property.serializedName === "product" && property.required && property.schema.type === "string") {
+      productFound = true;
+    } else if (property.serializedName === "promotionCode" && !property.required && property.schema.type === "string") {
+      promotionCodeFound = true;
+    } else if (property.serializedName === "version" && !property.required && property.schema.type === "string") {
+      versionFound = true;
+    }
+  }
+
+  return nameFound && publisherFound && productFound && promotionCodeFound && versionFound;
+}
+
+export function isManagedSerivceIdentity(schema: Schema): boolean {
+  if (!isObjectSchema(schema) || schema.properties?.length !== 4) return false;
+
+  const commonTypeVersion = getArmCommonTypeVersion();
+  let principalIdFound = false;
+  let tenantIdFound = false;
+  let typeFound = false;
+  let userAssignedIdentitiesFound = false;
+
+  for (const property of schema.properties) {
+    if (property.serializedName === "principalId" && !property.required && isUuidSchema(property.schema)) {
+      principalIdFound = true;
+    } else if (property.serializedName === "tenantId" && !property.required && isUuidSchema(property.schema)) {
+      tenantIdFound = true;
+    } else if (
+      property.serializedName === "type" &&
+      property.required &&
+      isManagedSerivceIdentityType(property.schema)
+    ) {
+      typeFound = true;
+    }
+    // For all the common type versions only check if it is dictionary with specific value type because of https://github.com/Azure/typespec-azure/issues/1163
+    else if (
+      property.serializedName === "userAssignedIdentities" &&
+      !property.required &&
+      isDictionarySchema(property.schema) &&
+      isUserAssignedIdentity(property.schema.elementType)
+    ) {
+      return (userAssignedIdentitiesFound = true);
+    }
+  }
+
+  return principalIdFound && tenantIdFound && typeFound && userAssignedIdentitiesFound;
+}
+
+function isManagedSerivceIdentityType(schema: Schema): boolean {
+  if (!isChoiceSchema(schema) || schema.choices.length !== 4) return false;
+
+  const commonTypeVersion = getArmCommonTypeVersion();
+  let noneFound = false;
+  let systemAssignedFound = false;
+  let userAssignedFound = false;
+  let systemAssignedUserAssignedFound = false;
+
+  for (const choice of schema.choices) {
+    if (choice.value === "None") {
+      noneFound = true;
+    } else if (choice.value === "SystemAssigned") {
+      systemAssignedFound = true;
+    } else if (choice.value === "UserAssigned") {
+      userAssignedFound = true;
+    } else if (
+      (choice.value === "SystemAssigned,UserAssigned" && ["v6", "v5", "v3"].includes(commonTypeVersion)) ||
+      (choice.value === "SystemAssigned, UserAssigned" && commonTypeVersion === "v4")
+    ) {
+      systemAssignedUserAssignedFound = true;
+    }
+  }
+
+  return noneFound && systemAssignedFound && userAssignedFound && systemAssignedUserAssignedFound;
+}
+
+function isUserAssignedIdentity(schema: Schema): boolean {
+  if (!isObjectSchema(schema) || schema.properties?.length !== 2) return false;
+
+  let principalIdFound = false;
+  let clientIdFound = false;
+
+  for (const property of schema.properties) {
+    if (property.serializedName === "principalId" && !property.required && isUuidSchema(property.schema)) {
+      principalIdFound = true;
+    } else if (property.serializedName === "clientId" && !property.required && isUuidSchema(property.schema)) {
+      clientIdFound = true;
+    }
+  }
+
+  return principalIdFound && clientIdFound;
+}

--- a/packages/extensions/openapi-to-typespec/src/utils/model-generation.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/model-generation.ts
@@ -1,35 +1,64 @@
-import { TypespecObjectProperty } from "../interfaces";
+import { generateParameter } from "../generate/generate-parameter";
+import { TypespecObjectProperty, TypespecSpreadStatement, TypespecTemplateModel } from "../interfaces";
 import { getOptions } from "../options";
 import { generateDecorators } from "./decorators";
 import { generateDocs } from "./docs";
-import { generateSuppressionForDocumentRequired, generateSuppressions } from "./suppressions";
+import { generateSuppressions } from "./suppressions";
 import { getFullyQualifiedName } from "./type-mapping";
 
 export function getModelPropertiesDeclarations(properties: TypespecObjectProperty[]): string[] {
-  const { isFullCompatible } = getOptions();
   const definitions: string[] = [];
   for (const property of properties) {
-    const propertyDoc = generateDocs(property);
-    if (propertyDoc === "" && isFullCompatible) definitions.push(generateSuppressionForDocumentRequired());
-    propertyDoc && definitions.push(propertyDoc);
-    const decorators = generateDecorators(property.decorators);
-    decorators && definitions.push(decorators);
-    property.fixMe && property.fixMe.length && definitions.push(property.fixMe.join("\n"));
-    let defaultValue = "";
-    if (property.defaultValue) {
-      defaultValue = ` = ${property.defaultValue}`;
-    }
-    if (isFullCompatible && property.suppressions) {
-      definitions.push(...generateSuppressions(property.suppressions));
-    }
-    definitions.push(
-      `"${property.name}"${getOptionalOperator(property)}: ${getFullyQualifiedName(property.type)}${defaultValue};`,
-    );
+    definitions.push(...getModelPropertyDeclarations(property));
   }
 
   return definitions;
 }
 
+export function getModelPropertyDeclarations(property: TypespecObjectProperty): string[] {
+  const definitions: string[] = [];
+  const propertyDoc = generateDocs(property);
+  propertyDoc && definitions.push(propertyDoc);
+  const decorators = generateDecorators(property.decorators);
+  decorators && definitions.push(decorators);
+  property.fixMe && property.fixMe.length && definitions.push(property.fixMe.join("\n"));
+  let defaultValue = "";
+  if (property.defaultValue) {
+    defaultValue = ` = ${property.defaultValue}`;
+  }
+  if (property.suppressions) {
+    definitions.push(...generateSuppressions(property.suppressions));
+  }
+  definitions.push(
+    `"${property.name}"${getOptionalOperator(property)}: ${getFullyQualifiedName(property.type)}${defaultValue};`,
+  );
+  return definitions;
+}
+
+export function getSpreadExpressionDecalaration(property: TypespecSpreadStatement): string {
+  return `...${generateTemplateModel(property.model)}`;
+}
+
 function getOptionalOperator(property: TypespecObjectProperty) {
   return property.isOptional ? "?" : "";
+}
+
+export function generateTemplateModel(templateModel: TypespecTemplateModel): string {
+  return `${templateModel.name}${
+    templateModel.namedArguments
+      ? `<${Object.keys(templateModel.namedArguments)
+          .map((k) => `${k} = ${templateModel.namedArguments![k]}`)
+          .join(",")}>`
+      : ""
+  }${
+    !templateModel.namedArguments && templateModel.arguments
+      ? `<${templateModel.arguments
+          .map((a) => (a.kind === "template" ? generateTemplateModel(a as TypespecTemplateModel) : a.name))
+          .join(",")}>`
+      : ""
+  }${
+    templateModel.additionalProperties
+      ? ` & { ${templateModel.additionalProperties.map((p) => generateParameter(p)).join(";")} }`
+      : ""
+  }${templateModel.additionalTemplateModel ? templateModel.additionalTemplateModel : ""}`;
 }

--- a/packages/extensions/openapi-to-typespec/src/utils/resource-discovery.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/resource-discovery.ts
@@ -174,7 +174,6 @@ const _ArmCoreCustomTypes = [
   "TrackedResource",
   "ProxyResource",
   "ExtensionResource",
-  "ManagedServiceIdentity",
   "ManagedIdentityProperties",
   "UserAssignedIdentity",
   "ManagedSystemAssignedIdentity",

--- a/packages/extensions/openapi-to-typespec/src/utils/resource-discovery.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/resource-discovery.ts
@@ -224,7 +224,3 @@ export function filterArmEnums(enums: TypespecEnum[]): TypespecEnum[] {
   }
   return enums.filter((e) => !filtered.includes(e.name));
 }
-
-export function isTspArmResource(schema: TypespecObject): schema is TspArmResource {
-  return Boolean((schema as TspArmResource).resourceKind);
-}

--- a/packages/extensions/openapi-to-typespec/src/utils/schemas.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/schemas.ts
@@ -12,6 +12,7 @@ import {
   StringSchema,
   ArmIdSchema,
   UriSchema,
+  UuidSchema,
 } from "@autorest/codemodel";
 
 export function isConstantSchema(schema: Schema): schema is ConstantSchema {
@@ -24,6 +25,10 @@ export function isStringSchema(schema: Schema): schema is StringSchema {
 
 export function isUriSchema(schema: Schema): schema is UriSchema {
   return schema.type === SchemaType.Uri;
+}
+
+export function isUuidSchema(schema: Schema): schema is UuidSchema {
+  return schema.type === SchemaType.Uuid;
 }
 
 export function isArraySchema(schema: Schema): schema is ArraySchema {

--- a/packages/extensions/openapi-to-typespec/src/utils/suppressions.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/suppressions.ts
@@ -2,17 +2,8 @@ import { Property } from "@autorest/codemodel";
 import { WithSuppressDirective } from "../interfaces";
 import { isDictionarySchema } from "./schemas";
 
-// TO-DO: remove it
-export function generateSuppressionForDocumentRequired(): string {
-  return `#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"`;
-}
-
 export function generateSuppressionForNoEnum(): string {
   return `#suppress "@azure-tools/typespec-azure-core/no-enum" "For backward compatibility"`;
-}
-
-export function getPropertySuppressions(propertySchema: Property): WithSuppressDirective[] | undefined {
-  return isDictionarySchema(propertySchema.schema) ? getSuppressionsForRecordProperty() : undefined;
 }
 
 export function generateSuppressions(suppressions: WithSuppressDirective[]): string[] {
@@ -70,15 +61,6 @@ export function getSuppressionsForModelExtension(): WithSuppressDirective[] {
   return [
     {
       suppressionCode: "@azure-tools/typespec-azure-core/composition-over-inheritance",
-      suppressionMessage: "For backward compatibility",
-    },
-  ];
-}
-
-export function getSuppressionsForRecordProperty(): WithSuppressDirective[] {
-  return [
-    {
-      suppressionCode: "@azure-tools/typespec-azure-resource-manager/arm-no-record",
       suppressionMessage: "For backward compatibility",
     },
   ];

--- a/packages/extensions/openapi-to-typespec/src/utils/type-mapping.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/type-mapping.ts
@@ -8,7 +8,6 @@ import { isArraySchema, isResponseSchema, isStringSchema, isUriSchema } from "./
 
 export function getFullyQualifiedName(type: string, namespace: string | undefined = undefined): string {
   switch (type) {
-    case "ManagedServiceIdentity":
     case "TenantBaseParameters":
     case "BaseParameters":
     case "SubscriptionBaseParameters":

--- a/packages/extensions/openapi-to-typespec/src/utils/type-mapping.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/type-mapping.ts
@@ -1,9 +1,9 @@
 import { ArraySchema, isObjectSchema, ObjectSchema, Operation, Response, SchemaResponse } from "@autorest/codemodel";
 import { getSession } from "../autorest-session";
 import { getDataTypes } from "../data-types";
-import { generateTemplateModel } from "../generate/generate-arm-resource";
 import { TypespecDataType, TypespecTemplateModel } from "../interfaces";
 import { isResource } from "../resource/resource-equivalent";
+import { generateTemplateModel } from "./model-generation";
 import { isArraySchema, isResponseSchema, isStringSchema, isUriSchema } from "./schemas";
 
 export function getFullyQualifiedName(type: string, namespace: string | undefined = undefined): string {

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/swagger-output/swagger.json
@@ -2173,8 +2173,8 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "../../common-types/resource-management/v4/managedidentity.json#/definitions/ManagedServiceIdentity",
-          "description": "The managed service identities assigned to this resource."
+          "$ref": "#/definitions/Identity",
+          "description": "Identity for the resource."
         }
       },
       "allOf": [

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/DataManagerForAgriculture.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/DataManagerForAgriculture.tsp
@@ -21,7 +21,12 @@ model DataManagerForAgriculture
     SegmentName = "farmBeats",
     NamePattern = "^[A-Za-z0-9]+(-[A-Za-z0-9]+)*$"
   >;
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
+
+  /**
+   * Identity for the resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  identity?: Identity;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/tsp-output/main.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/tsp-output/main.tsp
@@ -31,8 +31,8 @@ using TypeSpec.Versioning;
   title: "AlertsManagementClient",
 })
 @versioned(Versions)
-// FIXME: Common type version v2 is not supported for now.
-// @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v2)
+// FIXME: Common type version v2 is not supported for now. Set to v3.
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v3)
 namespace Azure.ResourceManager.AlertsManagement;
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-analysisservices/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-analysisservices/swagger-output/swagger.json
@@ -823,7 +823,7 @@
           "readOnly": true
         },
         "sku": {
-          "$ref": "#/definitions/ResourceSku",
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty",
           "description": "The SKU of the Analysis Services resource."
         }
       },
@@ -838,7 +838,7 @@
       "description": "Provision request specification",
       "properties": {
         "sku": {
-          "$ref": "#/definitions/ResourceSku",
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty",
           "description": "The SKU of the Analysis Services resource."
         },
         "tags": {
@@ -870,6 +870,16 @@
       "required": [
         "value"
       ]
+    },
+    "Azure.ResourceManager.ResourceSkuProperty": {
+      "type": "object",
+      "description": "The SKU (Stock Keeping Unit) assigned to this resource.",
+      "properties": {
+        "sku": {
+          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/Sku",
+          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
+        }
+      }
     },
     "CheckServerNameAvailabilityParameters": {
       "type": "object",
@@ -1073,31 +1083,6 @@
       },
       "readOnly": true
     },
-    "ResourceSku": {
-      "type": "object",
-      "description": "Represents the SKU name and Azure pricing tier for Analysis Services resource.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Name of the SKU level."
-        },
-        "tier": {
-          "$ref": "#/definitions/SkuTier",
-          "description": "The name of the Azure pricing tier to which the SKU applies."
-        },
-        "capacity": {
-          "type": "integer",
-          "format": "int32",
-          "description": "The number of instances in the read only query pool.",
-          "default": 1,
-          "minimum": 1,
-          "maximum": 8
-        }
-      },
-      "required": [
-        "name"
-      ]
-    },
     "ServerAdministrators": {
       "type": "object",
       "description": "An array of administrator user identities.",
@@ -1138,7 +1123,7 @@
       "description": "An object that represents SKU details for existing resources.",
       "properties": {
         "sku": {
-          "$ref": "#/definitions/ResourceSku",
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty",
           "description": "The SKU in SKU details for existing resources."
         },
         "resourceType": {
@@ -1171,39 +1156,12 @@
           "type": "array",
           "description": "The collection of available SKUs for new resources.",
           "items": {
-            "$ref": "#/definitions/ResourceSku"
+            "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty"
           },
           "x-ms-identifiers": [
             "name"
           ]
         }
-      }
-    },
-    "SkuTier": {
-      "type": "string",
-      "description": "The name of the Azure pricing tier to which the SKU applies.",
-      "enum": [
-        "Development",
-        "Basic",
-        "Standard"
-      ],
-      "x-ms-enum": {
-        "name": "SkuTier",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Development",
-            "value": "Development"
-          },
-          {
-            "name": "Basic",
-            "value": "Basic"
-          },
-          {
-            "name": "Standard",
-            "value": "Standard"
-          }
-        ]
       }
     },
     "State": {

--- a/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/main.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/main.tsp
@@ -30,6 +30,8 @@ using TypeSpec.Versioning;
   title: "AzureAnalysisServices",
 })
 @versioned(Versions)
+// FIXME: Common type version not set. Set to v3.
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v3)
 namespace Azure.ResourceManager.Analysis;
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/models.tsp
@@ -75,19 +75,6 @@ union ProvisioningState {
 }
 
 /**
- * The name of the Azure pricing tier to which the SKU applies.
- */
-union SkuTier {
-  string,
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Development: "Development",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Basic: "Basic",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Standard: "Standard",
-}
-
-/**
  * The managed mode of the server (0 = not managed, 1 = managed).
  */
 union ManagedMode {
@@ -146,28 +133,6 @@ model AnalysisServicesServerProperties
    * The SKU of the Analysis Services resource.
    */
   sku?: ResourceSku;
-}
-
-/**
- * Represents the SKU name and Azure pricing tier for Analysis Services resource.
- */
-model ResourceSku {
-  /**
-   * Name of the SKU level.
-   */
-  name: string;
-
-  /**
-   * The name of the Azure pricing tier to which the SKU applies.
-   */
-  tier?: SkuTier;
-
-  /**
-   * The number of instances in the read only query pool.
-   */
-  @maxValue(8)
-  @minValue(1)
-  capacity?: int32 = 1;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/ApiManagementServiceResource.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/ApiManagementServiceResource.tsp
@@ -26,18 +26,25 @@ model ApiManagementServiceResource
   >;
 
   /**
+   * SKU properties of the API Management service.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  sku: ApiManagementServiceSkuProperties;
+
+  /**
+   * Managed service identity of the Api Management service.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  identity?: ApiManagementServiceIdentity;
+
+  /**
    * ETag of the resource.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   etag?: string;
 
-  /**
-   * A list of availability zones denoting where the resource needs to come from.
-   */
-  zones?: string[];
-
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
-  ...Azure.ResourceManager.ResourceSkuProperty;
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/DeletedServiceContract.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/DeletedServiceContract.tsp
@@ -27,6 +27,7 @@ model DeletedServiceContract
   /**
    * API Management Service Master Location.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   location?: string;
 }

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/main.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/main.tsp
@@ -72,8 +72,8 @@ using TypeSpec.Versioning;
   title: "ApiManagementClient",
 })
 @versioned(Versions)
-// FIXME: Common type version v2 is not supported for now.
-// @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v2)
+// FIXME: Common type version v2 is not supported for now. Set to v3.
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v3)
 namespace Azure.ResourceManager.ApiManagement;
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/models.tsp
@@ -3514,8 +3514,8 @@ model ConnectivityIssue {
   context?: Record<string>[];
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ContentTypeContractProperties {
   /**
    * Content type identifier
@@ -3543,8 +3543,8 @@ model ContentTypeContractProperties {
   version?: string;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model DeletedServiceContractProperties {
   /**
    * Fully-qualified API Management Service Resource ID
@@ -4563,8 +4563,8 @@ model GatewayHostnameConfigurationContractProperties {
   http2Enabled?: boolean;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model GatewayApiData extends ApiContract {}
 
 /**
@@ -4714,8 +4714,8 @@ model GroupUpdateParametersProperties {
   externalId?: string;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ApiManagementGroupUserData extends UserContract {}
 
 /**
@@ -5495,8 +5495,8 @@ model PolicyDescriptionContractProperties {
   scope?: int64;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model PortalRevisionContractProperties {
   /**
    * Portal revision description.
@@ -5832,12 +5832,12 @@ model ProductUpdateProperties extends ProductEntityBaseParameters {
   displayName?: string;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ProductApiData extends ApiContract {}
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ProductGroupData extends GroupContract {}
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/DenyAssignment.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/DenyAssignment.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Deny Assignment
  */
+@extensionResource
 model DenyAssignment
   is Azure.ResourceManager.ExtensionResource<DenyAssignmentProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/ProviderOperationsMetadata.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/ProviderOperationsMetadata.tsp
@@ -26,17 +26,20 @@ model ProviderOperationsMetadata is Azure.ResourceManager.ProxyResource<{}> {
   /**
    * The provider display name.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   displayName?: string;
 
   /**
    * The provider resource types
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @OpenAPI.extension("x-ms-identifiers", ["name"])
   resourceTypes?: AuthorizationProviderResourceType[];
 
   /**
    * The provider operations.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @OpenAPI.extension("x-ms-identifiers", [])
   operations?: ProviderOperation[];
 }

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignment.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignment.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role Assignments
  */
+@extensionResource
 model RoleAssignment
   is Azure.ResourceManager.ExtensionResource<RoleAssignmentProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignmentSchedule.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignmentSchedule.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role Assignment schedule
  */
+@extensionResource
 model RoleAssignmentSchedule
   is Azure.ResourceManager.ExtensionResource<RoleAssignmentScheduleProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignmentScheduleInstance.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignmentScheduleInstance.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Information about current or upcoming role assignment schedule instance
  */
+@extensionResource
 model RoleAssignmentScheduleInstance
   is Azure.ResourceManager.ExtensionResource<RoleAssignmentScheduleInstanceProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignmentScheduleRequest.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleAssignmentScheduleRequest.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role Assignment schedule request
  */
+@extensionResource
 model RoleAssignmentScheduleRequest
   is Azure.ResourceManager.ExtensionResource<RoleAssignmentScheduleRequestProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleDefinition.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleDefinition.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role definition.
  */
+@extensionResource
 model RoleDefinition
   is Azure.ResourceManager.ExtensionResource<RoleDefinitionProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleEligibilitySchedule.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleEligibilitySchedule.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role eligibility schedule
  */
+@extensionResource
 model RoleEligibilitySchedule
   is Azure.ResourceManager.ExtensionResource<RoleEligibilityScheduleProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleEligibilityScheduleInstance.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleEligibilityScheduleInstance.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Information about current or upcoming role eligibility schedule instance
  */
+@extensionResource
 model RoleEligibilityScheduleInstance
   is Azure.ResourceManager.ExtensionResource<RoleEligibilityScheduleInstanceProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleEligibilityScheduleRequest.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleEligibilityScheduleRequest.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role Eligibility schedule request
  */
+@extensionResource
 model RoleEligibilityScheduleRequest
   is Azure.ResourceManager.ExtensionResource<RoleEligibilityScheduleRequestProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleManagementPolicy.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleManagementPolicy.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role management policy
  */
+@extensionResource
 model RoleManagementPolicy
   is Azure.ResourceManager.ExtensionResource<RoleManagementPolicyProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleManagementPolicyAssignment.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/RoleManagementPolicyAssignment.tsp
@@ -13,6 +13,7 @@ namespace Azure.ResourceManager.Authorization;
 /**
  * Role management policy
  */
+@extensionResource
 model RoleManagementPolicyAssignment
   is Azure.ResourceManager.ExtensionResource<RoleManagementPolicyAssignmentProperties> {
   ...ResourceNameParameter<

--- a/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/main.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-authorization/tsp-output/main.tsp
@@ -41,8 +41,8 @@ using TypeSpec.Versioning;
   title: "AuthorizationManagementClient",
 })
 @versioned(Versions)
-// FIXME: Common type version v2 is not supported for now.
-// @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v2)
+// FIXME: Common type version v2 is not supported for now. Set to v3.
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v3)
 namespace Azure.ResourceManager.Authorization;
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/AvailabilitySet.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/AvailabilitySet.tsp
@@ -25,6 +25,7 @@ model AvailabilitySet
   /**
    * Sku of the availability set, only name is required to be set. See AvailabilitySetSkuTypes for possible set of values. Use 'Aligned' for virtual machines with managed disks and 'Classic' for virtual machines with unmanaged disks. Default value is 'Classic'.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku?: Sku;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CapacityReservation.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CapacityReservation.tsp
@@ -27,12 +27,10 @@ model CapacityReservation
   /**
    * SKU of the resource for which capacity needs be reserved. The SKU name and capacity is required to be set. Currently VM Skus with the capability called 'CapacityReservationSupported' set to true are supported. Refer to List Microsoft.Compute SKUs in a region (https://docs.microsoft.com/rest/api/compute/resourceskus/list) for supported values.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku: Sku;
 
-  /**
-   * Availability Zone to use for this capacity reservation. The zone has to be single value and also should be part for the list of zones specified during the capacity reservation group creation. The zone can be assigned only during creation. If not provided, the reservation supports only non-zonal deployments. If provided, enforces VM/VMSS using this capacity reservation to be in same zone.
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CapacityReservationGroup.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CapacityReservationGroup.tsp
@@ -21,11 +21,7 @@ model CapacityReservationGroup
     SegmentName = "capacityReservationGroups",
     NamePattern = ""
   >;
-
-  /**
-   * Availability Zones to use for this capacity reservation group. The zones can be assigned only during creation. If not provided, the group supports only regional resources in the region. If provided, enforces each capacity reservation in the group to be in one of the zones.
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CloudService.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CloudService.tsp
@@ -21,11 +21,7 @@ model CloudService
     SegmentName = "cloudServices",
     NamePattern = ""
   >;
-
-  /**
-   * List of logical availability zone of the resource. List should contain only 1 zone where cloud service should be provisioned. This field is optional.
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CloudServiceRole.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/CloudServiceRole.tsp
@@ -27,12 +27,14 @@ model CloudServiceRole
   /**
    * Resource location
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   location?: string;
 
   /**
    * Describes the cloud service role sku.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku?: CloudServiceRoleSku;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DedicatedHost.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DedicatedHost.tsp
@@ -27,6 +27,7 @@ model DedicatedHost
   /**
    * SKU of the dedicated host for Hardware Generation and VM family. Only name is required to be set. List Microsoft.Compute SKUs for a list of possible values.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku: Sku;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DedicatedHostGroup.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DedicatedHostGroup.tsp
@@ -21,11 +21,7 @@ model DedicatedHostGroup
     SegmentName = "hostGroups",
     NamePattern = ""
   >;
-
-  /**
-   * Availability Zone to use for this host group. Only single zone is supported. The zone can be assigned only during creation. If not provided, the group supports all zones in the region. If provided, enforces each host in the group to be in the same zone.
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/Disk.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/Disk.tsp
@@ -24,28 +24,29 @@ model Disk is Azure.ResourceManager.TrackedResource<DiskProperties> {
   /**
    * A relative URI containing the ID of the VM that has the disk attached.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   managedBy?: string;
 
   /**
    * List of relative URIs containing the IDs of the VMs that have the disk attached. maxShares should be set to a value greater than one for disks to allow attaching them to multiple VMs.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   managedByExtended?: string[];
 
   /**
    * The disks sku name. Can be Standard_LRS, Premium_LRS, StandardSSD_LRS, UltraSSD_LRS, Premium_ZRS, StandardSSD_ZRS, or PremiumV2_LRS.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku?: DiskSku;
 
-  /**
-   * The Logical zone list for Disk.
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 
   /**
    * The extended location where the disk will be created. Extended location cannot be changed.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   extendedLocation?: ExtendedLocation;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DiskAccess.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DiskAccess.tsp
@@ -25,6 +25,7 @@ model DiskAccess
   /**
    * The extended location where the disk access will be created. Extended location cannot be changed.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   extendedLocation?: ExtendedLocation;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DiskEncryptionSet.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/DiskEncryptionSet.tsp
@@ -25,6 +25,7 @@ model DiskEncryptionSet
   /**
    * The managed identity for the disk encryption set. It should be given permission on the key vault before it can be used to encrypt disks.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   identity?: EncryptionSetIdentity;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/Image.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/Image.tsp
@@ -24,6 +24,7 @@ model Image is Azure.ResourceManager.TrackedResource<ImageProperties> {
   /**
    * The extended location of the Image.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   extendedLocation?: ExtendedLocation;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/OSFamily.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/OSFamily.tsp
@@ -26,6 +26,7 @@ model OSFamily is Azure.ResourceManager.ProxyResource<OSFamilyProperties> {
   /**
    * Resource location.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   location?: string;
 }

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/OSVersion.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/OSVersion.tsp
@@ -26,6 +26,7 @@ model OSVersion is Azure.ResourceManager.ProxyResource<OSVersionProperties> {
   /**
    * Resource location.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   location?: string;
 }

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/ProximityPlacementGroup.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/ProximityPlacementGroup.tsp
@@ -21,11 +21,7 @@ model ProximityPlacementGroup
     SegmentName = "proximityPlacementGroups",
     NamePattern = ""
   >;
-
-  /**
-   * Specifies the Availability Zone where virtual machine, virtual machine scale set or availability set associated with the  proximity placement group can be created.
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/RoleInstance.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/RoleInstance.tsp
@@ -27,6 +27,7 @@ model RoleInstance
   /**
    * The role instance SKU.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku?: InstanceSku;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/Snapshot.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/Snapshot.tsp
@@ -24,17 +24,20 @@ model Snapshot is Azure.ResourceManager.TrackedResource<SnapshotProperties> {
   /**
    * Unused. Always Null.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   managedBy?: string;
 
   /**
    * The snapshots sku name. Can be Standard_LRS, Premium_LRS, or Standard_ZRS. This is an optional parameter for incremental snapshot and the default behavior is the SKU will be set to the same sku as the previous snapshot
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku?: SnapshotSku;
 
   /**
    * The extended location where the snapshot will be created. Extended location cannot be changed.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   extendedLocation?: ExtendedLocation;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachine.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachine.tsp
@@ -25,27 +25,28 @@ model VirtualMachine
   /**
    * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   plan?: Plan;
 
   /**
    * The virtual machine child extension resources.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   resources?: VirtualMachineExtension[];
 
   /**
    * The identity of the virtual machine, if configured.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   identity?: VirtualMachineIdentity;
 
-  /**
-   * The virtual machine zones.
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 
   /**
    * The extended location of the Virtual Machine.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   extendedLocation?: ExtendedLocation;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachineScaleSet.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachineScaleSet.tsp
@@ -25,26 +25,27 @@ model VirtualMachineScaleSet
   /**
    * The virtual machine scale set sku.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   sku?: Sku;
 
   /**
    * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   plan?: Plan;
 
   /**
    * The identity of the virtual machine scale set, if configured.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   identity?: VirtualMachineScaleSetIdentity;
 
-  /**
-   * The virtual machine scale set zones. NOTE: Availability zones can only be set when you create the scale set
-   */
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 
   /**
    * The extended location of the Virtual Machine Scale Set.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   extendedLocation?: ExtendedLocation;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachineScaleSetVM.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachineScaleSetVM.tsp
@@ -27,35 +27,36 @@ model VirtualMachineScaleSetVM
   /**
    * The virtual machine instance ID.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   instanceId?: string;
 
   /**
    * The virtual machine SKU.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   sku?: Sku;
 
   /**
    * Specifies information about the marketplace image used to create the virtual machine. This element is only used for marketplace images. Before you can use a marketplace image from an API, you must enable the image for programmatic use.  In the Azure portal, find the marketplace image that you want to use and then click **Want to deploy programmatically, Get Started ->**. Enter any required information and then click **Save**.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   plan?: Plan;
 
   /**
    * The virtual machine child extension resources.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   resources?: VirtualMachineExtension[];
 
-  /**
-   * The virtual machine zones.
-   */
-  @visibility("read")
-  zones?: string[];
+  ...Azure.ResourceManager.AvailabilityZonesProperty;
 
   /**
    * The identity of the virtual machine, if configured.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   identity?: VirtualMachineIdentity;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachineScaleSetVMExtension.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/VirtualMachineScaleSetVMExtension.tsp
@@ -27,6 +27,7 @@ model VirtualMachineScaleSetVMExtension
   /**
    * The location of the extension.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read", "create")
   location?: string;
 }

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/main.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/main.tsp
@@ -71,6 +71,8 @@ using TypeSpec.Versioning;
   title: "Azure Compute resource management API.",
 })
 @versioned(Versions)
+// FIXME: Common type version not set. Set to v3.
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v3)
 namespace Microsoft.Compute;
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/models.tsp
@@ -7214,8 +7214,8 @@ model ProximityPlacementGroupProperties {
   intent?: ProximityPlacementGroupPropertiesIntent;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model SubResourceWithColocationStatus extends SubResource {
   /**
    * Describes colocation status of a resource in the Proximity Placement Group.
@@ -7973,29 +7973,6 @@ model DiskRestorePointReplicationStatus {
    * Replication completion percentage.
    */
   completionPercent?: int32;
-}
-
-/**
- * The resource model definition for an Azure Resource Manager proxy resource. It will not have tags and a location
- */
-model ProxyResource {
-  /**
-   * Resource Id
-   */
-  @visibility("read")
-  id?: string;
-
-  /**
-   * Resource name
-   */
-  @visibility("read")
-  name?: string;
-
-  /**
-   * Resource type
-   */
-  @visibility("read")
-  type?: string;
 }
 
 /**
@@ -9878,93 +9855,6 @@ model SnapshotList is Azure.Core.Page<Snapshot>;
  * The List Resource Skus operation response.
  */
 model ResourceSkusResult is Azure.Core.Page<ResourceSku>;
-
-/**
- * Describes an available Compute SKU.
- */
-model ResourceSku {
-  /**
-   * The type of resource the SKU applies to.
-   */
-  @visibility("read")
-  resourceType?: string;
-
-  /**
-   * The name of SKU.
-   */
-  @visibility("read")
-  name?: string;
-
-  /**
-   * Specifies the tier of virtual machines in a scale set.<br /><br /> Possible Values:<br /><br /> **Standard**<br /><br /> **Basic**
-   */
-  @visibility("read")
-  tier?: string;
-
-  /**
-   * The Size of the SKU.
-   */
-  @visibility("read")
-  size?: string;
-
-  /**
-   * The Family of this particular SKU.
-   */
-  @visibility("read")
-  family?: string;
-
-  /**
-   * The Kind of resources that are supported in this SKU.
-   */
-  @visibility("read")
-  kind?: string;
-
-  /**
-   * Specifies the number of virtual machines in the scale set.
-   */
-  @visibility("read")
-  capacity?: ResourceSkuCapacity;
-
-  /**
-   * The set of locations that the SKU is available.
-   */
-  @visibility("read")
-  locations?: string[];
-
-  /**
-   * A list of locations and availability zones in those locations where the SKU is available.
-   */
-  @visibility("read")
-  @OpenAPI.extension("x-ms-identifiers", ["location"])
-  locationInfo?: ResourceSkuLocationInfo[];
-
-  /**
-   * The api versions that support this SKU.
-   */
-  @visibility("read")
-  apiVersions?: string[];
-
-  /**
-   * Metadata for retrieving price info.
-   */
-  @visibility("read")
-  @OpenAPI.extension("x-ms-identifiers", [])
-  costs?: ResourceSkuCosts[];
-
-  /**
-   * A name value pair to describe the capability.
-   */
-  @visibility("read")
-  @OpenAPI.extension("x-ms-identifiers", ["name"])
-  capabilities?: ResourceSkuCapabilities[];
-
-  /**
-   * The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.
-   */
-  @visibility("read")
-  @OpenAPI.extension("x-ms-identifiers", [])
-  restrictions?: ResourceSkuRestrictions[];
-}
 
 /**
  * Describes scaling information of a SKU.

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/BatchDeploymentTrackedResource.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/BatchDeploymentTrackedResource.tsp
@@ -21,13 +21,14 @@ model BatchDeploymentTrackedResource
     SegmentName = "deployments",
     NamePattern = ""
   >;
+  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
 
   /**
    * Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   kind?: string;
 
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
   ...Azure.ResourceManager.ResourceSkuProperty;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/BatchEndpointTrackedResource.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/BatchEndpointTrackedResource.tsp
@@ -21,13 +21,14 @@ model BatchEndpointTrackedResource
     SegmentName = "batchEndpoints",
     NamePattern = ""
   >;
+  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
 
   /**
    * Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   kind?: string;
 
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
   ...Azure.ResourceManager.ResourceSkuProperty;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/OnlineDeploymentTrackedResource.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/OnlineDeploymentTrackedResource.tsp
@@ -21,13 +21,14 @@ model OnlineDeploymentTrackedResource
     SegmentName = "deployments",
     NamePattern = ""
   >;
+  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
 
   /**
    * Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   kind?: string;
 
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
   ...Azure.ResourceManager.ResourceSkuProperty;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/OnlineEndpointTrackedResource.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/OnlineEndpointTrackedResource.tsp
@@ -21,13 +21,14 @@ model OnlineEndpointTrackedResource
     SegmentName = "onlineEndpoints",
     NamePattern = ""
   >;
+  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
 
   /**
    * Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   kind?: string;
 
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
   ...Azure.ResourceManager.ResourceSkuProperty;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/Registry.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/Registry.tsp
@@ -19,13 +19,14 @@ model Registry
     SegmentName = "registries",
     NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9\\-_]{2,32}$"
   >;
+  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
 
   /**
    * Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   kind?: string;
 
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
   ...Azure.ResourceManager.ResourceSkuProperty;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/Workspace.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/Workspace.tsp
@@ -21,9 +21,9 @@ model Workspace
     SegmentName = "workspaces",
     NamePattern = "^[a-zA-Z0-9][a-zA-Z0-9_-]{2,32}$"
   >;
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  kind?: string;
   ...Azure.ResourceManager.ManagedServiceIdentityProperty;
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  kind?: string;
   ...Azure.ResourceManager.ResourceSkuProperty;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
@@ -3671,6 +3671,34 @@ model ResourceName {
 model PaginatedComputeResourcesList is Azure.Core.Page<ComputeResource>;
 
 /**
+ * Managed service identity (system assigned and/or user assigned identities)
+ */
+model ManagedServiceIdentity {
+  /**
+   * The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.
+   */
+  @visibility("read")
+  principalId?: string;
+
+  /**
+   * The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.
+   */
+  @visibility("read")
+  tenantId?: string;
+
+  /**
+   * Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
+   */
+  type: ManagedServiceIdentityType;
+
+  /**
+   * The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "For backward compatibility"
+  userAssignedIdentities?: Record<UserAssignedIdentity>;
+}
+
+/**
  * The resource model definition representing SKU
  */
 model Sku {
@@ -7296,7 +7324,7 @@ model WorkspaceUpdateParameters {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */
-  identity?: Azure.ResourceManager.Foundations.ManagedServiceIdentity;
+  identity?: ManagedServiceIdentity;
 
   /**
    * The properties that the machine learning workspace will be updated with.
@@ -7756,7 +7784,7 @@ model PrivateLinkResource extends Resource {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */
-  identity?: Azure.ResourceManager.Foundations.ManagedServiceIdentity;
+  identity?: ManagedServiceIdentity;
 
   /**
    * Same as workspace location.
@@ -12826,7 +12854,7 @@ model ManagedComputeIdentity extends MonitorComputeIdentityBase {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */
-  identity?: Azure.ResourceManager.Foundations.ManagedServiceIdentity;
+  identity?: ManagedServiceIdentity;
 
   /**
    * [Required] Monitor compute identity type enum.

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
@@ -4131,8 +4131,8 @@ model CodeContainer extends AssetContainer {
   provisioningState?: AssetProvisioningState;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model AssetContainer extends ResourceBase {
   /**
    * Is the asset archived?
@@ -4196,8 +4196,8 @@ model CodeVersion extends AssetBase {
   provisioningState?: AssetProvisioningState;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model AssetBase extends ResourceBase {
   /**
    * Specifies the lifecycle setting of managed data asset.
@@ -4557,8 +4557,8 @@ model Route {
 model ModelContainerResourceArmPaginatedResult
   is Azure.Core.Page<ModelContainerResource>;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ModelContainer extends AssetContainer {
   /**
    * Provisioning state for the model container.
@@ -5021,8 +5021,8 @@ model BatchDeploymentConfiguration {}
 @discriminator("referenceType")
 model AssetReferenceBase {}
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model DeploymentResourceConfiguration extends ResourceConfiguration {}
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
@@ -6079,8 +6079,8 @@ model OnlineEndpoint extends EndpointPropertiesBase {
 model OnlineDeploymentTrackedResourceArmPaginatedResult
   is Azure.Core.Page<OnlineDeploymentTrackedResource>;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 @discriminator("endpointComputeType")
 model OnlineDeployment extends EndpointDeploymentPropertiesBase {
   /**
@@ -7405,8 +7405,8 @@ model EncryptionKeyVaultUpdateProperties {
 model WorkspaceConnectionPropertiesV2BasicResourceArmPaginatedResult
   is Azure.Core.Page<WorkspaceConnectionPropertiesV2BasicResource>;
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 @discriminator("authType")
 model WorkspaceConnectionPropertiesV2 {
   /**
@@ -7414,8 +7414,8 @@ model WorkspaceConnectionPropertiesV2 {
    */
   category?: ConnectionCategory;
 
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   expiryTime?: utcDateTime;
 
   /**
@@ -9481,8 +9481,8 @@ model QueueSettings {
   priority?: int32;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model JobResourceConfiguration extends ResourceConfiguration {
   /**
    * Extra arguments to pass to the Docker run command. This would override any parameters that have already been set by the system, or in this section. This parameter is only supported for Azure ML compute types.
@@ -11779,8 +11779,8 @@ model ImageClassification extends AutoMLVertical {
   taskType: "ImageClassification";
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ImageClassificationBase extends ImageVertical {
   /**
    * Settings used for training the model.
@@ -12314,8 +12314,8 @@ model ImageInstanceSegmentation extends AutoMLVertical {
   taskType: "ImageInstanceSegmentation";
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ImageObjectDetectionBase extends ImageVertical {
   /**
    * Settings used for training the model.
@@ -13117,8 +13117,8 @@ model NlpVertical {
   validationData?: MLTableJobInput;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model NlpVerticalFeaturizationSettings extends FeaturizationSettings {}
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/swagger-output/swagger.json
@@ -1577,7 +1577,7 @@
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
@@ -1840,7 +1840,7 @@
       "description": "The type used for update operations of the DataProduct.",
       "properties": {
         "identity": {
-          "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
+          "$ref": "#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         },
         "tags": {
@@ -2298,6 +2298,68 @@
         "name",
         "location"
       ]
+    },
+    "ManagedServiceIdentity": {
+      "type": "object",
+      "description": "Managed service identity (system assigned and/or user assigned identities)",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.",
+          "readOnly": true
+        },
+        "tenantId": {
+          "type": "string",
+          "description": "The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.",
+          "readOnly": true
+        },
+        "type": {
+          "$ref": "#/definitions/ManagedServiceIdentityType",
+          "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed)."
+        },
+        "userAssignedIdentities": {
+          "type": "object",
+          "description": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.",
+          "additionalProperties": {
+            "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/UserAssignedIdentity"
+          }
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "ManagedServiceIdentityType": {
+      "type": "string",
+      "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
+      "enum": [
+        "None",
+        "SystemAssigned",
+        "UserAssigned",
+        "SystemAssigned, UserAssigned"
+      ],
+      "x-ms-enum": {
+        "name": "ManagedServiceIdentityType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "None",
+            "value": "None"
+          },
+          {
+            "name": "SystemAssigned",
+            "value": "SystemAssigned"
+          },
+          {
+            "name": "UserAssigned",
+            "value": "UserAssigned"
+          },
+          {
+            "name": "SystemAssigned, UserAssigned",
+            "value": "SystemAssigned, UserAssigned"
+          }
+        ]
+      }
     },
     "ProvisioningState": {
       "type": "string",

--- a/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/DataProduct.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/DataProduct.tsp
@@ -21,7 +21,11 @@ model DataProduct
     SegmentName = "dataProducts",
     NamePattern = "^[a-z][a-z0-9]*$"
   >;
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
+
+  /**
+   * The managed service identities assigned to this resource.
+   */
+  identity?: ManagedServiceIdentity;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/models.tsp
@@ -433,6 +433,33 @@ model ConsumptionEndpointsProperties {
 }
 
 /**
+ * Managed service identity (system assigned and/or user assigned identities)
+ */
+model ManagedServiceIdentity {
+  /**
+   * The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.
+   */
+  @visibility("read")
+  principalId?: string;
+
+  /**
+   * The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.
+   */
+  @visibility("read")
+  tenantId?: string;
+
+  /**
+   * Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
+   */
+  type: ManagedServiceIdentityType;
+
+  /**
+   * The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.
+   */
+  userAssignedIdentities?: Record<UserAssignedIdentity>;
+}
+
+/**
  * Common fields that are returned in the response for all Azure Resource Manager resources
  */
 model Resource {
@@ -532,7 +559,7 @@ model DataProductUpdate {
   /**
    * The managed service identities assigned to this resource.
    */
-  identity?: Azure.ResourceManager.Foundations.ManagedServiceIdentity;
+  identity?: ManagedServiceIdentity;
 
   /**
    * Resource tags.

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/swagger-output/swagger.json
@@ -6200,8 +6200,9 @@
           "x-ms-client-flatten": true
         },
         "sku": {
-          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/Sku",
-          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
+          "$ref": "#/definitions/Sku",
+          "description": "Sku name and tier.",
+          "readOnly": true
         }
       },
       "allOf": [
@@ -7072,8 +7073,9 @@
           "x-ms-client-flatten": true
         },
         "sku": {
-          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/Sku",
-          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
+          "$ref": "#/definitions/Sku",
+          "description": "Sku name and tier.",
+          "readOnly": true
         }
       },
       "allOf": [
@@ -10003,22 +10005,23 @@
           "description": "Properties of the storage account.",
           "x-ms-client-flatten": true
         },
+        "sku": {
+          "$ref": "#/definitions/Sku",
+          "description": "Gets the SKU.",
+          "readOnly": true
+        },
         "kind": {
           "$ref": "#/definitions/Kind",
           "description": "Gets the Kind.",
           "readOnly": true
         },
+        "identity": {
+          "$ref": "#/definitions/Identity",
+          "description": "The identity of the resource."
+        },
         "extendedLocation": {
           "$ref": "#/definitions/ExtendedLocation",
           "description": "The extendedLocation of the resource."
-        },
-        "identity": {
-          "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
-          "description": "The managed service identities assigned to this resource."
-        },
-        "sku": {
-          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/Sku",
-          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
         }
       },
       "allOf": [

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/BlobServiceProperties.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/BlobServiceProperties.tsp
@@ -24,7 +24,13 @@ model BlobServiceProperties
     SegmentName = "blobServices",
     NamePattern = ""
   >;
-  ...Azure.ResourceManager.ResourceSkuProperty;
+
+  /**
+   * Sku name and tier.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  @visibility("read")
+  sku?: Sku;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/FileServiceProperties.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/FileServiceProperties.tsp
@@ -24,7 +24,13 @@ model FileServiceProperties
     SegmentName = "fileServices",
     NamePattern = ""
   >;
-  ...Azure.ResourceManager.ResourceSkuProperty;
+
+  /**
+   * Sku name and tier.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  @visibility("read")
+  sku?: Sku;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/StorageAccount.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/StorageAccount.tsp
@@ -23,18 +23,30 @@ model StorageAccount
   >;
 
   /**
+   * Gets the SKU.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  @visibility("read")
+  sku?: Sku;
+
+  /**
    * Gets the Kind.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   @visibility("read")
   kind?: Kind;
 
   /**
+   * The identity of the resource.
+   */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
+  identity?: Identity;
+
+  /**
    * The extendedLocation of the resource.
    */
+  #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
   extendedLocation?: ExtendedLocation;
-
-  ...Azure.ResourceManager.ManagedServiceIdentityProperty;
-  ...Azure.ResourceManager.ResourceSkuProperty;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/main.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/main.tsp
@@ -46,8 +46,8 @@ using TypeSpec.Versioning;
   title: "Azure Storage resource management API.",
 })
 @versioned(Versions)
-// FIXME: Common type version v1 is not supported for now.
-// @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v1)
+// FIXME: Common type version v1 is not supported for now. Set to v3.
+@armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v3)
 namespace Microsoft.Storage;
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/models.tsp
@@ -1963,11 +1963,12 @@ model StorageAccountInternetEndpoints {
  * Storage account keys creation time.
  */
 model KeyCreationTime {
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   key1?: utcDateTime;
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   key2?: utcDateTime;
 }
 
@@ -4339,8 +4340,8 @@ model QueueServicePropertiesProperties {
   cors?: CorsRules;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model QueueProperties {
   /**
    * A name-value pair that represents queue metadata.
@@ -4380,8 +4381,8 @@ model TableServicePropertiesProperties {
   cors?: CorsRules;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model TableProperties {
   /**
    * Table name under the specified account
@@ -4463,8 +4464,8 @@ model FileShareItem extends AzureEntityResource {
   properties?: FileShareProperties;
 }
 
-#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
+#suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ListQueue extends Resource {
   /**
    * List Queue resource properties.

--- a/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/ArrayDefault.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/ArrayDefault.tsp
@@ -20,8 +20,7 @@ model ArrayDefault
   ...ResourceNameParameter<
     Resource = ArrayDefault,
     KeyName = "name",
-    SegmentName = "arraydefaults",
-    NamePattern = "^[a-zA-Z0-9-]{3,24}$"
+    SegmentName = "arraydefaults"
   >;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/DictProperty.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/DictProperty.tsp
@@ -19,8 +19,7 @@ model DictProperty is Azure.ResourceManager.TrackedResource<Record<unknown>> {
   ...ResourceNameParameter<
     Resource = DictProperty,
     KeyName = "name",
-    SegmentName = "dictproperties",
-    NamePattern = "^[a-zA-Z0-9-]{3,24}$"
+    SegmentName = "dictproperties"
   >;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/Employee.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/Employee.tsp
@@ -17,8 +17,7 @@ model Employee is Azure.ResourceManager.TrackedResource<EmployeeProperties> {
   ...ResourceNameParameter<
     Resource = Employee,
     KeyName = "employeeName",
-    SegmentName = "employees",
-    NamePattern = "^[a-zA-Z0-9-]{3,24}$"
+    SegmentName = "employees"
   >;
 }
 


### PR DESCRIPTION
1. If the common type is not in v3-v6, set it to v3, otherwise we cannot extend the resource model from arm library.
2. If the property in the resource model can be replaced by the envelop property from arm library, then use the envelope property, otherwise remain the same.