### PR TITLE
Fix clientLocation issue

### DIFF
--- a/common/changes/@autorest/openapi-to-typespec/clientLocationFix_2025-07-28-06-52.json
+++ b/common/changes/@autorest/openapi-to-typespec/clientLocationFix_2025-07-28-06-52.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@autorest/openapi-to-typespec",
+      "comment": "Fix clientLocation issue",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@autorest/openapi-to-typespec"
+}

--- a/packages/extensions/openapi-to-typespec/src/model.ts
+++ b/packages/extensions/openapi-to-typespec/src/model.ts
@@ -8,9 +8,9 @@ import { transformEnum } from "./transforms/transform-choices";
 import { getTypespecType, transformObject } from "./transforms/transform-object";
 import { isListOperation, transformOperationGroup } from "./transforms/transform-operations";
 import { transformServiceInformation } from "./transforms/transform-service-information";
+import { isInterfaceName } from "./utils/operation-group";
 import { ArmResourceSchema, filterArmEnums, filterArmModels, isResourceSchema } from "./utils/resource-discovery";
 import { isChoiceSchema } from "./utils/schemas";
-import { isInterfaceName } from "./utils/operation-group";
 
 const models: Map<CodeModel, TypespecProgram> = new Map();
 

--- a/packages/extensions/openapi-to-typespec/src/utils/operation-group.ts
+++ b/packages/extensions/openapi-to-typespec/src/utils/operation-group.ts
@@ -33,7 +33,7 @@ function isExistingOperationGroupName(operationGroupName: string): boolean {
   const codeModel = getSession().model;
   return (
     codeModel.schemas.objects?.find((o) => o.language.default.name === operationGroupName) !== undefined ||
-    Array.from(operationGroupNameCache.values()).find((v) => v === operationGroupName) !== undefined
+    isInterfaceName(operationGroupName)
   );
 }
 
@@ -42,12 +42,23 @@ export function getSwaggerOperationName(operationId: string): string {
   return splittedOperationId.length === 2 ? splittedOperationId[1] : operationId;
 }
 
+const nonResourceOperationGroupNameCache: Set<string> = new Set<string>();
 export function getTSPNonResourceOperationGroupName(name: string): string {
   const operationGroupName = `${name}OperationGroup`;
   if (!isExistingOperationGroupName(operationGroupName)) {
+    nonResourceOperationGroupNameCache.add(operationGroupName);
     return operationGroupName;
   }
 
   // Arm resource operation group name cannot be ended with "Operations"
-  return getOptions().isArm ? `${name}NonResourceOperationGroup` : `${name}Operations`;
+  const groupName = getOptions().isArm ? `${name}NonResourceOperationGroup` : `${name}Operations`;
+  nonResourceOperationGroupNameCache.add(groupName);
+  return groupName;
+}
+
+export function isInterfaceName(name: string): boolean {
+  return (
+    Array.from(operationGroupNameCache.values()).find((v) => v === name) !== undefined ||
+    nonResourceOperationGroupNameCache.has(name)
+  );
 }

--- a/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-alertsmanagement/tsp-output/back-compatible.tsp
@@ -16,5 +16,5 @@ using Azure.ResourceManager.AlertsManagement;
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(SmartGroup.properties);
 
-@@clientLocation(AlertsOperationGroup.metaData, "Alerts");
-@@clientLocation(AlertsOperationGroup.getSummary, "Alerts");
+@@clientLocation(AlertsOperationGroup.metaData, Alerts);
+@@clientLocation(AlertsOperationGroup.getSummary, Alerts);

--- a/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-analysisservices/tsp-output/back-compatible.tsp
@@ -11,5 +11,5 @@ using Azure.ResourceManager.Analysis;
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(AnalysisServicesServer.properties);
 
-@@clientLocation(ServersOperationGroup.listSkusForNew, "Servers");
-@@clientLocation(ServersOperationGroup.checkNameAvailability, "Servers");
+@@clientLocation(ServersOperationGroup.listSkusForNew, Servers);
+@@clientLocation(ServersOperationGroup.checkNameAvailability, Servers);

