### PR TITLE
Fix common type replacement logic

### DIFF
--- a/common/changes/@autorest/openapi-to-typespec/commonType5100_2025-05-07-06-28.json
+++ b/common/changes/@autorest/openapi-to-typespec/commonType5100_2025-05-07-06-28.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/openapi-to-typespec",
+      "comment": "Change common type replacement logic",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/openapi-to-typespec"
+}

--- a/packages/extensions/openapi-to-typespec/src/autorest-session.ts
+++ b/packages/extensions/openapi-to-typespec/src/autorest-session.ts
@@ -5,6 +5,8 @@ let _session: Session<CodeModel>;
 let _armCommonTypeVersion: ArmCommonTypeVersion | undefined;
 let _userSetArmCommonTypeVersion: string;
 
+const commonTypeModels: string[] = [];
+
 export function setSession(session: Session<CodeModel>): void {
   _session = session;
 }
@@ -14,7 +16,21 @@ export function getSession(): Session<CodeModel> {
 }
 
 export function setArmCommonTypeVersion(version: string): void {
-  _userSetArmCommonTypeVersion = version;
+  if (_userSetArmCommonTypeVersion === undefined) {
+    _userSetArmCommonTypeVersion = version;
+  }
+}
+
+export function setArmCommonTypeModel(model: string): void {
+  if (!commonTypeModels.includes(model)) {
+    commonTypeModels.push(model);
+  }
+}
+
+export function isCommonTypeModel(model: string): boolean {
+  const lowerCaseModel = model.toLowerCase();
+  const lowerCaseCommonTypeModels = commonTypeModels.map((m) => m.toLowerCase());
+  return lowerCaseCommonTypeModels.includes(lowerCaseModel);
 }
 
 export type ArmCommonTypeVersion = "v3" | "v4" | "v5" | "v6";

--- a/packages/extensions/openapi-to-typespec/src/autorest-session.ts
+++ b/packages/extensions/openapi-to-typespec/src/autorest-session.ts
@@ -5,7 +5,7 @@ let _session: Session<CodeModel>;
 let _armCommonTypeVersion: ArmCommonTypeVersion | undefined;
 let _userSetArmCommonTypeVersion: string;
 
-const commonTypeModels: string[] = [];
+const commonTypeModels: Set<string> = new Set();
 
 export function setSession(session: Session<CodeModel>): void {
   _session = session;
@@ -21,16 +21,15 @@ export function setArmCommonTypeVersion(version: string): void {
   }
 }
 
-export function setArmCommonTypeModel(model: string): void {
-  if (!commonTypeModels.includes(model)) {
-    commonTypeModels.push(model);
-  }
+export function addArmCommonTypeModel(model: string): void {
+  commonTypeModels.add(model);
 }
 
 export function isCommonTypeModel(model: string): boolean {
   const lowerCaseModel = model.toLowerCase();
-  const lowerCaseCommonTypeModels = commonTypeModels.map((m) => m.toLowerCase());
-  return lowerCaseCommonTypeModels.includes(lowerCaseModel);
+  return Array.from(commonTypeModels)
+    .map((m) => m.toLowerCase())
+    .includes(lowerCaseModel);
 }
 
 export type ArmCommonTypeVersion = "v3" | "v4" | "v5" | "v6";

--- a/packages/extensions/openapi-to-typespec/src/generate/generate-object.ts
+++ b/packages/extensions/openapi-to-typespec/src/generate/generate-object.ts
@@ -1,7 +1,7 @@
 import { TypespecObject } from "../interfaces";
 import { generateDecorators } from "../utils/decorators";
 import { generateDocs } from "../utils/docs";
-import { getModelPropertiesDeclarations } from "../utils/model-generation";
+import { getArmCommonTypeModelName, getModelPropertiesDeclarations } from "../utils/model-generation";
 import { generateSuppressions } from "../utils/suppressions";
 
 export function generateObject(typespecObject: TypespecObject) {
@@ -20,7 +20,7 @@ export function generateObject(typespecObject: TypespecObject) {
 
   if (typespecObject.extendedParents?.length) {
     const firstParent = typespecObject.extendedParents[0];
-    definitions.push(`model ${typespecObject.name} extends ${firstParent} {`);
+    definitions.push(`model ${typespecObject.name} extends ${getArmCommonTypeModelName(firstParent)} {`);
   } else if (typespecObject.alias) {
     const { alias, params } = typespecObject.alias;
 

--- a/packages/extensions/openapi-to-typespec/src/generate/generate-operations.ts
+++ b/packages/extensions/openapi-to-typespec/src/generate/generate-operations.ts
@@ -8,6 +8,7 @@ import { getOptions } from "../options";
 import { generateDecorators } from "../utils/decorators";
 import { generateDocs, generateSummary } from "../utils/docs";
 import { generateLroHeaders } from "../utils/lro";
+import { getArmCommonTypeModelName } from "../utils/model-generation";
 import { generateSuppressions } from "../utils/suppressions";
 import { generateExamples, getGeneratedOperationId } from "./generate-arm-resource";
 import { generateParameter } from "./generate-parameter";
@@ -83,14 +84,14 @@ export function generateProviderAction(operation: TspArmProviderActionOperation)
   const templateParameters = [];
 
   if (operation.request) {
-    templateParameters.push(`Request = ${operation.request.type}`);
+    templateParameters.push(`Request = ${getArmCommonTypeModelName(operation.request.type)}`);
   }
 
   if (operation.response) {
     if (operation.response.endsWith("[]")) {
-      templateParameters.push(`Response = {@bodyRoot _: ${operation.response}}`);
+      templateParameters.push(`Response = {@bodyRoot _: ${getArmCommonTypeModelName(operation.response)}}`);
     } else {
-      templateParameters.push(`Response = ${operation.response}`);
+      templateParameters.push(`Response = ${getArmCommonTypeModelName(operation.response)}`);
     }
   }
 

--- a/packages/extensions/openapi-to-typespec/src/main.ts
+++ b/packages/extensions/openapi-to-typespec/src/main.ts
@@ -7,7 +7,7 @@ import { AutoRestExtension, AutorestExtensionHost, Session, startSession } from 
 import { serialize } from "@azure-tools/codegen";
 import { OpenAPI3Document } from "@azure-tools/openapi";
 import { Metadata } from "utils/resource-discovery";
-import { setArmCommonTypeModel, setArmCommonTypeVersion, setSession } from "./autorest-session";
+import { addArmCommonTypeModel, setArmCommonTypeVersion, setSession } from "./autorest-session";
 import { emitArmResources } from "./emiters/emit-arm-resources";
 import { emitClient } from "./emiters/emit-client";
 import { emitLegacy } from "./emiters/emit-legacy";
@@ -93,7 +93,7 @@ export async function processDetector(host: AutorestExtensionHost) {
 
           const typeResult = p.match(/\/common-types\/resource-management\/(v\d)\/.*\/components\/schemas\/(.*)/);
           if (typeResult) {
-            setArmCommonTypeModel(typeResult[2]);
+            addArmCommonTypeModel(typeResult[2]);
           }
         }
       }

--- a/packages/extensions/openapi-to-typespec/src/main.ts
+++ b/packages/extensions/openapi-to-typespec/src/main.ts
@@ -7,7 +7,7 @@ import { AutoRestExtension, AutorestExtensionHost, Session, startSession } from 
 import { serialize } from "@azure-tools/codegen";
 import { OpenAPI3Document } from "@azure-tools/openapi";
 import { Metadata } from "utils/resource-discovery";
-import { setArmCommonTypeVersion, setSession } from "./autorest-session";
+import { setArmCommonTypeModel, setArmCommonTypeVersion, setSession } from "./autorest-session";
 import { emitArmResources } from "./emiters/emit-arm-resources";
 import { emitClient } from "./emiters/emit-client";
 import { emitLegacy } from "./emiters/emit-legacy";
@@ -86,10 +86,14 @@ export async function processDetector(host: AutorestExtensionHost) {
     for (const v of Object.values(session.model.components.schemas)) {
       if (v["x-ms-metadata"]?.originalLocations) {
         for (const p of v["x-ms-metadata"].originalLocations) {
-          const result = p.match(/\/common-types\/resource-management\/(v\d)\//);
-          if (result) {
-            setArmCommonTypeVersion(result[1]);
-            return;
+          const versionResult = p.match(/\/common-types\/resource-management\/(v\d)\//);
+          if (versionResult) {
+            setArmCommonTypeVersion(versionResult[1]);
+          }
+
+          const typeResult = p.match(/\/common-types\/resource-management\/(v\d)\/.*\/components\/schemas\/(.*)/);
+          if (typeResult) {
+            setArmCommonTypeModel(typeResult[2]);
           }
         }
       }

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/swagger-output/swagger.json
@@ -363,7 +363,7 @@
             "description": "The request body",
             "required": true,
             "schema": {
-              "$ref": "#/definitions/CheckNameAvailabilityRequest"
+              "$ref": "../../common-types/resource-management/v4/types.json#/definitions/CheckNameAvailabilityRequest"
             }
           }
         ],
@@ -371,7 +371,7 @@
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "$ref": "#/definitions/CheckNameAvailabilityResponse"
+              "$ref": "../../common-types/resource-management/v4/types.json#/definitions/CheckNameAvailabilityResponse"
             }
           },
           "default": {
@@ -1342,7 +1342,7 @@
           "200": {
             "description": "Azure operation completed successfully.",
             "schema": {
-              "$ref": "#/definitions/PrivateEndpointConnectionListResult"
+              "$ref": "../../common-types/resource-management/v4/privatelinks.json#/definitions/PrivateLinkResourceListResult"
             }
           },
           "default": {
@@ -1461,7 +1461,7 @@
           "200": {
             "description": "Resource 'PrivateEndpointConnection' update operation succeeded",
             "schema": {
-              "$ref": "#/definitions/PrivateEndpointConnection"
+              "$ref": "../../common-types/resource-management/v4/privatelinks.json#/definitions/PrivateEndpointConnection"
             }
           },
           "default": {
@@ -2091,62 +2091,6 @@
         ]
       }
     },
-    "Azure.ResourceManager.CommonTypes.CheckNameAvailabilityReason": {
-      "type": "string",
-      "description": "Possible reasons for a name not being available.",
-      "enum": [
-        "Invalid",
-        "AlreadyExists"
-      ],
-      "x-ms-enum": {
-        "name": "CheckNameAvailabilityReason",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Invalid",
-            "value": "Invalid",
-            "description": "Name is invalid."
-          },
-          {
-            "name": "AlreadyExists",
-            "value": "AlreadyExists",
-            "description": "Name already exists."
-          }
-        ]
-      }
-    },
-    "CheckNameAvailabilityRequest": {
-      "type": "object",
-      "description": "The check availability request body.",
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "The name of the resource for which availability needs to be checked."
-        },
-        "type": {
-          "type": "string",
-          "description": "The resource type."
-        }
-      }
-    },
-    "CheckNameAvailabilityResponse": {
-      "type": "object",
-      "description": "The check availability result.",
-      "properties": {
-        "nameAvailable": {
-          "type": "boolean",
-          "description": "Indicates if the resource name is available."
-        },
-        "reason": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.CheckNameAvailabilityReason",
-          "description": "The reason why the given name is not available."
-        },
-        "message": {
-          "type": "string",
-          "description": "Detailed reason why the given name is available."
-        }
-      }
-    },
     "DataConnector": {
       "type": "object",
       "description": "DataConnector Model.",
@@ -2215,7 +2159,7 @@
           "x-ms-client-flatten": true
         },
         "identity": {
-          "$ref": "#/definitions/Identity",
+          "$ref": "../../common-types/resource-management/v4/types.json#/definitions/Identity",
           "description": "Identity for the resource."
         }
       },
