### PR TITLE
Fix minLength constraint on api version...

### DIFF
--- a/packages/libs/autorest-schemas/example-schema.json
+++ b/packages/libs/autorest-schemas/example-schema.json
@@ -46,7 +46,7 @@
       "api-version": {
         "type": "string",
         "description": "An example of the api-version used in the request.",
-        "minLength": 3
+        "minLength": 1
       },
       "subcriptionId": {
         "type": "string",


### PR DESCRIPTION
...which for some reason was 3 - which disallows valid api versions such as v1.