--- a/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-apimanagement/tsp-output/back-compatible.tsp
@@ -238,28 +238,28 @@ using Azure.ResourceManager.ApiManagement;
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(PolicyContract.properties);
 
-@@clientLocation(TagContracts.getByOperation, "Tag");
-@@clientLocation(TagContracts.getEntityStateByOperation, "Tag");
-@@clientLocation(TagContracts.assignToOperation, "Tag");
-@@clientLocation(TagContracts.detachFromOperation, "Tag");
-@@clientLocation(TagContracts.listByOperation, "Tag");
-@@clientLocation(TagContractOperationGroup.getByProduct, "Tag");
-@@clientLocation(TagContractOperationGroup.getEntityStateByProduct, "Tag");
-@@clientLocation(TagContractOperationGroup.assignToProduct, "Tag");
-@@clientLocation(TagContractOperationGroup.detachFromProduct, "Tag");
-@@clientLocation(TagContractOperationGroup.listByProduct, "Tag");
-@@clientLocation(TagContractOperationGroup.get, "Tag");
-@@clientLocation(TagContractOperationGroup.getEntityState, "Tag");
-@@clientLocation(TagContractOperationGroup.createOrUpdate, "Tag");
+@@clientLocation(TagContracts.getByOperation, Tag);
+@@clientLocation(TagContracts.getEntityStateByOperation, Tag);
+@@clientLocation(TagContracts.assignToOperation, Tag);
+@@clientLocation(TagContracts.detachFromOperation, Tag);
+@@clientLocation(TagContracts.listByOperation, Tag);
+@@clientLocation(TagContractOperationGroup.getByProduct, Tag);
+@@clientLocation(TagContractOperationGroup.getEntityStateByProduct, Tag);
+@@clientLocation(TagContractOperationGroup.assignToProduct, Tag);
+@@clientLocation(TagContractOperationGroup.detachFromProduct, Tag);
+@@clientLocation(TagContractOperationGroup.listByProduct, Tag);
+@@clientLocation(TagContractOperationGroup.get, Tag);
+@@clientLocation(TagContractOperationGroup.getEntityState, Tag);
+@@clientLocation(TagContractOperationGroup.createOrUpdate, Tag);
 @@clientName(TagContractOperationGroup.createOrUpdate::parameters.resource,
   "parameters"
 );
-@@clientLocation(TagContractOperationGroup.update, "Tag");
+@@clientLocation(TagContractOperationGroup.update, Tag);
 @@clientName(TagContractOperationGroup.update::parameters.properties,
   "parameters"
 );
-@@clientLocation(TagContractOperationGroup.delete, "Tag");
-@@clientLocation(TagContractOperationGroup.listByService, "Tag");
+@@clientLocation(TagContractOperationGroup.delete, Tag);
+@@clientLocation(TagContractOperationGroup.listByService, Tag);
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(TagContract.properties);
 

--- a/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-compute/tsp-output/back-compatible.tsp
@@ -392,19 +392,19 @@ using Microsoft.Compute;
 @@flattenProperty(DiskAccess.properties);
 
 @@clientLocation(PrivateEndpointConnections.getAPrivateEndpointConnection,
-  "DiskAccesses"
+  DiskAccesses
 );
 @@clientLocation(PrivateEndpointConnections.updateAPrivateEndpointConnection,
-  "DiskAccesses"
+  DiskAccesses
 );
 @@clientName(PrivateEndpointConnections.updateAPrivateEndpointConnection::parameters.resource,
   "privateEndpointConnection"
 );
 @@clientLocation(PrivateEndpointConnections.deleteAPrivateEndpointConnection,
-  "DiskAccesses"
+  DiskAccesses
 );
 @@clientLocation(PrivateEndpointConnections.listPrivateEndpointConnections,
-  "DiskAccesses"
+  DiskAccesses
 );
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(PrivateEndpointConnection.properties);
@@ -522,12 +522,10 @@ using Microsoft.Compute;
 @@clientLocation(VirtualMachineSizesOperationGroup.list, "VirtualMachineSizes");
 
 @@clientLocation(VirtualMachineScaleSetsOperationGroup.listByLocation,
-  "VirtualMachineScaleSets"
+  VirtualMachineScaleSets
 );
 