@@ -2532,7 +2476,7 @@
           "description": "Geo-location where the resource lives."
         },
         "identity": {
-          "$ref": "#/definitions/Identity",
+          "$ref": "../../common-types/resource-management/v4/types.json#/definitions/Identity",
           "description": "Identity for the resource."
         },
         "properties": {
@@ -2686,34 +2630,6 @@
         }
       }
     },
-    "Identity": {
-      "type": "object",
-      "description": "Identity for the resource.",
-      "properties": {
-        "principalId": {
-          "type": "string",
-          "format": "uuid",
-          "description": "The principal ID of resource identity. The value must be an UUID.",
-          "readOnly": true
-        },
-        "tenantId": {
-          "type": "string",
-          "format": "uuid",
-          "description": "The tenant ID of resource. The value must be an UUID.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The identity type.",
-          "enum": [
-            "SystemAssigned"
-          ],
-          "x-ms-enum": {
-            "modelAsString": false
-          }
-        }
-      }
-    },
     "KeyVaultProperties": {
       "type": "object",
       "description": "Properties of the key vault.",
@@ -2776,23 +2692,12 @@
       ],
       "x-ms-discriminator-value": "OAuthClientCredentials"
     },
-    "PrivateEndpoint": {
-      "type": "object",
-      "description": "The private endpoint resource.",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "The ARM identifier for private endpoint.",
-          "readOnly": true
-        }
-      }
-    },
     "PrivateEndpointConnection": {
       "type": "object",
       "description": "The private endpoint connection resource.",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/PrivateEndpointConnectionProperties",
+          "$ref": "../../common-types/resource-management/v4/privatelinks.json#/definitions/PrivateEndpointConnectionProperties",
           "description": "Resource properties.",
           "x-ms-client-flatten": true
         }
@@ -2803,114 +2708,12 @@
         }
       ]
     },
-    "PrivateEndpointConnectionListResult": {
-      "type": "object",
-      "description": "List of private endpoint connections associated with the specified resource.",
-      "properties": {
-        "value": {
-          "type": "array",
-          "description": "Array of private endpoint connections.",
-          "items": {
-            "$ref": "#/definitions/PrivateEndpointConnection"
-          }
-        }
-      }
-    },
-    "PrivateEndpointConnectionProperties": {
-      "type": "object",
-      "description": "Properties of the private endpoint connection.",
-      "properties": {
-        "groupIds": {
-          "type": "array",
-          "description": "The group ids for the private endpoint resource.",
-          "items": {
-            "type": "string"
-          },
-          "readOnly": true
-        },
-        "privateEndpoint": {
-          "$ref": "#/definitions/PrivateEndpoint",
-          "description": "The private endpoint resource."
-        },
-        "privateLinkServiceConnectionState": {
-          "$ref": "#/definitions/PrivateLinkServiceConnectionState",
-          "description": "A collection of information about the state of the connection between service consumer and provider."
-        },
-        "provisioningState": {
-          "$ref": "#/definitions/PrivateEndpointConnectionProvisioningState",
-          "description": "The provisioning state of the private endpoint connection resource.",
-          "readOnly": true
-        }
-      },
-      "required": [
-        "privateLinkServiceConnectionState"
-      ]
-    },
-    "PrivateEndpointConnectionProvisioningState": {
-      "type": "string",
-      "description": "The current provisioning state.",
-      "enum": [
-        "Succeeded",
-        "Creating",
-        "Deleting",
-        "Failed"
-      ],
-      "x-ms-enum": {
-        "name": "PrivateEndpointConnectionProvisioningState",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Succeeded",
-            "value": "Succeeded"
-          },
-          {
-            "name": "Creating",
-            "value": "Creating"
-          },
-          {
-            "name": "Deleting",
-            "value": "Deleting"
-          },
-          {
-            "name": "Failed",
-            "value": "Failed"
-          }
-        ]
-      }
-    },
-    "PrivateEndpointServiceConnectionStatus": {
-      "type": "string",
-      "description": "The private endpoint connection status.",
-      "enum": [
-        "Pending",
-        "Approved",
-        "Rejected"
-      ],
-      "x-ms-enum": {
-        "name": "PrivateEndpointServiceConnectionStatus",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Pending",
-            "value": "Pending"
-          },
-          {
-            "name": "Approved",
-            "value": "Approved"
-          },
-          {
-            "name": "Rejected",
-            "value": "Rejected"
-          }
-        ]
-      }
-    },
     "PrivateLinkResource": {
       "type": "object",
       "description": "A private link resource.",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/PrivateLinkResourceProperties",
+          "$ref": "../../common-types/resource-management/v4/privatelinks.json#/definitions/PrivateLinkResourceProperties",
           "description": "Resource properties.",
           "x-ms-client-flatten": true
         }
