### PR TITLE
[deduplication] Only treat "$ref" as reference if value is string (part 2)

### DIFF
--- a/packages/libs/deduplication/src/main.ts
+++ b/packages/libs/deduplication/src/main.ts
@@ -420,7 +420,7 @@ export class Deduplicator {
 
       if (value && typeof value === "object") {
         const ref = value.$ref;
-        if (ref) {
+        if (ref && typeof ref === "string") {
           // see if this object has a $ref
           const newRef = this.refs[ref];
           if (newRef) {


### PR DESCRIPTION
- Continuation of #5088