-@@clientLocation(VirtualMachinesOperationGroup.listByLocation,
-  "VirtualMachines"
-);
+@@clientLocation(VirtualMachinesOperationGroup.listByLocation, VirtualMachines);
 
 @@clientLocation(VirtualMachineImagesOperationGroup.get,
   "VirtualMachineImages"
@@ -572,10 +570,10 @@ using Microsoft.Compute;
 );
 
 @@clientLocation(VirtualMachineRunCommandsOperationGroup.list,
-  "VirtualMachineRunCommands"
+  VirtualMachineRunCommands
 );
 @@clientLocation(VirtualMachineRunCommandsOperationGroup.get,
-  "VirtualMachineRunCommands"
+  VirtualMachineRunCommands
 );
 
 @@clientLocation(ResourceSkusOperationGroup.list, "ResourceSkus");

--- a/packages/extensions/openapi-to-typespec/test/arm-guestconfiguration/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-guestconfiguration/tsp-output/back-compatible.tsp
@@ -68,5 +68,5 @@ using Microsoft.GuestConfiguration;
 );
 
 @@clientLocation(GuestConfigurationAssignmentsOperationGroup.rGList,
-  "GuestConfigurationAssignments"
+  GuestConfigurationAssignments
 );

--- a/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/back-compatible.tsp
+++ b/packages/extensions/openapi-to-typespec/test/arm-storage/tsp-output/back-compatible.tsp
@@ -193,20 +193,16 @@ using Microsoft.Storage;
 #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
 @@flattenProperty(BlobContainer.properties);
 
-@@clientLocation(ImmutabilityPolicies.getImmutabilityPolicy, "BlobContainers");
+@@clientLocation(ImmutabilityPolicies.getImmutabilityPolicy, BlobContainers);
 @@clientLocation(ImmutabilityPolicies.createOrUpdateImmutabilityPolicy,
-  "BlobContainers"
+  BlobContainers
 );
 @@clientName(ImmutabilityPolicies.createOrUpdateImmutabilityPolicy::parameters.resource,
   "parameters"
 );
-@@clientLocation(ImmutabilityPolicies.deleteImmutabilityPolicy,
-  "BlobContainers"
-);
-@@clientLocation(ImmutabilityPolicies.lockImmutabilityPolicy, "BlobContainers");
-@@clientLocation(ImmutabilityPolicies.extendImmutabilityPolicy,
-  "BlobContainers"
-);
+@@clientLocation(ImmutabilityPolicies.deleteImmutabilityPolicy, BlobContainers);
+@@clientLocation(ImmutabilityPolicies.lockImmutabilityPolicy, BlobContainers);
+@@clientLocation(ImmutabilityPolicies.extendImmutabilityPolicy, BlobContainers);
 @@clientName(ImmutabilityPolicies.extendImmutabilityPolicy::parameters.body,
   "parameters"
 );
@@ -261,9 +257,9 @@ using Microsoft.Storage;
 @@clientLocation(SkusOperationGroup.list, "Skus");
 
 @@clientLocation(StorageAccountsOperationGroup.checkNameAvailability,
-  "StorageAccounts"
+  StorageAccounts
 );
 
-@@clientLocation(DeletedAccountsOperationGroup.list, "DeletedAccounts");
+@@clientLocation(DeletedAccountsOperationGroup.list, DeletedAccounts);
 
 @@clientLocation(UsagesOperationGroup.listByLocation, "Usages");


### PR DESCRIPTION
If the interface exists, we should refer to the interface directly instead of a string.