@@ -2923,58 +2726,14 @@
     },
     "PrivateLinkResourceListResult": {
       "type": "object",
-      "description": "A list of private link resources.",
+      "description": "A list of private link resources for versions before v6.\n\nThis model represents the standard `PrivateLinkResourceListResult` envelope for versions v3, v4, and v5. It has been deprecated for v6 and beyond.\n\nNote: This is only intended for use with versions before v6. Do not use this if you are already on CommonTypes.Version.v6 or beyond.\n\nIf you are migrating to v6 or above, use `PrivateLinkResourceListResult` directly.",
       "properties": {
         "value": {
           "type": "array",
           "description": "Array of private link resources",
           "items": {
-            "$ref": "#/definitions/PrivateLinkResource"
+            "$ref": "../../common-types/resource-management/v4/privatelinks.json#/definitions/PrivateLinkResource"
           }
-        }
-      }
-    },
-    "PrivateLinkResourceProperties": {
-      "type": "object",
-      "description": "Properties of a private link resource.",
-      "properties": {
-        "groupId": {
-          "type": "string",
-          "description": "The private link resource group id.",
-          "readOnly": true
-        },
-        "requiredMembers": {
-          "type": "array",
-          "description": "The private link resource required member names.",
-          "items": {
-            "type": "string"
-          },
-          "readOnly": true
-        },
-        "requiredZoneNames": {
-          "type": "array",
-          "description": "The private link resource private link DNS zone name.",
-          "items": {
-            "type": "string"
-          }
-        }
-      }
-    },
-    "PrivateLinkServiceConnectionState": {
-      "type": "object",
-      "description": "A collection of information about the state of the connection between service consumer and provider.",
-      "properties": {
-        "status": {
-          "$ref": "#/definitions/PrivateEndpointServiceConnectionStatus",
-          "description": "Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service."
-        },
-        "description": {
-          "type": "string",
-          "description": "The reason for approval/rejection of the connection."
-        },
-        "actionsRequired": {
-          "type": "string",
-          "description": "A message indicating if changes on the service provider require any updates on the consumer."
         }
       }
     },

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/DataManagerForAgriculture.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/DataManagerForAgriculture.tsp
@@ -26,7 +26,7 @@ model DataManagerForAgriculture
    * Identity for the resource.
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-envelope-property" "For backward compatibility"
-  identity?: Identity;
+  identity?: Azure.ResourceManager.CommonTypes.Identity;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/PrivateEndpointConnection.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/PrivateEndpointConnection.tsp
@@ -38,7 +38,7 @@ interface PrivateEndpointConnections {
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-put-operation-response-codes" "For backward compatibility"
   createOrUpdate is ArmResourceCreateOrReplaceSync<
     PrivateEndpointConnection,
-    Response = ArmResourceUpdatedResponse<PrivateEndpointConnection>
+    Response = ArmResourceUpdatedResponse<Azure.ResourceManager.CommonTypes.PrivateEndpointConnection>
   >;
 
   /**
@@ -57,7 +57,7 @@ interface PrivateEndpointConnections {
    */
   listByResource is ArmResourceListByParent<
     PrivateEndpointConnection,
-    Response = ArmResponse<PrivateEndpointConnectionListResult>
+    Response = ArmResponse<Azure.ResourceManager.CommonTypes.PrivateEndpointConnectionListResultV5>
   >;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/PrivateLinkResource.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/PrivateLinkResource.tsp
@@ -37,7 +37,7 @@ interface PrivateLinkResources {
    */
   listByResource is ArmResourceListByParent<
     PrivateLinkResource,
-    Response = ArmResponse<PrivateLinkResourceListResult>
+    Response = ArmResponse<Azure.ResourceManager.CommonTypes.PrivateLinkResourceListResultV5>
   >;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/models.tsp
@@ -11,6 +11,17 @@ using Azure.ResourceManager.Foundations;
 namespace Microsoft.AgFoodPlatform;
 
 /**
+ * The reason why the given name is not available.
+ */
+union CheckNameAvailabilityReason {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Invalid: "Invalid",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  AlreadyExists: "AlreadyExists",
+}
+
+/**
  * Enum for different types of AuthCredentials supported.
  */
 union AuthCredentialsKind {
@@ -19,6 +30,21 @@ union AuthCredentialsKind {
   OAuthClientCredentials: "OAuthClientCredentials",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   ApiKeyAuthCredentials: "ApiKeyAuthCredentials",
+}
+
+/**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  User: "User",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Application: "Application",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  ManagedIdentity: "ManagedIdentity",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Key: "Key",
 }
 
 /**
@@ -53,67 +79,25 @@ union PublicNetworkAccess {
 }
 
 /**
- * The private endpoint connection status.
+ * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
  */
-union PrivateEndpointServiceConnectionStatus {
+union Origin {
   string,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Pending: "Pending",
+  user: "user",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Approved: "Approved",
+  system: "system",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Rejected: "Rejected",
+  `user,system`: "user,system",
 }
 
 /**
- * The current provisioning state.
+ * Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
  */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
-union PrivateEndpointConnectionProvisioningState {
+union ActionType {
   string,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Succeeded: "Succeeded",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Creating: "Creating",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Deleting: "Deleting",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Failed: "Failed",
-}
-
-/**
- * The check availability request body.
- */
-model CheckNameAvailabilityRequest {
-  /**
-   * The name of the resource for which availability needs to be checked.
-   */
-  name?: string;
-
-  /**
-   * The resource type.
-   */
-  type?: string;
-}
-
-/**
- * The check availability result.
- */
-model CheckNameAvailabilityResponse {
-  /**
-   * Indicates if the resource name is available.
-   */
-  nameAvailable?: boolean;
-
-  /**
-   * The reason why the given name is not available.
-   */
-  reason?: CheckNameAvailabilityReason;
-
-  /**
-   * Detailed reason why the given name is available.
-   */
-  message?: string;
+  Internal: "Internal",
 }
 
 /**
@@ -136,35 +120,6 @@ model AuthCredentials {
    * Enum for different types of AuthCredentials supported.
    */
   kind: AuthCredentialsKind;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. E.g. "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}"
-   */
-  @visibility(Lifecycle.Read)
-  id?: Azure.Core.armResourceIdentifier;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
 }
 
 /**
@@ -330,32 +285,6 @@ model UnitSystemsInfo {
 }
 
 /**
- * Identity for the resource.
- */
-model Identity {
-  /**
-   * The principal ID of resource identity. The value must be an UUID.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-format"
-  @visibility(Lifecycle.Read)
-  @format("uuid")
-  principalId?: string;
-
-  /**
-   * The tenant ID of resource. The value must be an UUID.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-format"
-  @visibility(Lifecycle.Read)
-  @format("uuid")
-  tenantId?: string;
-
-  /**
-   * The identity type.
-   */
-  type?: "SystemAssigned";
-}
-
-/**
  * Data Manager For Agriculture ARM Resource properties.
  */
 model DataManagerForAgricultureProperties {
@@ -406,65 +335,7 @@ model SensorIntegration {
   /**
    * Common error response for all Azure Resource Manager APIs to return error details for failed operations. (This also follows the OData error response format.).
    */
-  provisioningInfo?: ErrorResponse;
-}
-
-/**
- * Properties of the private endpoint connection.
- */
-model PrivateEndpointConnectionProperties {
-  /**
-   * The group ids for the private endpoint resource.
-   */
-  @visibility(Lifecycle.Read)
-  groupIds?: string[];
-
-  /**
-   * The private endpoint resource.
-   */
-  privateEndpoint?: PrivateEndpoint;
-
-  /**
-   * A collection of information about the state of the connection between service consumer and provider.
-   */
-  privateLinkServiceConnectionState: PrivateLinkServiceConnectionState;
-
-  /**
-   * The provisioning state of the private endpoint connection resource.
-   */
-  @visibility(Lifecycle.Read)
-  provisioningState?: PrivateEndpointConnectionProvisioningState;
-}
-
-/**
- * The private endpoint resource.
- */
-model PrivateEndpoint {
-  /**
-   * The ARM identifier for private endpoint.
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-}
-
-/**
- * A collection of information about the state of the connection between service consumer and provider.
- */
-model PrivateLinkServiceConnectionState {
-  /**
-   * Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service.
-   */
-  status?: PrivateEndpointServiceConnectionStatus;
-
-  /**
-   * The reason for approval/rejection of the connection.
-   */
-  description?: string;
-
-  /**
-   * A message indicating if changes on the service provider require any updates on the consumer.
-   */
-  actionsRequired?: string;
+  provisioningInfo?: Azure.ResourceManager.CommonTypes.ErrorResponse;
 }
 
 /**
@@ -479,7 +350,7 @@ model DataManagerForAgricultureUpdateRequestModel {
   /**
    * Identity for the resource.
    */
-  identity?: Identity;
+  identity?: Azure.ResourceManager.CommonTypes.Identity;
 
   /**
    * Data Manager For Agriculture ARM Resource properties.
@@ -637,46 +508,32 @@ model ExtensionListResponse is Azure.Core.Page<Extension> {
 }
 
 /**
- * List of private endpoint connections associated with the specified resource.
+ * Localized display information for this particular operation.
  */
-model PrivateEndpointConnectionListResult {
+model OperationDisplay {
   /**
-   * Array of private endpoint connections.
-   */
-  value?: PrivateEndpointConnection[];
-}
-
-/**
- * A list of private link resources.
- */
-model PrivateLinkResourceListResult {
-  /**
-   * Array of private link resources
-   */
-  value?: PrivateLinkResource[];
-}
-
-/**
- * Properties of a private link resource.
- */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
-model PrivateLinkResourceProperties {
-  /**
-   * The private link resource group id.
+   * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
    */
   @visibility(Lifecycle.Read)
-  groupId?: string;
+  provider?: string;
 
   /**
-   * The private link resource required member names.
+   * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or "Job Schedule Collections".
    */
   @visibility(Lifecycle.Read)
-  requiredMembers?: string[];
+  resource?: string;
 
   /**
-   * The private link resource private link DNS zone name.
+   * The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual Machine".
    */
-  requiredZoneNames?: string[];
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/routes.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-agrifood/tsp-output/routes.tsp
@@ -22,8 +22,8 @@ interface CheckNameAvailabilityOperationGroup {
   @operationId("CheckNameAvailability_CheckNameAvailability")
   @autoRoute
   checkNameAvailability is ArmProviderActionSync<
-    Request = CheckNameAvailabilityRequest,
-    Response = CheckNameAvailabilityResponse,
+    Request = Azure.ResourceManager.CommonTypes.CheckNameAvailabilityRequest,
+    Response = Azure.ResourceManager.CommonTypes.CheckNameAvailabilityResponse,
     Scope = SubscriptionActionScope,
     Parameters = {}
   >;

--- a/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/swagger-output/swagger.json
@@ -1778,7 +1778,7 @@
       "description": "Action to be applied.",
       "properties": {
         "actionType": {
-          "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ActionType",
+          "$ref": "#/definitions/ActionType",
           "description": "Action that should be applied."
         }
       },
@@ -1795,6 +1795,28 @@
           "type": "boolean",
           "description": "Value indicating whether alert is suppressed."
         }
+      }
+    },
+    "ActionType": {
+      "type": "string",
+      "description": "Action that should be applied.",
+      "enum": [
+        "AddActionGroups",
+        "RemoveAllActionGroups"
+      ],
+      "x-ms-enum": {
+        "name": "ActionType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "AddActionGroups",
+            "value": "AddActionGroups"
+          },
+          {
+            "name": "RemoveAllActionGroups",
+            "value": "RemoveAllActionGroups"
+          }
+        ]
       }
     },
     "AddActionGroups": {
@@ -2166,24 +2188,6 @@
           },
           "x-ms-identifiers": []
         }
-      }
-    },
-    "Azure.ResourceManager.CommonTypes.ActionType": {
-      "type": "string",
-      "description": "Extensible enum. Indicates the action type. \"Internal\" refers to actions that are for internal only APIs.",
-      "enum": [
-        "Internal"
-      ],
-      "x-ms-enum": {
-        "name": "ActionType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "Internal",
-            "value": "Internal",
-            "description": "Actions are for internal-only APIs."
-          }
-        ]
       }
     },
     "Condition": {

--- a/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/tsp-output/models.tsp
@@ -67,6 +67,32 @@ union RecurrenceType {
   Monthly: "Monthly",
 }
 
+/**
+ * Action that should be applied.
+ */
+union ActionType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  AddActionGroups: "AddActionGroups",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  RemoveAllActionGroups: "RemoveAllActionGroups",
+}
+
+/**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  User: "User",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Application: "Application",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  ManagedIdentity: "ManagedIdentity",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Key: "Key",
+}
+
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 union Identifier {
   string,
@@ -529,6 +555,51 @@ model PatchProperties {
    * Indicates if the given alert processing rule is enabled or disabled.
    */
   enabled?: boolean;
+}
+
+/**
+ * Operation provided by provider
+ */
+model Operation {
+  /**
+   * Name of the operation
+   */
+  name?: string;
+
+  /**
+   * Properties of the operation
+   */
+  display?: OperationDisplay;
+
+  /**
+   * Origin of the operation
+   */
+  origin?: string;
+}
+
+/**
+ * Properties of the operation
+ */
+model OperationDisplay {
+  /**
+   * Provider name
+   */
+  provider?: string;
+
+  /**
+   * Resource name
+   */
+  resource?: string;
+
+  /**
+   * Operation name
+   */
+  operation?: string;
+
+  /**
+   * Description of the operation
+   */
+  description?: string;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-analysisservices/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-analysisservices/swagger-output/swagger.json
@@ -869,7 +869,7 @@
           "readOnly": true
         },
         "sku": {
-          "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty",
+          "$ref": "#/definitions/ResourceSku",
           "description": "The SKU of the Analysis Services resource."
         }
       },
@@ -884,7 +884,7 @@
       "description": "Provision request specification",
       "properties": {
         "sku": {
-          "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty",
+          "$ref": "#/definitions/ResourceSku",
           "description": "The SKU of the Analysis Services resource."
         },
         "tags": {
@@ -916,16 +916,6 @@
       "required": [
         "value"
       ]
-    },
-    "Azure.ResourceManager.ResourceSkuProperty": {
-      "type": "object",
-      "description": "The SKU (Stock Keeping Unit) assigned to this resource.",
-      "properties": {
-        "sku": {
-          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/Sku",
-          "description": "The SKU (Stock Keeping Unit) assigned to this resource."
-        }
-      }
     },
     "CheckServerNameAvailabilityParameters": {
       "type": "object",
@@ -1128,6 +1118,31 @@
         ]
       }
     },
