### PR TITLE
Fix regression with json path failing on eval error

### DIFF
--- a/common/changes/@autorest/openapi-to-typespec/fix-ci-failures_2025-05-21-19-09.json
+++ b/common/changes/@autorest/openapi-to-typespec/fix-ci-failures_2025-05-21-19-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/core",
+      "comment": "Fix directive not applying when json path query result in some eval errors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/datastore"
+}

--- a/common/changes/@azure-tools/datastore/fix-ci-failures_2025-05-21-19-09.json
+++ b/common/changes/@azure-tools/datastore/fix-ci-failures_2025-05-21-19-09.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/datastore",
+      "comment": "Fix json path query not applying when json path query result in some eval errors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@azure-tools/datastore"
+}

--- a/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
+++ b/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
@@ -62,8 +62,7 @@ export async function generateSwagger(folder: string) {
 
   const { path: root } = await resolveProject(__dirname);
   const path = join(root, "test", folder, "tsp-output");
-  const command =
-    "tsp compile . --emit=@azure-tools/typespec-autorest --option @azure-tools/typespec-autorest.output-file=./swagger-output/swagger.json";
+  const command = `tsp compile . --emit=@azure-tools/typespec-autorest --option @azure-tools/typespec-autorest.emitter-output-dir="{project-root}/../swagger-output" --option @azure-tools/typespec-autorest.output-file=swagger.json`;
   execSync(command, { cwd: path, stdio: "inherit" });
 }
 

--- a/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
+++ b/packages/extensions/openapi-to-typespec/test/utils/generate-typespec.ts
@@ -87,6 +87,8 @@ async function generate(root: string, path: string, debug = false, isFullCompati
     resolve(root, "packages/apps/autorest/entrypoints/app.js"),
     "--openapi-to-typespec",
     inputFile,
+    `--version=${resolve(root, "packages/extensions/core")}`,
+    `--use=${resolve(root, "packages/extensions/modelerfour")}`,
     "--use=.",
     `--output-folder=${dirname(path)}`,
     "--src-path=tsp-output",

--- a/packages/libs/datastore/src/json-path/json-path.test.ts
+++ b/packages/libs/datastore/src/json-path/json-path.test.ts
@@ -42,7 +42,35 @@ describe("JsonPath", () => {
     expect(jp.nodes(obj, "$..['d']").length).toEqual(1);
     expect(jp.nodes(obj, "$..d").length).toEqual(1);
     expect(jp.nodes(obj, "$..[2]").length).toEqual(1);
-    // expect(jp.nodes(obj, "$..[?(@.a[2] === 3)]").length).toEqual(1);
+    expect(jp.nodes(obj, "$..[?(@.a[2] === 3)]").length).toEqual(1);
     // expect(jp.nodes(obj, "$..[?(@.a.reduce((x,y) => x+y, 0) === 6)]").length).toEqual(1);
+  });
+
+  it("doesn't crash on null values", () => {
+    const obj = {
+      a: "a",
+      paths: {
+        "/test": {
+          get: {
+            parameters: [
+              {
+                name: "$orderby",
+                description: "May be used to expand the participants.",
+                in: "query",
+                required: false,
+                type: "string",
+              },
+            ],
+            responses: {
+              "200": {
+                "x-custom": null,
+                description: "OK. The request has succeeded.",
+              },
+            },
+          },
+        },
+      },
+    };
+    expect(jp.nodes(obj, "$..[?(@.name=='$orderby')]").length).toEqual(1);
   });
 });

--- a/packages/libs/datastore/src/json-path/json-path.ts
+++ b/packages/libs/datastore/src/json-path/json-path.ts
@@ -2,7 +2,6 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { createSandbox } from "@azure-tools/codegen";
 import { JSONPath } from "jsonpath-plus";
 
 export type JsonPath = JsonPathComponent[];

--- a/packages/libs/datastore/src/json-path/json-path.ts
+++ b/packages/libs/datastore/src/json-path/json-path.ts
@@ -22,19 +22,6 @@ interface JsonPathResult {
   pointer: string;
 }
 
-// Override the vm used in jsonpath to use our safeEval and ignore errors.
-const safeEval = createSandbox();
-JSONPath.prototype.vm = {
-  runInNewContext: (code: string, context: Record<string, any>) => {
-    try {
-      return safeEval(code, context);
-    } catch (e) {
-      // We just ignore javascript errors.
-      return false;
-    }
-  },
-};
-
 export function parse(jsonPath: string): JsonPath {
   return (JSONPath as any as JSONPathExt).toPathArray(jsonPath).slice(1);
 }
@@ -44,7 +31,7 @@ export function paths<T>(obj: T, jsonQuery: string): Array<JsonPath> {
 }
 
 function run(obj: any, query: string): JsonPathResult[] {
-  return JSONPath({ path: query, json: obj as any, resultType: "all" });
+  return JSONPath({ path: query, json: obj as any, resultType: "all", ignoreEvalErrors: true });
 }
 
 export function nodes<T>(obj: T, query: string): Array<{ path: JsonPath; value: any }> {


### PR DESCRIPTION
A few fix:
- make sure the openapi to tsp use the local version of core and autorest to not catch error after the fact
- Fix the json path issue 