+    "ResourceSku": {
+      "type": "object",
+      "description": "Represents the SKU name and Azure pricing tier for Analysis Services resource.",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name of the SKU level."
+        },
+        "tier": {
+          "$ref": "#/definitions/SkuTier",
+          "description": "The name of the Azure pricing tier to which the SKU applies."
+        },
+        "capacity": {
+          "type": "integer",
+          "format": "int32",
+          "description": "The number of instances in the read only query pool.",
+          "default": 1,
+          "minimum": 1,
+          "maximum": 8
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "ServerAdministrators": {
       "type": "object",
       "description": "An array of administrator user identities.",
@@ -1168,7 +1183,7 @@
       "description": "An object that represents SKU details for existing resources.",
       "properties": {
         "sku": {
-          "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty",
+          "$ref": "#/definitions/ResourceSku",
           "description": "The SKU in SKU details for existing resources."
         },
         "resourceType": {
@@ -1201,12 +1216,39 @@
           "type": "array",
           "description": "The collection of available SKUs for new resources.",
           "items": {
-            "$ref": "#/definitions/Azure.ResourceManager.ResourceSkuProperty"
+            "$ref": "#/definitions/ResourceSku"
           },
           "x-ms-identifiers": [
             "name"
           ]
         }
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "The name of the Azure pricing tier to which the SKU applies.",
+      "enum": [
+        "Development",
+        "Basic",
+        "Standard"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Development",
+            "value": "Development"
+          },
+          {
+            "name": "Basic",
+            "value": "Basic"
+          },
+          {
+            "name": "Standard",
+            "value": "Standard"
+          }
+        ]
       }
     },
     "State": {

--- a/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/models.tsp
@@ -75,6 +75,19 @@ union ProvisioningState {
 }
 
 /**
+ * The name of the Azure pricing tier to which the SKU applies.
+ */
+union SkuTier {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Development: "Development",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Basic: "Basic",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Standard: "Standard",
+}
+
+/**
  * The managed mode of the server (0 = not managed, 1 = managed).
  */
 union ManagedMode {
@@ -133,6 +146,28 @@ model AnalysisServicesServerProperties
    * The SKU of the Analysis Services resource.
    */
   sku?: ResourceSku;
+}
+
+/**
+ * Represents the SKU name and Azure pricing tier for Analysis Services resource.
+ */
+model ResourceSku {
+  /**
+   * Name of the SKU level.
+   */
+  name: string;
+
+  /**
+   * The name of the Azure pricing tier to which the SKU applies.
+   */
+  tier?: SkuTier;
+
+  /**
+   * The number of instances in the read only query pool.
+   */
+  @maxValue(8)
+  @minValue(1)
+  capacity?: int32 = 1;
 }
 
 /**
@@ -286,6 +321,89 @@ model Resource {
 }
 
 /**
+ * Describes the format of Error response.
+ */
+@error
+model ErrorResponse {
+  /**
+   * The error object
+   */
+  error?: ErrorDetail;
+}
+
+/**
+ * The error detail.
+ */
+model ErrorDetail {
+  /**
+   * The error code.
+   */
+  @visibility(Lifecycle.Read)
+  code?: string;
+
+  /**
+   * The error message.
+   */
+  @visibility(Lifecycle.Read)
+  message?: string;
+
+  /**
+   * The error target.
+   */
+  @visibility(Lifecycle.Read)
+  target?: string;
+
+  /**
+   * The error sub code
+   */
+  @visibility(Lifecycle.Read)
+  subCode?: int32;
+
+  /**
+   * The http status code
+   */
+  @visibility(Lifecycle.Read)
+  httpStatusCode?: int32;
+
+  /**
+   * the timestamp for the error.
+   */
+  @visibility(Lifecycle.Read)
+  timeStamp?: string;
+
+  /**
+   * The error details.
+   */
+  @visibility(Lifecycle.Read)
+  @OpenAPI.extension("x-ms-identifiers", #["message", "target"])
+  details?: ErrorDetail[];
+
+  /**
+   * The error additional info.
+   */
+  @visibility(Lifecycle.Read)
+  @OpenAPI.extension("x-ms-identifiers", #[])
+  additionalInfo?: ErrorAdditionalInfo[];
+}
+
+/**
+ * The resource management error additional info.
+ */
+model ErrorAdditionalInfo {
+  /**
+   * The additional info type.
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+
+  /**
+   * The additional info.
+   */
+  @visibility(Lifecycle.Read)
+  info?: Record<unknown>;
+}
+
+/**
  * Provision request specification
  */
 model AnalysisServicesServerUpdateParameters {
@@ -414,6 +532,62 @@ model CheckServerNameAvailabilityResult {
    * The detailed message of the request unavailability.
    */
   message?: string;
+}
+
+/**
+ * A Consumption REST API operation.
+ */
+model Operation {
+  /**
+   * Operation name: {provider}/{resource}/{operation}.
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * The object that represents the operation.
+   */
+  display?: OperationDisplay;
+
+  /**
+   * The origin
+   */
+  @visibility(Lifecycle.Read)
+  origin?: string;
+
+  /**
+   * Additional properties to expose performance metrics to shoebox.
+   */
+  properties?: OperationProperties;
+}
+
+/**
+ * The object that represents the operation.
+ */
+model OperationDisplay {
+  /**
+   * Service provider: Microsoft.Consumption.
+   */
+  @visibility(Lifecycle.Read)
+  provider?: string;
+
+  /**
+   * Resource on which the operation is performed: UsageDetail, etc.
+   */
+  @visibility(Lifecycle.Read)
+  resource?: string;
+
+  /**
+   * Operation type: Read, write, delete, etc.
+   */
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * Description of the operation object.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/PrivateEndpointConnection.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/PrivateEndpointConnection.tsp
@@ -42,7 +42,7 @@ interface PrivateEndpointConnections {
   @operationId("PrivateEndpointConnection_CreateOrUpdate")
   createOrUpdate is ArmResourceCreateOrReplaceAsync<
     PrivateEndpointConnection,
-    Response = ArmResourceUpdatedResponse<PrivateEndpointConnection> | ArmAcceptedLroResponse,
+    Response = ArmResourceUpdatedResponse<Azure.ResourceManager.CommonTypes.PrivateEndpointConnection> | ArmAcceptedLroResponse,
     LroHeaders = ArmLroLocationHeader & Azure.Core.Foundations.RetryAfterHeader
   >;
 
@@ -64,7 +64,7 @@ interface PrivateEndpointConnections {
   @operationId("PrivateEndpointConnection_ListByService")
   listByService is ArmResourceListByParent<
     PrivateEndpointConnection,
-    Response = ArmResponse<PrivateEndpointConnectionListResult>
+    Response = ArmResponse<Azure.ResourceManager.CommonTypes.PrivateEndpointConnectionListResultV5>
   >;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/PrivateLinkResource.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/PrivateLinkResource.tsp
@@ -41,7 +41,7 @@ interface PrivateLinkResources {
   @operationId("PrivateEndpointConnection_ListPrivateLinkResources")
   listPrivateLinkResources is ArmResourceListByParent<
     PrivateLinkResource,
-    Response = ArmResponse<PrivateLinkResourceListResult>
+    Response = ArmResponse<Azure.ResourceManager.CommonTypes.PrivateLinkResourceListResultV5>
   >;
 }
 

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/back-compatible.tsp
@@ -9,6 +9,9 @@ using Azure.ResourceManager.ApiManagement;
 );
 
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
+@@flattenProperty(ErrorResponse.error);
+
+#suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(ApiCreateOrUpdateParameter.properties);
 
 @@clientName(ApiCreateOrUpdateProperties.apiType, "soapApiType");

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/models.tsp
@@ -492,6 +492,19 @@ union Method {
 }
 
 /**
+ * The origin of the issue.
+ */
+union Origin {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Local: "Local",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Inbound: "Inbound",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Outbound: "Outbound",
+}
+
+/**
  * The severity of the issue.
  */
 union Severity {
@@ -740,19 +753,6 @@ union VirtualNetworkType {
 }
 
 /**
- * The private endpoint connection status.
- */
-union PrivateEndpointServiceConnectionStatus {
-  string,
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Pending: "Pending",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Approved: "Approved",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Rejected: "Rejected",
-}
-
-/**
  * The type of identity used for the resource. The type 'SystemAssigned, UserAssigned' includes both an implicitly created identity and a set of user assigned identities. The type 'None' will remove any identities from the service.
  */
 union ApimIdentityType {
@@ -765,6 +765,21 @@ union ApimIdentityType {
   `SystemAssigned, UserAssigned`: "SystemAssigned, UserAssigned",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   None: "None",
+}
+
+/**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  User: "User",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Application: "Application",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  ManagedIdentity: "ManagedIdentity",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Key: "Key",
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
@@ -962,22 +977,6 @@ union PortalRevisionStatus {
    * Portal's revision publishing failed.
    */
   failed: "failed",
-}
-
-/**
- * The current provisioning state.
- */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
-union PrivateEndpointConnectionProvisioningState {
-  string,
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Succeeded: "Succeeded",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Creating: "Creating",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Deleting: "Deleting",
-  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  Failed: "Failed",
 }
 
 /**
@@ -1432,26 +1431,16 @@ model ApiLicenseInformation {
 }
 
 /**
- * Common fields that are returned in the response for all Azure Resource Manager resources
+ * Error Response.
  */
-model Resource {
+@error
+model ErrorResponse {
   /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
+   * Properties of the Error Response.
    */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
+  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
+  @Azure.ResourceManager.Private.conditionalClientFlatten
+  error?: ErrorResponseBody;
 }
 
 /**
@@ -3582,6 +3571,16 @@ model ResourceSkuResult {
 }
 
 /**
+ * Describes an available API Management SKU.
+ */
+model ResourceSku {
+  /**
+   * Name of the Sku.
+   */
+  name?: SkuType;
+}
+
+/**
  * Describes scaling information of a SKU.
  */
 model ResourceSkuCapacity {
@@ -4072,7 +4071,7 @@ model PrivateEndpointConnectionWrapperProperties {
   /**
    * A collection of information about the state of the connection between service consumer and provider.
    */
-  privateLinkServiceConnectionState: PrivateLinkServiceConnectionState;
+  privateLinkServiceConnectionState: Azure.ResourceManager.CommonTypes.PrivateLinkServiceConnectionState;
 
   /**
    * The provisioning state of the private endpoint connection resource.
@@ -4094,26 +4093,6 @@ model ArmIdWrapper {
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
   @visibility(Lifecycle.Read)
   id?: string;
-}
-
-/**
- * A collection of information about the state of the connection between service consumer and provider.
- */
-model PrivateLinkServiceConnectionState {
-  /**
-   * Indicates whether the connection has been Approved/Rejected/Removed by the owner of the service.
-   */
-  status?: PrivateEndpointServiceConnectionStatus;
-
-  /**
-   * The reason for approval/rejection of the connection.
-   */
-  description?: string;
-
-  /**
-   * A message indicating if changes on the service provider require any updates on the consumer.
-   */
-  actionsRequired?: string;
 }
 
 /**
@@ -5694,50 +5673,6 @@ model PortalSettingValidationKeyContract {
 }
 
 /**
- * List of private endpoint connection associated with the specified storage account
- */
-@pagedResult
-model PrivateEndpointConnectionListResult {
-  /**
-   * Array of private endpoint connections
-   */
-  @items
-  value?: PrivateEndpointConnection[];
-}
-
-/**
- * Properties of the PrivateEndpointConnectProperties.
- */
-model PrivateEndpointConnectionProperties {
-  /**
-   * The resource of private end point.
-   */
-  privateEndpoint?: PrivateEndpoint;
-
-  /**
-   * A collection of information about the state of the connection between service consumer and provider.
-   */
-  privateLinkServiceConnectionState: PrivateLinkServiceConnectionState;
-
-  /**
-   * The provisioning state of the private endpoint connection resource.
-   */
-  @visibility(Lifecycle.Read)
-  provisioningState?: PrivateEndpointConnectionProvisioningState;
-}
-
-/**
- * The Private Endpoint resource.
- */
-model PrivateEndpoint {
-  /**
-   * The ARM identifier for Private Endpoint
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-}
-
-/**
  * A request to approve or reject a private endpoint connection
  */
 model PrivateEndpointConnectionRequest {
@@ -5759,40 +5694,7 @@ model PrivateEndpointConnectionRequestProperties {
   /**
    * A collection of information about the state of the connection between service consumer and provider.
    */
-  privateLinkServiceConnectionState?: PrivateLinkServiceConnectionState;
-}
-
-/**
- * A list of private link resources
- */
-model PrivateLinkResourceListResult {
-  /**
-   * Array of private link resources
-   */
-  value?: PrivateLinkResource[];
-}
-
-/**
- * Properties of a private link resource.
- */
-#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state" "For backward compatibility"
-model PrivateLinkResourceProperties {
-  /**
-   * The private link resource group id.
-   */
-  @visibility(Lifecycle.Read)
-  groupId?: string;
-
-  /**
-   * The private link resource required member names.
-   */
-  @visibility(Lifecycle.Read)
-  requiredMembers?: string[];
-
-  /**
-   * The private link resource Private link DNS zone name.
-   */
-  requiredZoneNames?: string[];
+  privateLinkServiceConnectionState?: Azure.ResourceManager.CommonTypes.PrivateLinkServiceConnectionState;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/models.tsp
@@ -2753,7 +2753,8 @@ model TokenBodyParameterContract {
  * External OAuth authorization server settings.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model AuthorizationServerUpdateContract extends Resource {
+model AuthorizationServerUpdateContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Properties of the External OAuth authorization server update Contract.
    */
@@ -3069,7 +3070,8 @@ model BackendUpdateParameterProperties extends BackendBaseParameters {
  * Reconnect request parameters.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model BackendReconnectContract extends Resource {
+model BackendReconnectContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Reconnect request properties.
    */
@@ -4545,7 +4547,7 @@ model GatewayApiData extends ApiContract {}
  * Association entity details.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model AssociationContract extends Resource {
+model AssociationContract extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Association entity contract properties.
    */
@@ -4846,7 +4848,8 @@ model IdentityProviderBaseParameters {
  * Identity Provider details.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model IdentityProviderCreateContract extends Resource {
+model IdentityProviderCreateContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Identity Provider contract properties.
    */
@@ -5031,7 +5034,8 @@ model NamedValueEntityBaseParameters {
  * NamedValue details.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model NamedValueCreateContract extends Resource {
+model NamedValueCreateContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * NamedValue entity contract properties for PUT operation.
    */
@@ -5236,7 +5240,7 @@ model RecipientsContractProperties {
  * Recipient User details.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model RecipientUserContract extends Resource {
+model RecipientUserContract extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Recipient User entity contract properties.
    */
@@ -5259,7 +5263,8 @@ model RecipientUsersContractProperties {
  * Recipient Email details.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model RecipientEmailContract extends Resource {
+model RecipientEmailContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Recipient Email contract properties.
    */
@@ -5438,7 +5443,8 @@ model PolicyDescriptionListResult {
  * Policy description details.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model PolicyDescriptionContract extends Resource {
+model PolicyDescriptionContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Policy description contract properties.
    */
@@ -5525,7 +5531,8 @@ model PortalSettingsListResult {
  * Portal Settings for the Developer Portal.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model PortalSettingsContract extends Resource {
+model PortalSettingsContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Portal Settings contract properties.
    */
@@ -6782,7 +6789,8 @@ model DeployConfigurationParameterProperties {
  * Long Running Git Operation Results.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model OperationResultContract extends Resource {
+model OperationResultContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Properties of the Operation Contract.
    */
@@ -6888,7 +6896,8 @@ model SaveConfigurationParameterProperties {
  * Result of Tenant Configuration Sync State.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model TenantConfigurationSyncStateContract extends Resource {
+model TenantConfigurationSyncStateContract
+  extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Properties returned Tenant Configuration Sync State check.
    */

--- a/packages/extensions/openapi-to-typespec/test/arm-azureintegrationspaces/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-azureintegrationspaces/tsp-output/models.tsp
@@ -10,6 +10,28 @@ using Azure.ResourceManager.Foundations;
 namespace Microsoft.IntegrationSpaces;
 
 /**
+ * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
+ */
+union Origin {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  user: "user",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  system: "system",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  `user,system`: "user,system",
+}
+
+/**
+ * Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
+ */
+union ActionType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Internal: "Internal",
+}
+
+/**
  * The status of the current operation.
  */
 union ProvisioningState {
@@ -41,6 +63,50 @@ union ProvisioningState {
 }
 
 /**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  User: "User",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Application: "Application",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  ManagedIdentity: "ManagedIdentity",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Key: "Key",
+}
+
+/**
+ * Localized display information for this particular operation.
+ */
+model OperationDisplay {
+  /**
+   * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
+   */
+  @visibility(Lifecycle.Read)
+  provider?: string;
+
+  /**
+   * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or "Job Schedule Collections".
+   */
+  @visibility(Lifecycle.Read)
+  resource?: string;
+
+  /**
+   * The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual Machine".
+   */
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
+}
+
+/**
  * The properties of space.
  */
 model SpaceResourceProperties {
@@ -54,35 +120,6 @@ model SpaceResourceProperties {
    * The description of the resource.
    */
   description?: string;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/models.tsp
@@ -1755,6 +1755,21 @@ union CloudServiceSlotType {
 }
 
 /**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  User: "User",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Application: "Application",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  ManagedIdentity: "ManagedIdentity",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Key: "Key",
+}
+
+/**
  * Specifies the sku of an Availability Set. Use 'Aligned' for virtual machines with managed disks and 'Classic' for virtual machines with unmanaged disks. Default value is 'Classic'.
  */
 union AvailabilitySetSkuTypes {
@@ -7972,6 +7987,29 @@ model DiskRestorePointReplicationStatus {
 }
 
 /**
+ * The resource model definition for an Azure Resource Manager proxy resource. It will not have tags and a location
+ */
+model ProxyResource {
+  /**
+   * Resource Id
+   */
+  @visibility(Lifecycle.Read)
+  id?: string;
+
+  /**
+   * Resource name
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * Resource type
+   */
+  @visibility(Lifecycle.Read)
+  type?: string;
+}
+
+/**
  * Update Restore Point collection parameters.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
@@ -9845,6 +9883,93 @@ model SnapshotList is Azure.Core.Page<Snapshot>;
  * The List Resource Skus operation response.
  */
 model ResourceSkusResult is Azure.Core.Page<ResourceSku>;
+
+/**
+ * Describes an available Compute SKU.
+ */
+model ResourceSku {
+  /**
+   * The type of resource the SKU applies to.
+   */
+  @visibility(Lifecycle.Read)
+  resourceType?: string;
+
+  /**
+   * The name of SKU.
+   */
+  @visibility(Lifecycle.Read)
+  name?: string;
+
+  /**
+   * Specifies the tier of virtual machines in a scale set.<br /><br /> Possible Values:<br /><br /> **Standard**<br /><br /> **Basic**
+   */
+  @visibility(Lifecycle.Read)
+  tier?: string;
+
+  /**
+   * The Size of the SKU.
+   */
+  @visibility(Lifecycle.Read)
+  size?: string;
+
+  /**
+   * The Family of this particular SKU.
+   */
+  @visibility(Lifecycle.Read)
+  family?: string;
+
+  /**
+   * The Kind of resources that are supported in this SKU.
+   */
+  @visibility(Lifecycle.Read)
+  kind?: string;
+
+  /**
+   * Specifies the number of virtual machines in the scale set.
+   */
+  @visibility(Lifecycle.Read)
+  capacity?: ResourceSkuCapacity;
+
+  /**
+   * The set of locations that the SKU is available.
+   */
+  @visibility(Lifecycle.Read)
+  locations?: string[];
+
+  /**
+   * A list of locations and availability zones in those locations where the SKU is available.
+   */
+  @visibility(Lifecycle.Read)
+  @OpenAPI.extension("x-ms-identifiers", #["location"])
+  locationInfo?: ResourceSkuLocationInfo[];
+
+  /**
+   * The api versions that support this SKU.
+   */
+  @visibility(Lifecycle.Read)
+  apiVersions?: string[];
+
+  /**
+   * Metadata for retrieving price info.
+   */
+  @visibility(Lifecycle.Read)
+  @OpenAPI.extension("x-ms-identifiers", #[])
+  costs?: ResourceSkuCosts[];
+
+  /**
+   * A name value pair to describe the capability.
+   */
+  @visibility(Lifecycle.Read)
+  @OpenAPI.extension("x-ms-identifiers", #["name"])
+  capabilities?: ResourceSkuCapabilities[];
+
+  /**
+   * The restrictions because of which SKU cannot be used. This is empty if there are no restrictions.
+   */
+  @visibility(Lifecycle.Read)
+  @OpenAPI.extension("x-ms-identifiers", #[])
+  restrictions?: ResourceSkuRestrictions[];
+}
 
 /**
  * Describes scaling information of a SKU.
@@ -11965,6 +12090,43 @@ model CloudServiceVaultAndSecretReference {
    * Secret URL which contains the protected settings of the extension
    */
   secretUrl?: string;
+}
+
+/**
+ * Metadata pertaining to creation and last modification of the resource.
+ */
+model SystemData {
+  /**
+   * The identity that created the resource.
+   */
+  createdBy?: string;
+
+  /**
+   * The type of identity that created the resource.
+   */
+  createdByType?: CreatedByType;
+
+  /**
+   * The timestamp of resource creation (UTC).
+   */
+  // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
+  createdAt?: utcDateTime;
+
+  /**
+   * The identity that last modified the resource.
+   */
+  lastModifiedBy?: string;
+
+  /**
+   * The type of identity that last modified the resource.
+   */
+  lastModifiedByType?: CreatedByType;
+
+  /**
+   * The timestamp of resource last modification (UTC)
+   */
+  // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
+  lastModifiedAt?: utcDateTime;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
@@ -95,18 +95,18 @@ union Status {
 }
 
 /**
- * Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
+ * The type of identity that created the resource.
  */
-union ManagedServiceIdentityType {
+union CreatedByType {
   string,
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  None: "None",
+  User: "User",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  SystemAssigned: "SystemAssigned",
+  Application: "Application",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  UserAssigned: "UserAssigned",
+  ManagedIdentity: "ManagedIdentity",
   #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-  `SystemAssigned,UserAssigned`: "SystemAssigned,UserAssigned",
+  Key: "Key",
 }
 
 /**
@@ -3670,97 +3670,6 @@ model ResourceName {
  */
 model PaginatedComputeResourcesList is Azure.Core.Page<ComputeResource>;
 
-/**
- * Managed service identity (system assigned and/or user assigned identities)
- */
-model ManagedServiceIdentity {
-  /**
-   * The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-format"
-  @visibility(Lifecycle.Read)
-  @format("uuid")
-  principalId?: string;
-
-  /**
-   * The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.
-   */
-  #suppress "@azure-tools/typespec-azure-core/no-format"
-  @visibility(Lifecycle.Read)
-  @format("uuid")
-  tenantId?: string;
-
-  /**
-   * Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
-   */
-  type: ManagedServiceIdentityType;
-
-  /**
-   * The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.
-   */
-  #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "For backward compatibility"
-  userAssignedIdentities?: Record<UserAssignedIdentity>;
-}
-
-/**
- * The resource model definition representing SKU
- */
-model Sku {
-  /**
-   * The name of the SKU. Ex - P3. It is typically a letter+number code
-   */
-  name: string;
-
-  /**
-   * This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
-   */
-  tier?: SkuTier;
-
-  /**
-   * The SKU size. When the name field is the combination of tier and some other value, this would be the standalone code.
-   */
-  size?: string;
-
-  /**
-   * If the service has different generations of hardware, for the same SKU, then that can be captured here.
-   */
-  family?: string;
-
-  /**
-   * If the SKU supports scale out/in then the capacity integer should be included. If scale out/in is not possible for the resource this may be omitted.
-   */
-  capacity?: int32;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
-}
-
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
 model ComputeResourceSchema {
   /**
@@ -4976,7 +4885,7 @@ model PartialManagedServiceIdentity {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */
-  type?: ManagedServiceIdentityType;
+  type?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentityType;
 
   /**
    * The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.
@@ -6448,7 +6357,7 @@ model PartialSku {
   /**
    * This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
    */
-  tier?: SkuTier;
+  tier?: Azure.ResourceManager.CommonTypes.SkuTier;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
@@ -6537,7 +6446,7 @@ model SkuSetting {
   /**
    * This field is required to be implemented by the Resource Provider if the service has more than one tier, but is not required on a PUT.
    */
-  tier?: SkuTier;
+  tier?: Azure.ResourceManager.CommonTypes.SkuTier;
 }
 
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
@@ -6750,17 +6659,6 @@ model PrivateEndpointResource extends PrivateEndpoint {
    * The subnetId that the private endpoint is connected to.
    */
   subnetArmId?: string;
-}
-
-/**
- * The Private Endpoint resource.
- */
-model PrivateEndpoint {
-  /**
-   * The ARM identifier for Private Endpoint
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
 }
 
 /**
@@ -6980,6 +6878,32 @@ model AmlOperation {
    * The intended executor of the operation: user/system
    */
   origin?: string;
+}
+
+/**
+ * Display name of operation
+ */
+model OperationDisplay {
+  /**
+   * Gets or sets the description for the operation.
+   */
+  description?: string;
+
+  /**
+   * Gets or sets the operation that users can perform.
+   */
+  operation?: string;
+
+  /**
+   * Gets or sets the resource provider name:
+   * Microsoft.MachineLearningExperimentation
+   */
+  provider?: string;
+
+  /**
+   * Gets or sets the resource on which the operation is performed.
+   */
+  resource?: string;
 }
 
 /**
@@ -7464,7 +7388,7 @@ model WorkspaceUpdateParameters {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */
-  identity?: ManagedServiceIdentity;
+  identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
 
   /**
    * The properties that the machine learning workspace will be updated with.
@@ -7476,7 +7400,7 @@ model WorkspaceUpdateParameters {
   /**
    * Optional. This field is required to be implemented by the RP because AML is supporting more than one tier
    */
-  sku?: Sku;
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 
   /**
    * The resource tags for the machine learning workspace.
@@ -7929,7 +7853,7 @@ model PrivateLinkResource extends Resource {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */
-  identity?: ManagedServiceIdentity;
+  identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
 
   /**
    * Same as workspace location.
@@ -7946,7 +7870,7 @@ model PrivateLinkResource extends Resource {
   /**
    * Optional. This field is required to be implemented by the RP because AML is supporting more than one tier
    */
-  sku?: Sku;
+  sku?: Azure.ResourceManager.CommonTypes.Sku;
 
   /**
    * Dictionary of <string>
@@ -13143,7 +13067,7 @@ model ManagedComputeIdentity extends MonitorComputeIdentityBase {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */
-  identity?: ManagedServiceIdentity;
+  identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
 
   /**
    * [Required] Monitor compute identity type enum.

--- a/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-machinelearningservices/tsp-output/models.tsp
@@ -6654,7 +6654,8 @@ model RegistryPrivateEndpointConnectionProperties {
  * The PE network resource that is linked to this PE connection.
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model PrivateEndpointResource extends PrivateEndpoint {
+model PrivateEndpointResource
+  extends Azure.ResourceManager.CommonTypes.PrivateEndpoint {
   /**
    * The subnetId that the private endpoint is connected to.
    */
@@ -6828,7 +6829,8 @@ model PartialRegistryPartialTrackedResource {
  * Managed service identity (system assigned and/or user assigned identities)
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model RegistryPartialManagedServiceIdentity extends ManagedServiceIdentity {}
+model RegistryPartialManagedServiceIdentity
+  extends Azure.ResourceManager.CommonTypes.ManagedServiceIdentity {}
 
 /**
  * The List Aml user feature operation response.
@@ -7849,7 +7851,7 @@ model PrivateLinkResourceListResult {
  * A private link resource
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model PrivateLinkResource extends Resource {
+model PrivateLinkResource extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Managed service identity (system assigned and/or user assigned identities)
    */

--- a/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/swagger-output/swagger.json
@@ -1584,7 +1584,7 @@
           "description": "The resource-specific properties for this resource."
         },
         "identity": {
-          "$ref": "#/definitions/ManagedServiceIdentity",
+          "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         }
       },
@@ -1847,7 +1847,7 @@
       "description": "The type used for update operations of the DataProduct.",
       "properties": {
         "identity": {
-          "$ref": "#/definitions/ManagedServiceIdentity",
+          "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/ManagedServiceIdentity",
           "description": "The managed service identities assigned to this resource."
         },
         "tags": {
@@ -2305,70 +2305,6 @@
         "name",
         "location"
       ]
-    },
-    "ManagedServiceIdentity": {
-      "type": "object",
-      "description": "Managed service identity (system assigned and/or user assigned identities)",
-      "properties": {
-        "principalId": {
-          "type": "string",
-          "format": "uuid",
-          "description": "The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.",
-          "readOnly": true
-        },
-        "tenantId": {
-          "type": "string",
-          "format": "uuid",
-          "description": "The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.",
-          "readOnly": true
-        },
-        "type": {
-          "$ref": "#/definitions/ManagedServiceIdentityType",
-          "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed)."
-        },
-        "userAssignedIdentities": {
-          "type": "object",
-          "description": "The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.",
-          "additionalProperties": {
-            "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/UserAssignedIdentity"
-          }
-        }
-      },
-      "required": [
-        "type"
-      ]
-    },
-    "ManagedServiceIdentityType": {
-      "type": "string",
-      "description": "Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).",
-      "enum": [
-        "None",
-        "SystemAssigned",
-        "UserAssigned",
-        "SystemAssigned, UserAssigned"
-      ],
-      "x-ms-enum": {
-        "name": "ManagedServiceIdentityType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "None",
-            "value": "None"
-          },
-          {
-            "name": "SystemAssigned",
-            "value": "SystemAssigned"
-          },
-          {
-            "name": "UserAssigned",
-            "value": "UserAssigned"
-          },
-          {
-            "name": "SystemAssigned, UserAssigned",
-            "value": "SystemAssigned, UserAssigned"
-          }
-        ]
-      }
     },
     "ProvisioningState": {
       "type": "string",

--- a/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/DataProduct.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/DataProduct.tsp
@@ -25,7 +25,7 @@ model DataProduct
   /**
    * The managed service identities assigned to this resource.
    */
-  identity?: ManagedServiceIdentity;
+  identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
 }
 
 @armResourceOperations

--- a/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-networkanalytics/tsp-output/models.tsp
@@ -10,6 +10,24 @@ using Azure.ResourceManager.Foundations;
 namespace Microsoft.NetworkAnalytics;
 
 /**
+ * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
+ */
+union Origin {
+  string,
+  user: "user",
+  system: "system",
+  `user,system`: "user,system",
+}
+
+/**
+ * Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
+ */
+union ActionType {
+  string,
+  Internal: "Internal",
+}
+
+/**
  * The status of the current operation.
  */
 union ProvisioningState {
@@ -86,14 +104,14 @@ union DefaultAction {
 }
 
 /**
- * Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
+ * The type of identity that created the resource.
  */
-union ManagedServiceIdentityType {
+union CreatedByType {
   string,
-  None: "None",
-  SystemAssigned: "SystemAssigned",
-  UserAssigned: "UserAssigned",
-  `SystemAssigned, UserAssigned`: "SystemAssigned, UserAssigned",
+  User: "User",
+  Application: "Application",
+  ManagedIdentity: "ManagedIdentity",
+  Key: "Key",
 }
 
 /**
@@ -156,6 +174,35 @@ union Bypass {
    * Represents bypassing azure services traffic.
    */
   AzureServices: "AzureServices",
+}
+
+/**
+ * Localized display information for this particular operation.
+ */
+model OperationDisplay {
+  /**
+   * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
+   */
+  @visibility(Lifecycle.Read)
+  provider?: string;
+
+  /**
+   * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or "Job Schedule Collections".
+   */
+  @visibility(Lifecycle.Read)
+  resource?: string;
+
+  /**
+   * The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual Machine".
+   */
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
 }
 
 /**
@@ -433,64 +480,6 @@ model ConsumptionEndpointsProperties {
 }
 
 /**
- * Managed service identity (system assigned and/or user assigned identities)
- */
-model ManagedServiceIdentity {
-  /**
-   * The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity.
-   */
-  @visibility(Lifecycle.Read)
-  @format("uuid")
-  principalId?: string;
-
-  /**
-   * The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.
-   */
-  @visibility(Lifecycle.Read)
-  @format("uuid")
-  tenantId?: string;
-
-  /**
-   * Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).
-   */
-  type: ManagedServiceIdentityType;
-
-  /**
-   * The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests.
-   */
-  userAssignedIdentities?: Record<UserAssignedIdentity>;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
-}
-
-/**
  * Details for data catalog properties.
  */
 model DataProductsCatalogProperties {
@@ -561,7 +550,7 @@ model DataProductUpdate {
   /**
    * The managed service identities assigned to this resource.
    */
-  identity?: ManagedServiceIdentity;
+  identity?: Azure.ResourceManager.CommonTypes.ManagedServiceIdentity;
 
   /**
    * Resource tags.

--- a/packages/extensions/openapi-to-typespec/test/arm-playwrighttesting/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-playwrighttesting/tsp-output/models.tsp
@@ -10,6 +10,24 @@ using Azure.ResourceManager.Foundations;
 namespace Microsoft.AzurePlaywrightService;
 
 /**
+ * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
+ */
+union Origin {
+  string,
+  user: "user",
+  system: "system",
+  `user,system`: "user,system",
+}
+
+/**
+ * Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
+ */
+union ActionType {
+  string,
+  Internal: "Internal",
+}
+
+/**
  * The enablement status of a feature.
  */
 union EnablementStatus {
@@ -59,6 +77,17 @@ union ProvisioningState {
 }
 
 /**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  User: "User",
+  Application: "Application",
+  ManagedIdentity: "ManagedIdentity",
+  Key: "Key",
+}
+
+/**
  * The free-trial state.
  */
 union FreeTrialState {
@@ -82,6 +111,35 @@ union QuotaNames {
    * The quota details for scalable execution feature. When enabled, Playwright client workers can connect to cloud-hosted browsers. This can increase the number of parallel workers for a test run, significantly minimizing test completion durations.
    */
   ScalableExecution: "ScalableExecution",
+}
+
+/**
+ * Localized display information for this particular operation.
+ */
+model OperationDisplay {
+  /**
+   * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
+   */
+  @visibility(Lifecycle.Read)
+  provider?: string;
+
+  /**
+   * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or "Job Schedule Collections".
+   */
+  @visibility(Lifecycle.Read)
+  resource?: string;
+
+  /**
+   * The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual Machine".
+   */
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
 }
 
 /**
@@ -114,35 +172,6 @@ model AccountProperties {
    */
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-servicenetworking/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-servicenetworking/tsp-output/models.tsp
@@ -9,6 +9,24 @@ using Azure.ResourceManager.Foundations;
 
 namespace Microsoft.ServiceNetworking;
 
+/**
+ * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
+ */
+union Origin {
+  string,
+  user: "user",
+  system: "system",
+  `user,system`: "user,system",
+}
+
+/**
+ * Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
+ */
+union ActionType {
+  string,
+  Internal: "Internal",
+}
+
 union ProvisioningState {
   string,
   Provisioning: "Provisioning",
@@ -20,9 +38,49 @@ union ProvisioningState {
   Canceled: "Canceled",
 }
 
+/**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  User: "User",
+  Application: "Application",
+  ManagedIdentity: "ManagedIdentity",
+  Key: "Key",
+}
+
 union AssociationType {
   string,
   subnets: "subnets",
+}
+
+/**
+ * Localized display information for this particular operation.
+ */
+model OperationDisplay {
+  /**
+   * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
+   */
+  @visibility(Lifecycle.Read)
+  provider?: string;
+
+  /**
+   * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or "Job Schedule Collections".
+   */
+  @visibility(Lifecycle.Read)
+  resource?: string;
+
+  /**
+   * The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual Machine".
+   */
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
 }
 
 /**
@@ -62,35 +120,6 @@ model ResourceId {
    * Resource ID of child resource.
    */
   id: string;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-sphere/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-sphere/tsp-output/models.tsp
@@ -11,6 +11,24 @@ using Azure.ResourceManager.Foundations;
 namespace Microsoft.AzureSphere;
 
 /**
+ * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
+ */
+union Origin {
+  string,
+  user: "user",
+  system: "system",
+  `user,system`: "user,system",
+}
+
+/**
+ * Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
+ */
+union ActionType {
+  string,
+  Internal: "Internal",
+}
+
+/**
  * Provisioning state of the resource.
  */
 union ProvisioningState {
@@ -50,6 +68,17 @@ union ProvisioningState {
    * The resource create request has been accepted
    */
   Accepted: "Accepted",
+}
+
+/**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  User: "User",
+  Application: "Application",
+  ManagedIdentity: "ManagedIdentity",
+  Key: "Key",
 }
 
 /**
@@ -292,6 +321,35 @@ union CapabilityType {
 }
 
 /**
+ * Localized display information for this particular operation.
+ */
+model OperationDisplay {
+  /**
+   * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
+   */
+  @visibility(Lifecycle.Read)
+  provider?: string;
+
+  /**
+   * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or "Job Schedule Collections".
+   */
+  @visibility(Lifecycle.Read)
+  resource?: string;
+
+  /**
+   * The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual Machine".
+   */
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
+}
+
+/**
  * Catalog properties
  */
 model CatalogProperties {
@@ -300,35 +358,6 @@ model CatalogProperties {
    */
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningState;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/swagger-output/swagger.json
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/swagger-output/swagger.json
@@ -5884,22 +5884,6 @@
         "body"
       ]
     },
-    "AzureEntityResource": {
-      "type": "object",
-      "description": "The resource model definition for an Azure Resource Manager resource with an etag.",
-      "properties": {
-        "etag": {
-          "type": "string",
-          "description": "Resource Etag.",
-          "readOnly": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Resource"
-        }
-      ]
-    },
     "AzureFilesIdentityBasedAuthentication": {
       "type": "object",
       "description": "Settings for Azure Files identity based authentication.",
@@ -7142,22 +7126,6 @@
         }
       ]
     },
-    "FileShareItem": {
-      "type": "object",
-      "description": "The file share properties be listed out.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/FileShareProperties",
-          "description": "The file share properties be listed out.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/AzureEntityResource"
-        }
-      ]
-    },
     "FileShareItems": {
       "type": "object",
       "description": "Response schema. Contains list of shares returned, and if paging is requested or required, a URL to next page of shares.",
@@ -7417,7 +7385,7 @@
           "type": "object",
           "description": "Gets or sets a list of key value pairs that describe the set of User Assigned identities that will be used with this storage account. The key is the ARM resource identifier of the identity. Only 1 User Assigned identity is permitted here.",
           "additionalProperties": {
-            "$ref": "../../common-types/resource-management/v3/managedidentity.json#/definitions/UserAssignedIdentity"
+            "$ref": "#/definitions/UserAssignedIdentity"
           }
         }
       },
@@ -8132,22 +8100,6 @@
         }
       }
     },
-    "ListContainerItem": {
-      "type": "object",
-      "description": "The blob container properties be listed out.",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/ContainerProperties",
-          "description": "The blob container properties be listed out.",
-          "x-ms-client-flatten": true
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/AzureEntityResource"
-        }
-      ]
-    },
     "ListContainerItems": {
       "type": "object",
       "description": "Response schema. Contains list of blobs returned, and if paging is requested or required, a URL to next page of containers.",
@@ -8168,34 +8120,6 @@
       "required": [
         "value"
       ]
-    },
-    "ListQueue": {
-      "type": "object",
-      "properties": {
-        "properties": {
-          "$ref": "#/definitions/ListQueueProperties",
-          "description": "List Queue resource properties.",
-          "x-ms-client-flatten": true,
-          "x-ms-client-name": "queueProperties"
-        }
-      },
-      "allOf": [
-        {
-          "$ref": "#/definitions/Resource"
-        }
-      ]
-    },
-    "ListQueueProperties": {
-      "type": "object",
-      "properties": {
-        "metadata": {
-          "type": "object",
-          "description": "A name-value pair that represents queue metadata.",
-          "additionalProperties": {
-            "type": "string"
-          }
-        }
-      }
     },
     "ListQueueResource": {
       "type": "object",
@@ -9097,7 +9021,7 @@
       },
       "allOf": [
         {
-          "$ref": "#/definitions/Resource"
+          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/Resource"
         }
       ]
     },
@@ -9308,27 +9232,6 @@
             "value": "NotAvailableForSubscription"
           }
         ]
-      }
-    },
-    "Resource": {
-      "type": "object",
-      "description": "Common fields that are returned in the response for all Azure Resource Manager resources",
-      "properties": {
-        "id": {
-          "type": "string",
-          "description": "Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}",
-          "readOnly": true
-        },
-        "name": {
-          "type": "string",
-          "description": "The name of the resource",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "description": "The type of the resource. E.g. \"Microsoft.Compute/virtualMachines\" or \"Microsoft.Storage/storageAccounts\"",
-          "readOnly": true
-        }
       }
     },
     "ResourceAccessRule": {
@@ -9799,7 +9702,7 @@
           "description": "The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType."
         },
         "tier": {
-          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/SkuTier",
+          "$ref": "#/definitions/SkuTier",
           "description": "The SKU tier. This is based on the SKU name.",
           "readOnly": true
         }
@@ -9844,7 +9747,7 @@
           "description": "The SKU name. Required for account creation; optional for update. Note that in older versions, SKU name was called accountType."
         },
         "tier": {
-          "$ref": "../../common-types/resource-management/v3/types.json#/definitions/SkuTier",
+          "$ref": "#/definitions/SkuTier",
           "description": "The SKU tier. This is based on the SKU name.",
           "readOnly": true
         },
@@ -9938,6 +9841,18 @@
             "value": "Standard_RAGZRS"
           }
         ]
+      }
+    },
+    "SkuTier": {
+      "type": "string",
+      "description": "The SKU tier. This is based on the SKU name.",
+      "enum": [
+        "Standard",
+        "Premium"
+      ],
+      "x-ms-enum": {
+        "name": "SkuTier",
+        "modelAsString": false
       }
     },
     "SmbSetting": {
@@ -10862,6 +10777,22 @@
       "x-ms-enum": {
         "name": "UsageUnit",
         "modelAsString": false
+      }
+    },
+    "UserAssignedIdentity": {
+      "type": "object",
+      "description": "UserAssignedIdentity for the resource.",
+      "properties": {
+        "principalId": {
+          "type": "string",
+          "description": "The principal ID of the identity.",
+          "readOnly": true
+        },
+        "clientId": {
+          "type": "string",
+          "description": "The client ID of the identity.",
+          "readOnly": true
+        }
       }
     },
     "VirtualNetworkRule": {

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/back-compatible.tsp
@@ -4,6 +4,10 @@ using Azure.ClientGenerator.Core;
 using Microsoft.Storage;
 
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
+@@flattenProperty(Operation.properties);
+@@clientName(Operation.properties, "operationProperties");
+
+#suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(StorageAccountCreateParameters.properties);
 
 @@clientName(StorageAccountPropertiesCreateParameters.networkAcls,

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/models.tsp
@@ -471,6 +471,21 @@ union ObjectType {
 }
 
 /**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  User: "User",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Application: "Application",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  ManagedIdentity: "ManagedIdentity",
+  #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
+  Key: "Key",
+}
+
+/**
  * The provider for the encryption scope. Possible values (case-insensitive):  Microsoft.Storage, Microsoft.KeyVault.
  */
 union EncryptionScopeSource {
@@ -688,6 +703,15 @@ union LeaseShareAction {
 }
 
 /**
+ * The SKU tier. This is based on the SKU name.
+ */
+#suppress "@azure-tools/typespec-azure-core/no-enum" "For backward compatibility"
+enum SkuTier {
+  Standard,
+  Premium,
+}
+
+/**
  * Gets the reason that a storage account name could not be used. The Reason element is only returned if NameAvailable is false.
  */
 #suppress "@azure-tools/typespec-azure-core/no-enum" "For backward compatibility"
@@ -781,6 +805,58 @@ enum PublicAccess {
   Container,
   Blob,
   None,
+}
+
+/**
+ * Storage REST API operation definition.
+ */
+model Operation {
+  /**
+   * Operation name: {provider}/{resource}/{operation}
+   */
+  name?: string;
+
+  /**
+   * Display metadata associated with the operation.
+   */
+  display?: OperationDisplay;
+
+  /**
+   * The origin of operations.
+   */
+  origin?: string;
+
+  /**
+   * Properties of operation, include metric specifications.
+   */
+  #suppress "@azure-tools/typespec-azure-core/no-private-usage" "For backward compatibility"
+  @Azure.ResourceManager.Private.conditionalClientFlatten
+  properties?: OperationProperties;
+}
+
+/**
+ * Display metadata associated with the operation.
+ */
+model OperationDisplay {
+  /**
+   * Service provider: Microsoft Storage.
+   */
+  provider?: string;
+
+  /**
+   * Resource on which the operation is performed etc.
+   */
+  resource?: string;
+
+  /**
+   * Type of operation: get, read, delete, etc.
+   */
+  operation?: string;
+
+  /**
+   * Description of the operation.
+   */
+  description?: string;
 }
 
 /**
@@ -1103,6 +1179,23 @@ model Identity {
    */
   #suppress "@azure-tools/typespec-azure-resource-manager/arm-no-record" "For backward compatibility"
   userAssignedIdentities?: Record<UserAssignedIdentity>;
+}
+
+/**
+ * UserAssignedIdentity for the resource.
+ */
+model UserAssignedIdentity {
+  /**
+   * The principal ID of the identity.
+   */
+  @visibility(Lifecycle.Read)
+  principalId?: string;
+
+  /**
+   * The client ID of the identity.
+   */
+  @visibility(Lifecycle.Read)
+  clientId?: string;
 }
 
 /**
@@ -2028,29 +2121,6 @@ model PrivateLinkServiceConnectionState {
 }
 
 /**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-}
-
-/**
  * Blob restore status.
  */
 model BlobRestoreStatus {
@@ -2319,6 +2389,17 @@ model DeletedAccountProperties {
   @visibility(Lifecycle.Read)
   // FIXME: (utcDateTime) Please double check that this is the correct type for your scenario.
   deletionTime?: utcDateTime;
+}
+
+/**
+ * An error response from the storage resource provider.
+ */
+@error
+model ErrorResponse {
+  /**
+   * Azure Storage Resource Provider error response body.
+   */
+  error?: ErrorResponseBody;
 }
 
 /**
@@ -3897,18 +3978,6 @@ model ImmutableStorageWithVersioning {
    */
   @visibility(Lifecycle.Read)
   migrationState?: MigrationState;
-}
-
-/**
- * The resource model definition for an Azure Resource Manager resource with an etag.
- */
-#suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model AzureEntityResource extends Resource {
-  /**
-   * Resource Etag.
-   */
-  @visibility(Lifecycle.Read)
-  etag?: string;
 }
 
 /**

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/models.tsp
@@ -3170,7 +3170,7 @@ model PrivateLinkResourceListResult {
  * A private link resource
  */
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
-model PrivateLinkResource extends Resource {
+model PrivateLinkResource extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * Resource properties.
    */
@@ -4486,7 +4486,7 @@ model FileShareItem extends AzureEntityResource {
 
 #suppress "@azure-tools/typespec-azure-core/composition-over-inheritance" "For backward compatibility"
 #suppress "@azure-tools/typespec-azure-core/documentation-required" "For backward compatibility"
-model ListQueue extends Resource {
+model ListQueue extends Azure.ResourceManager.CommonTypes.Resource {
   /**
    * List Queue resource properties.
    */

--- a/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/models.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-test/tsp-output/models.tsp
@@ -10,6 +10,24 @@ using Azure.ResourceManager.Foundations;
 namespace Microsoft.Test;
 
 /**
+ * The intended executor of the operation; as in Resource Based Access Control (RBAC) and audit logs UX. Default value is "user,system"
+ */
+union Origin {
+  string,
+  user: "user",
+  system: "system",
+  `user,system`: "user,system",
+}
+
+/**
+ * Enum. Indicates the action type. "Internal" refers to actions that are for internal only APIs.
+ */
+union ActionType {
+  string,
+  Internal: "Internal",
+}
+
+/**
  * The provisioning state of a resource.
  */
 union ProvisioningStateTest {
@@ -52,6 +70,46 @@ union ProvisioningStateTest {
 }
 
 /**
+ * The type of identity that created the resource.
+ */
+union CreatedByType {
+  string,
+  User: "User",
+  Application: "Application",
+  ManagedIdentity: "ManagedIdentity",
+  Key: "Key",
+}
+
+/**
+ * Localized display information for this particular operation.
+ */
+model OperationDisplay {
+  /**
+   * The localized friendly form of the resource provider name, e.g. "Microsoft Monitoring Insights" or "Microsoft Compute".
+   */
+  @visibility(Lifecycle.Read)
+  provider?: string;
+
+  /**
+   * The localized friendly name of the resource type related to this operation. E.g. "Virtual Machines" or "Job Schedule Collections".
+   */
+  @visibility(Lifecycle.Read)
+  resource?: string;
+
+  /**
+   * The concise, localized friendly name for the operation; suitable for dropdowns. E.g. "Create or Update Virtual Machine", "Restart Virtual Machine".
+   */
+  @visibility(Lifecycle.Read)
+  operation?: string;
+
+  /**
+   * The short, localized friendly description of the operation; suitable for tool tips and detailed views.
+   */
+  @visibility(Lifecycle.Read)
+  description?: string;
+}
+
+/**
  * Employee properties
  */
 model EmployeeProperties {
@@ -75,35 +133,6 @@ model EmployeeProperties {
    */
   @visibility(Lifecycle.Read)
   provisioningState?: ProvisioningStateTest;
-}
-
-/**
- * Common fields that are returned in the response for all Azure Resource Manager resources
- */
-model Resource {
-  /**
-   * Fully qualified resource ID for the resource. Ex - /subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{resourceProviderNamespace}/{resourceType}/{resourceName}
-   */
-  @visibility(Lifecycle.Read)
-  id?: string;
-
-  /**
-   * The name of the resource
-   */
-  @visibility(Lifecycle.Read)
-  name?: string;
-
-  /**
-   * The type of the resource. E.g. "Microsoft.Compute/virtualMachines" or "Microsoft.Storage/storageAccounts"
-   */
-  @visibility(Lifecycle.Read)
-  type?: string;
-
-  /**
-   * Azure Resource Manager metadata containing createdBy and modifiedBy information.
-   */
-  @visibility(Lifecycle.Read)
-  systemData?: SystemData;
 }
 
 /**


### PR DESCRIPTION
Fix #5100

A known issue after this is: if user refers to a common type, we will use the common type in TypeSpec lib, however, if this common type has inner type, I cannot tell whether it is from common type, therefore I'll still generate it.